### PR TITLE
add maven upload support, source & javadocs jars for developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,9 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 version = version_major + '.' + version_minor + '.' + version_patch
 group= "mezz.jei" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "jei_" + mcversion
-
+    if (System.getenv().BUILD_NUMBER != null) {//adds the build number to the end of the version string if on a build server
+        version += ".${System.getenv().BUILD_NUMBER}"
+    }
 // java version
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -57,8 +59,43 @@ processResources
 	rename '(.+_at.cfg)', 'META-INF/$1'
 }
 
+// prevent java 8's strict doclint for javadocs from failing builds
+    allprojects {
+      tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
 jar {
 	manifest {
 		attributes 'FMLAT': 'jei_at.cfg'
 	}
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    from javadoc.destinationDir
+    classifier = 'javadoc'
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier = 'sources'
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+task("uploadJars", dependsOn:"build") {
+    description = "uploads JARs"
+    if (project.hasProperty("local_maven")) {
+	    apply plugin: 'maven'
+            uploadArchives {
+                repositories {
+                    mavenDeployer {
+                        repository(url: "file://${local_maven}")
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
no deobf jars are needed with FG2+, and thus are not provided in this PR.

I will put this on my jenkins/maven repo as discussed once this PR is merged