### PR TITLE
Extend German translation

### DIFF
--- a/src/main/resources/assets/jei/lang/de_DE.lang
+++ b/src/main/resources/assets/jei/lang/de_DE.lang
@@ -1,8 +1,62 @@
+# Tooltips
+jei.tooltip.config=Konfiguration
+jei.tooltip.show.all.recipes=Zeige alle Rezepte
+
+# Error Tooltips
+jei.tooltip.error.recipe.transfer.missing=Fehlende Items
+jei.tooltip.error.recipe.transfer.inventory.full=Inventar ist voll
+
 # Key Bindings
 key.jei.toggleOverlay=Item-Listen-Overlay (de-)aktivieren
 key.jei.showRecipe=Zeige Item-Rezepte
 key.jei.showUses=Zeige Item-Nutzung
 
 # Config
+config.jei.default=Standard
+config.jei.valid=Zulässig
+
+config.jei.title=%MODNAME Konfiguration
+
+config.jei.mode=Modus
+config.jei.mode.comment=Ändere den Modus, in dem sich JEI befindet
 config.jei.mode.cheatItemsEnabled=Aktiviere Item-Cheating
-config.jei.mode.cheatItemsEnabled.comment=/give Items, statt das Rezept zu zeigen
+config.jei.mode.cheatItemsEnabled.comment=/give Items, statt das Rezept zu zeigen.
+config.jei.mode.editEnabled=Aktiviere Itemlisteneditiermodus
+config.jei.mode.editEnabled.comment=Verstecke und zeige Items durch Klicken in der Itemliste.
+
+config.jei.interface=Interface
+config.jei.interface.comment=Das User Interface-betreffende Optionen
+config.jei.interface.tooltipModName=Zeige Modnamen in Tooltip
+config.jei.interface.tooltipModName.comment=Fügt den Namen der Mod, zu welcher ein Item/Block gehört, dessen Tooltip hinzu.
+config.jei.interface.recipeAnimationsEnabled=Aktiviere Rezeptanimationen
+config.jei.interface.recipeAnimationsEnabled.comment=Zeige Animationen für verschiedene Rezepte (Ofenfeuer, Fortschritssbalken, usw.)
+
+config.jei.advanced=Erweitert
+config.jei.advanced.comment=Erweiterte Konfigurationsoptionen, die ändern, wie JEI funktioniert.
+config.jei.advanced.nbtKeyIgnoreList=NBT-Schlüssel-Ignorierungsliste
+config.jei.advanced.nbtKeyIgnoreList.comment=Liste an NBT-Schlüsseln, die ignoriert werden sollen beim Rezepteauslesen.
+config.jei.advanced.itemBlacklist=Item Blacklist
+config.jei.advanced.itemBlacklist.comment=List an Items, die nicht in the Itemliste gezeigt werden sollen. Format: modId:name[:meta]. Der Listeneditiermodus entfernt und fügt automatisch neue Items zu diese Liste hinzu.
+config.jei.advanced.hideMissingModelsEnabled=Verstecke fehlende Itemmodelle
+config.jei.advanced.hideMissingModelsEnabled.comment=Items in der Itemliste mit fehlenden Modellen werden automatisch verborgen.
+
+config.jei.addons=Addons
+config.jei.addons.comment=Kategorie für JEI Addon-Optionen.
+
+# Edit Mode
+gui.jei.editMode.description=JEI Itemlisteneditiermodus:
+gui.jei.editMode.description.hide=Strg-Klick zum verbergen.
+gui.jei.editMode.description.show=Verborgen. Strg-Klick zum Zeigen.
+gui.jei.editMode.description.hide.wild=Strg-Rechtsklick um mit einer Wildcard zu verstecken.
+gui.jei.editMode.description.show.wild=Verborgen durch Wildcard. Strg-Rechtsklick zum Zeigen.
+
+# Recipes
+gui.jei.craftingTableRecipes=Craftingrezepte
+gui.jei.smeltingRecipes=Schmelzrezepte
+gui.jei.fuelRecipes=Kraftstoffrezepte
+gui.jei.furnaceExperience=%s Exp.
+gui.jei.furnaceBurnTime=Brennzeit: %s
+gui.jei.brewingRecipes=Braurezepte
+gui.jei.brewingRecipes.steps=Schritte: %s
+gui.jei.forestry.centrifugeRecipes=Forestry-Zentrifuge
+gui.jei.forestry.fabricatorRecipes=Forestry-Hersteller


### PR DESCRIPTION
Moar translations! :smile:

This is for 1.8.8. Will you merge them back for 1.8, or should I make a separate PR?

A thing I've noticed from the [English strings](https://github.com/mezz/JustEnoughItems/blob/1.8/src/main/resources/assets/jei/lang/en_US.lang#L7):

```
jei.tooltip.error.recipe.transfer.inventory.full=Inventory is too full
```

What is the difference between being full and too full?
