### PR TITLE
Update to the new registry system

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 mcversion=1.9
-forgeversion=12.16.0.1810-1.9
+forgeversion=12.16.0.1826-1.9
 mcp_mappings=snapshot_20160319
 curse_project_id=238222
 

--- a/src/main/java/mezz/jei/JustEnoughItems.java
+++ b/src/main/java/mezz/jei/JustEnoughItems.java
@@ -56,7 +56,8 @@ public class JustEnoughItems {
 			String name = "jeiDebug";
 			Item debugItem = new DebugItem(name);
 			debugItem.setUnlocalizedName(name);
-			GameRegistry.registerItem(debugItem, name);
+			debugItem.setRegistryName(name);
+			GameRegistry.register(debugItem);
 		}
 	}
 

--- a/src/main/java/mezz/jei/util/ErrorUtil.java
+++ b/src/main/java/mezz/jei/util/ErrorUtil.java
@@ -99,7 +99,7 @@ public class ErrorUtil {
 		}
 
 		final String itemName;
-		String registryName = item.getRegistryName();
+		String registryName = item.getRegistryName().toString();
 		if (registryName != null) {
 			itemName = registryName;
 		} else {

--- a/src/main/java/mezz/jei/util/ItemStackElement.java
+++ b/src/main/java/mezz/jei/util/ItemStackElement.java
@@ -58,7 +58,7 @@ public class ItemStackElement {
 		Item item = itemStack.getItem();
 
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-		ResourceLocation itemResourceLocation = GameData.getItemRegistry().getNameForObject(item);
+		ResourceLocation itemResourceLocation = Item.itemRegistry.getNameForObject(item);
 		String modId = itemResourceLocation.getResourceDomain().toLowerCase(Locale.ENGLISH);
 		String modName = Internal.getItemRegistry().getModNameForItem(item).toLowerCase(Locale.ENGLISH);
 

--- a/src/main/java/mezz/jei/util/ModList.java
+++ b/src/main/java/mezz/jei/util/ModList.java
@@ -29,7 +29,7 @@ public class ModList {
 
 	@Nonnull
 	public String getModNameForItem(@Nonnull Item item) {
-		ResourceLocation itemResourceLocation = GameData.getItemRegistry().getNameForObject(item);
+		ResourceLocation itemResourceLocation = Item.itemRegistry.getNameForObject(item);
 		String modId = itemResourceLocation.getResourceDomain();
 		String lowercaseModId = modId.toLowerCase(Locale.ENGLISH);
 		String modName = modNamesForIds.get(lowercaseModId);

--- a/src/main/java/mezz/jei/util/StackHelper.java
+++ b/src/main/java/mezz/jei/util/StackHelper.java
@@ -10,6 +10,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.RegistryNamespaced;
 import net.minecraftforge.fml.common.registry.FMLControlledNamespacedRegistry;
 import net.minecraftforge.fml.common.registry.GameData;
 import net.minecraftforge.oredict.OreDictionary;
@@ -322,10 +323,10 @@ public class StackHelper implements IStackHelper {
 
 	@Nonnull
 	public String getModId(@Nonnull Item item) {
-		FMLControlledNamespacedRegistry<Item> itemRegistry = GameData.getItemRegistry();
+		RegistryNamespaced<ResourceLocation, Item> itemRegistry = Item.itemRegistry;
 		ResourceLocation itemName = itemRegistry.getNameForObject(item);
 		if (itemName == null) {
-			throw new NullPointerException("GameData.getItemRegistry().getNameForObject returned null for: " + item.getClass());
+			throw new NullPointerException("Item.itemRegistry.getNameForObject returned null for: " + item.getClass());
 		}
 
 		return itemName.getResourceDomain();
@@ -350,10 +351,10 @@ public class StackHelper implements IStackHelper {
 			throw new NullPointerException("Found an itemStack with a null item. This is an error from another mod.");
 		}
 
-		FMLControlledNamespacedRegistry<Item> itemRegistry = GameData.getItemRegistry();
+		RegistryNamespaced<ResourceLocation, Item> itemRegistry = Item.itemRegistry;
 		ResourceLocation itemName = itemRegistry.getNameForObject(item);
 		if (itemName == null) {
-			throw new NullPointerException("GameData.getItemRegistry().getNameForObject returned null for: " + item.getClass());
+			throw new NullPointerException("Item.itemRegistry.getNameForObject returned null for: " + item.getClass());
 		}
 
 		String itemNameString = itemName.toString();


### PR DESCRIPTION
Update to the new registry system added in Forge 1.9-12.16.0.1819.

`GameData.getItemRegistry` has been deprecated and marked as internal, `Item.itemRegistry` seems to be the proper way to get the item registry now.

`GameRegistry.registerItem` has been deprecated and replaced with `GameRegistry.register`.

`Item#getRegistryName` now returns `ResourceLocation` instead of `String`.
