### PR TITLE
Add API jar creation + maven uploading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,17 @@ task sourcesJar(type: Jar) {
 	classifier = 'sources'
 }
 
+task apiJar(type: Jar) {
+	from sourceSets.main.allSource
+	from sourceSets.main.output
+	include 'mezz/jei/api/**/*'
+	classifier = 'api'
+}
+
 artifacts {
 	archives javadocJar
 	archives sourcesJar
+	archives apiJar
 }
 
 task("uploadJars", dependsOn: "build") {


### PR DESCRIPTION
Creates an extra `.jar` that contains only the API classes and source.

Useful for those who want to add JEI support but do not wish to have an extra mod loaded in the development workspace (or can't for other technical reasons).

http://gfycat.com/UnfortunateFavoriteDungbeetle
