### PR TITLE
Fix for items with both empty and some nbt

### DIFF
--- a/src/main/java/mezz/jei/SubtypeRegistry.java
+++ b/src/main/java/mezz/jei/SubtypeRegistry.java
@@ -71,7 +71,7 @@ public class SubtypeRegistry implements ISubtypeRegistry {
 		@Override
 		public String getSubtypeInfo(@Nonnull ItemStack itemStack) {
 			NBTTagCompound nbtTagCompound = itemStack.getTagCompound();
-			if (nbtTagCompound == null) {
+			if (nbtTagCompound == null || nbtTagCompound.hasNoTags()) {
 				return null;
 			}
 			return nbtTagCompound.toString();


### PR DESCRIPTION
I noticed that recipes were working for Reliquary's potions that have nbt but no recipe was coming up for empty potion vial that uses the same item, but no nbt.

Looks like the issue is that when it is registering the recipes the stack doesn't have nbt and thus returns null in subtypeinfo and nothing gets added to id. However when user clicks on the item in the JEI list it has empty nbt and thus ":{}" gets added to the id that is searched and it obviously won't find any recipe for that.

Thus the check for no tags that returns null as well. 

This is likely very much a corner case and I fixed that by implementing an nbt interpreter on my side, but may be good for others if they have similar case of an item.

And yeah feel free to change the title to something that makes more sense as it's probably too late for me to come up with a well thought out English sentence.
