### PR TITLE
Fix arbitrary item creation and server freeze vulnerability

### DIFF
--- a/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java
+++ b/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 
 import mezz.jei.network.IPacketId;
@@ -17,7 +16,7 @@ import mezz.jei.transfer.BasicRecipeTransferHandler;
 
 public class PacketRecipeTransfer extends PacketJEI {
 
-	private Map<Integer, ItemStack> recipeMap;
+	private Map<Integer, Integer> recipeMap;
 	private List<Integer> craftingSlots;
 	private List<Integer> inventorySlots;
 	private boolean maxTransfer;
@@ -26,7 +25,7 @@ public class PacketRecipeTransfer extends PacketJEI {
 
 	}
 
-	public PacketRecipeTransfer(@Nonnull Map<Integer, ItemStack> recipeMap, @Nonnull List<Integer> craftingSlots, @Nonnull List<Integer> inventorySlots, boolean maxTransfer) {
+	public PacketRecipeTransfer(@Nonnull Map<Integer, Integer> recipeMap, @Nonnull List<Integer> craftingSlots, @Nonnull List<Integer> inventorySlots, boolean maxTransfer) {
 		this.recipeMap = recipeMap;
 		this.craftingSlots = craftingSlots;
 		this.inventorySlots = inventorySlots;
@@ -44,7 +43,7 @@ public class PacketRecipeTransfer extends PacketJEI {
 		recipeMap = new HashMap<>(recipeMapSize);
 		for (int i = 0; i < recipeMapSize; i++) {
 			int slotIndex = buf.readVarIntFromBuffer();
-			ItemStack recipeItem = buf.readItemStackFromBuffer();
+			int recipeItem = buf.readVarIntFromBuffer();
 			recipeMap.put(slotIndex, recipeItem);
 		}
 
@@ -70,9 +69,9 @@ public class PacketRecipeTransfer extends PacketJEI {
 	@Override
 	public void writePacketData(PacketBuffer buf) throws IOException {
 		buf.writeVarIntToBuffer(recipeMap.size());
-		for (Map.Entry<Integer, ItemStack> recipeMapEntry : recipeMap.entrySet()) {
+		for (Map.Entry<Integer, Integer> recipeMapEntry : recipeMap.entrySet()) {
 			buf.writeVarIntToBuffer(recipeMapEntry.getKey());
-			buf.writeItemStackToBuffer(recipeMapEntry.getValue());
+			buf.writeVarIntToBuffer(recipeMapEntry.getValue());
 		}
 
 		buf.writeVarIntToBuffer(craftingSlots.size());

--- a/src/main/java/mezz/jei/util/StackHelper.java
+++ b/src/main/java/mezz/jei/util/StackHelper.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -76,7 +77,7 @@ public class StackHelper implements IStackHelper {
 	 * Returns a result that contains missingItems if there are not enough items in availableItemStacks.
 	 */
 	@Nonnull
-	public MatchingItemsResult getMatchingItems(@Nonnull List<ItemStack> availableItemStacks, @Nonnull Map<Integer, ? extends IGuiIngredient<ItemStack>> ingredientsMap) {
+	public MatchingItemsResult getMatchingItems(@Nonnull Map<Integer, ItemStack> availableItemStacks, @Nonnull Map<Integer, ? extends IGuiIngredient<ItemStack>> ingredientsMap) {
 		MatchingItemsResult matchingItemResult = new MatchingItemsResult();
 
 		int recipeSlotNumber = -1;
@@ -92,16 +93,17 @@ public class StackHelper implements IStackHelper {
 			if (requiredStacks.isEmpty()) {
 				continue;
 			}
-
-			ItemStack matching = containsStack(availableItemStacks, requiredStacks);
+			
+			Integer matching = containsAnyStackIndexed(availableItemStacks, requiredStacks);
 			if (matching == null) {
 				matchingItemResult.missingItems.add(key);
 			} else {
-				ItemStack matchingSplit = matching.splitStack(1);
-				if (matching.stackSize == 0) {
+				ItemStack matchingStack = availableItemStacks.get(matching);
+				matchingStack.stackSize--;
+				if (matchingStack.stackSize == 0) {
 					availableItemStacks.remove(matching);
 				}
-				matchingItemResult.matchingItems.put(recipeSlotNumber, matchingSplit);
+				matchingItemResult.matchingItems.put(recipeSlotNumber, matching);
 			}
 		}
 
@@ -122,15 +124,19 @@ public class StackHelper implements IStackHelper {
 		return null;
 	}
 
+	public boolean containsSameStacks(@Nonnull Collection<ItemStack> stacks, @Nonnull Collection<ItemStack> contains) {
+		return containsSameStacks(new MatchingIterable(stacks), new MatchingIterable(contains));
+	}
+
 	/** Returns true if all stacks from "contains" are found in "stacks" and the opposite is true as well. */
-	public boolean containsSameStacks(@Nonnull Iterable<ItemStack> stacks, @Nonnull Iterable<ItemStack> contains) {
-		for (ItemStack stack : contains) {
+	public <R> boolean containsSameStacks(@Nonnull Iterable<ItemStackMatchable<R>> stacks, @Nonnull Iterable<ItemStackMatchable<R>> contains) {
+		for (ItemStackMatchable stack : contains) {
 			if (containsStack(stacks, stack) == null) {
 				return false;
 			}
 		}
 
-		for (ItemStack stack : stacks) {
+		for (ItemStackMatchable stack : stacks) {
 			if (containsStack(contains, stack) == null) {
 				return false;
 			}
@@ -139,15 +145,26 @@ public class StackHelper implements IStackHelper {
 		return true;
 	}
 
+	public Integer containsAnyStackIndexed(@Nullable Map<Integer, ItemStack> stacks, @Nullable Iterable<ItemStack> contains) {
+		return containsStackMatchable(stacks == null ? null : new MatchingIndexed(stacks), contains == null ? null : (Iterable<ItemStackMatchable<?>>) (Iterable<?>) new MatchingIterable(contains));
+	}
+
+	public ItemStack containsStack(@Nullable Iterable<ItemStack> stacks, @Nullable ItemStack contains) {
+		return containsAnyStack(stacks == null ? null : stacks, contains == null ? null : Collections.singletonList(contains));
+	}
+
+	public ItemStack containsAnyStack(@Nullable Iterable<ItemStack> stacks, @Nullable Iterable<ItemStack> contains) {
+		return containsStackMatchable(stacks == null ? null : new MatchingIterable(stacks), contains == null ? null : (Iterable<ItemStackMatchable<?>>) (Iterable<?>) new MatchingIterable(contains));
+	}
+
 	/* Returns an ItemStack from "stacks" if it isEquivalent to an ItemStack from "contains" */
-	@Nullable
-	public ItemStack containsStack(@Nullable Iterable<ItemStack> stacks, @Nullable Iterable<ItemStack> contains) {
+	public <R> R containsStackMatchable(@Nullable Iterable<ItemStackMatchable<R>> stacks, @Nullable Iterable<ItemStackMatchable<?>> contains) {
 		if (stacks == null || contains == null) {
 			return null;
 		}
 
-		for (ItemStack containStack : contains) {
-			ItemStack matchingStack = containsStack(stacks, containStack);
+		for (ItemStackMatchable<?> containStack : contains) {
+			R matchingStack = containsStack(stacks, containStack);
 			if (matchingStack != null) {
 				return matchingStack;
 			}
@@ -157,15 +174,14 @@ public class StackHelper implements IStackHelper {
 	}
 
 	/* Returns an ItemStack from "stacks" if it isEquivalent to "contains" */
-	@Nullable
-	public ItemStack containsStack(@Nullable Iterable<ItemStack> stacks, @Nullable ItemStack contains) {
+	public <R> R containsStack(@Nullable Iterable<ItemStackMatchable<R>> stacks, @Nullable ItemStackMatchable<?> contains) {
 		if (stacks == null || contains == null) {
 			return null;
 		}
 
-		for (ItemStack stack : stacks) {
-			if (isEquivalent(contains, stack)) {
-				return stack;
+		for (ItemStackMatchable<R> stack : stacks) {
+			if (isEquivalent(contains.getStack(), stack.getStack())) {
+				return stack.getResult();
 			}
 		}
 		return null;
@@ -476,8 +492,101 @@ public class StackHelper implements IStackHelper {
 
 	public static class MatchingItemsResult {
 		@Nonnull
-		public final Map<Integer, ItemStack> matchingItems = new HashMap<>();
+		public final Map<Integer, Integer> matchingItems = new HashMap<>();
 		@Nonnull
 		public final List<Integer> missingItems = new ArrayList<>();
+	}
+
+	private interface ItemStackMatchable<R> {
+		@Nonnull
+		ItemStack getStack();
+		@Nonnull
+		R getResult();
+	}
+
+	private static abstract class DelegateIterator<T, R> implements Iterator<R> {
+		@Nonnull
+		protected final Iterator<T> delegate;
+
+		public DelegateIterator(@Nonnull Iterator<T> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return delegate.hasNext();
+		}
+
+		@Override
+		public void remove() {
+			delegate.remove();
+		}
+	}
+
+	private static class MatchingIterable implements Iterable<ItemStackMatchable<ItemStack>> {
+		@Nonnull
+		private final Iterable<ItemStack> list;
+
+		public MatchingIterable(@Nonnull Iterable<ItemStack> list) {
+			this.list = list;
+		}
+
+		@Nonnull
+		@Override
+		public Iterator<ItemStackMatchable<ItemStack>> iterator() {
+			Iterator<ItemStack> stacks = list.iterator();
+			return new DelegateIterator<ItemStack, ItemStackMatchable<ItemStack>>(stacks) {
+				@Override
+				public ItemStackMatchable<ItemStack> next() {
+					final ItemStack stack = delegate.next();
+					return new ItemStackMatchable<ItemStack>() {
+						@Nonnull
+						@Override
+						public ItemStack getStack() {
+							return stack;
+						}
+
+						@Nonnull
+						@Override
+						public ItemStack getResult() {
+							return stack;
+						}
+					};
+				}
+			};
+		}
+	}
+
+	private static class MatchingIndexed implements Iterable<ItemStackMatchable<Integer>> {
+		@Nonnull
+		private final Map<Integer, ItemStack> map;
+
+		public MatchingIndexed(@Nonnull Map<Integer, ItemStack> map) {
+			this.map = map;
+		}
+
+		@Nonnull
+		@Override
+		public Iterator<ItemStackMatchable<Integer>> iterator() {
+			return new DelegateIterator<Map.Entry<Integer, ItemStack>, ItemStackMatchable<Integer>>(map.entrySet().iterator()) {
+				@Override
+				public ItemStackMatchable<Integer> next() {
+					final Map.Entry<Integer, ItemStack> entry = delegate.next();
+					return new ItemStackMatchable<Integer>() {
+						@Nonnull
+						@Override
+						public ItemStack getStack() {
+							return entry.getValue();
+						}
+
+						@Nonnull
+						@Override
+						public Integer getResult() {
+							return entry.getKey();
+						}
+					};
+				}
+			};
+		}
 	}
 }


### PR DESCRIPTION
Currently, [PacketRecipeTransfer](https://github.com/mezz/JustEnoughItems/blob/568960886949d3e1ed65bcfd68699f0717a44980/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java) sends item stacks from the client to the server to be placed into the crafting grid. This can be exploited with a specially crafted packet to either arbitrarily place items in any container or freeze the server.

This PR resolves this issue by instead sending the slot numbers that contain the item stacks to move for the server to move items from its own slots.

The arbitrary item creation exploit works by sending desired item stacks with a stack size of -1 to trip up the logic into providing item stacks of their max stack size. Items that can't stack will remain a stack size of -1. In addition there is alternate means of producing items that do not use negative stack sizes by transforming actual chests in the player's inventory into chests with a [BlockEntityTag](https://minecraft.gamepedia.com/Player.dat_format#Block_Tags) that specify NBT for items in the chest.

To exploit the server freeze vulnerability the "maxTransfer" argument of PacketRecipeTransfer is set to `true` and the "recipeMap" argument contains strictly negative stack size item stacks. The result is the server becoming stuck in the following loop at [BasicRecipeTransferHelper#removeSetsFromInventory:207-216](https://github.com/mezz/JustEnoughItems/blob/568960886949d3e1ed65bcfd68699f0717a44980/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandler.java#L207-L216)

``` java
while (!requiredCopy.isEmpty() && removeSetsFromInventory(container, requiredCopy, craftingSlots, inventorySlots)) {
  removedSets++;
  Iterator<ItemStack> iterator = requiredCopy.iterator();
  while (iterator.hasNext()) {
    ItemStack stack = iterator.next();
    if (!stack.isStackable() || (stack.stackSize * (removedSets + 1) > stack.getMaxStackSize())) {
      iterator.remove();
    }
  }
}
```

In order to get the client to determine what slot numbers the item stacks that will be transferred belong to I have reworked the [StackHelper](https://github.com/mezz/JustEnoughItems/blob/568960886949d3e1ed65bcfd68699f0717a44980/src/main/java/mezz/jei/util/StackHelper.java) such that determing if a list of item stacks contains any item stack from another list works by seperating the return type from the compare type and parameterizing the assorted "contains" method by return type.

I have created a [concept mod](https://gist.github.com/pau101/ef1e32fe5f8731b57eb007635b61cf0d) which exploits these vulnerabilities. It sends an exploit packet which will fill the currently opened container with the item stack under the cursor when left CTRL is pressed.
