### PR TITLE
Prevent ForgeCaps from being set with zero size

### DIFF
--- a/src/main/java/mezz/jei/util/StackHelper.java
+++ b/src/main/java/mezz/jei/util/StackHelper.java
@@ -390,7 +390,7 @@ public class StackHelper implements IStackHelper {
 					nbtTagCompound = new NBTTagCompound();
 				}
 				NBTTagCompound forgeCaps = serializedNbt.getCompoundTag("ForgeCaps");
-				if (0 != forgeCaps.getSize()) { // ForgeCaps should never be empty
+				if (!forgeCaps.hasNoTags()) { // ForgeCaps should never be empty
 					nbtTagCompound.setTag("ForgeCaps", forgeCaps);
 				}
 			}

--- a/src/main/java/mezz/jei/util/StackHelper.java
+++ b/src/main/java/mezz/jei/util/StackHelper.java
@@ -389,7 +389,10 @@ public class StackHelper implements IStackHelper {
 				if (nbtTagCompound == null) {
 					nbtTagCompound = new NBTTagCompound();
 				}
-				nbtTagCompound.setTag("ForgeCaps", serializedNbt.getCompoundTag("ForgeCaps"));
+				NBTTagCompound forgeCaps = serializedNbt.getCompoundTag("ForgeCaps");
+				if (0 != forgeCaps.getSize()) { // ForgeCaps should never be empty
+					nbtTagCompound.setTag("ForgeCaps", forgeCaps);
+				}
 			}
 			if (nbtTagCompound != null && !nbtTagCompound.hasNoTags()) {
 				itemKey.append(':').append(nbtTagCompound);


### PR DESCRIPTION
According to Lex on #minecraftforge, the NBT tag ForgeCaps should never be empty. Forge Universal Buckets were being generated with an empty ForgeCaps tag, and this PR will prevent a ForgeCap tag from being set if it has zero size.

This may be a bandaid for an underlying problem, but it seems to fix the issue I was having with displaying NBT sensitive recipes and using cheated-in items from JEI in these recipes.
