### PR TITLE
Changed the mod ID to lowercase

### DIFF
--- a/src/main/java/mezz/jei/config/Constants.java
+++ b/src/main/java/mezz/jei/config/Constants.java
@@ -8,7 +8,7 @@ public class Constants {
 	public static final String minecraftModName = "Minecraft";
 
 	// Mod info
-	public static final String MOD_ID = "JEI";
+	public static final String MOD_ID = "jei";
 	public static final String NAME = "Just Enough Items";
 	public static final String VERSION = "@VERSION@";
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,6 +1,6 @@
 [
 {
-  "modid": "JEI",
+  "modid": "jei",
   "name": "Just Enough Items",
   "description": "Simple recipe and item helper.",
   "version": "${version}",


### PR DESCRIPTION
I have changed the mod ID to lowercase since it'll be enforced by Forge in Minecraft 1.11.
