### PR TITLE
Allow configuration of mod name tooltip

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -21,6 +21,7 @@ import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 public class Config {
 	private static final String configKeyPrefix = "config.jei";
@@ -42,6 +43,7 @@ public class Config {
 	private static boolean debugModeEnabled = false;
 	private static boolean colorSearchEnabled = false;
 	private static boolean centerSearchBarEnabled = false;
+	private static String modNameFormat = "\u00A79\u00A7o%s";
 
 	// search
 	private static boolean prefixRequiredForModNameSearch = true;
@@ -127,6 +129,10 @@ public class Config {
 
 	public static boolean isCenterSearchBarEnabled() {
 		return centerSearchBarEnabled;
+	}
+
+	public static String getModNameFormat() {
+		return modNameFormat;
 	}
 
 	public static boolean isPrefixRequiredForModNameSearch() {
@@ -308,6 +314,9 @@ public class Config {
 		}
 
 		centerSearchBarEnabled = config.getBoolean(CATEGORY_ADVANCED, "centerSearchBarEnabled", centerSearchBarEnabled);
+		modNameFormat = StringEscapeUtils.unescapeJava(config.getString("modNameFormat", CATEGORY_ADVANCED, StringEscapeUtils.escapeJava(modNameFormat)));
+		if (!modNameFormat.contains("%s"))
+			modNameFormat = "\u00A79\u00A7o%s";
 
 		debugModeEnabled = config.getBoolean(CATEGORY_ADVANCED, "debugModeEnabled", debugModeEnabled);
 		{

--- a/src/main/java/mezz/jei/util/ModIdUtil.java
+++ b/src/main/java/mezz/jei/util/ModIdUtil.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.config.Config;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -64,7 +65,7 @@ public class ModIdUtil {
 			}
 		}
 		List<String> tooltipCopy = new ArrayList<String>(tooltip);
-		tooltipCopy.add(TextFormatting.BLUE.toString() + TextFormatting.ITALIC.toString() + modName);
+		tooltipCopy.add(String.format(Config.getModNameFormat(), modName));
 		return tooltipCopy;
 	}
 }

--- a/src/main/resources/assets/jei/lang/en_US.lang
+++ b/src/main/resources/assets/jei/lang/en_US.lang
@@ -75,6 +75,8 @@ config.jei.advanced.debugModeEnabled=Debug Mode
 config.jei.advanced.debugModeEnabled.comment=Only useful for JEI developers, adds thousands of test items and some debug recipes.
 config.jei.advanced.centerSearchBarEnabled=Center Search Bar
 config.jei.advanced.centerSearchBarEnabled.comment=Move the JEI search bar to the bottom center of the screen.
+config.jei.advanced.modNameFormat=Mod Name Format
+config.jei.advanced.modNameFormat.comment=How the mod name should be formatted in the tooltip.
 
 # Edit Mode
 gui.jei.editMode.description=JEI Item List Edit Mode:


### PR DESCRIPTION
Would close #590. If `%s` is not found in the string, it will fallback to the default formatting (Blue with italics)

https://streamable.com/t50a