### PR TITLE
Fix cursor held item and player inventory craft items desyncing when opening RecipesGui

### DIFF
--- a/src/main/java/mezz/jei/gui/ItemListOverlayInternal.java
+++ b/src/main/java/mezz/jei/gui/ItemListOverlayInternal.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.Internal;
+import mezz.jei.JeiRuntime;
 import mezz.jei.JustEnoughItems;
 import mezz.jei.api.gui.IAdvancedGuiHandler;
 import mezz.jei.api.gui.IDrawable;
@@ -22,6 +23,7 @@ import mezz.jei.gui.ingredients.GuiIngredientFast;
 import mezz.jei.gui.ingredients.GuiIngredientFastList;
 import mezz.jei.gui.ingredients.GuiItemStackGroup;
 import mezz.jei.gui.ingredients.IIngredientListElement;
+import mezz.jei.gui.recipes.RecipesGui;
 import mezz.jei.input.ClickedIngredient;
 import mezz.jei.input.GuiTextFieldFilter;
 import mezz.jei.input.IClickedIngredient;
@@ -405,7 +407,8 @@ public class ItemListOverlayInternal implements IShowsRecipeFocuses, IMouseHandl
 			return false;
 		}
 
-		if (Config.isDeleteItemsInCheatModeActive()) {
+		JeiRuntime runtime = Internal.getRuntime();
+		if (Config.isDeleteItemsInCheatModeActive() && (runtime == null || !runtime.getRecipesGui().isOpen())) {
 			Minecraft minecraft = Minecraft.getMinecraft();
 			EntityPlayerSP player = minecraft.player;
 			ItemStack itemStack = player.inventory.getItemStack();
@@ -459,7 +462,7 @@ public class ItemListOverlayInternal implements IShowsRecipeFocuses, IMouseHandl
 				if (minecraft.currentScreen != null) {
 					parent.close();
 					GuiScreen configScreen = new JEIModConfigGui(minecraft.currentScreen);
-					minecraft.displayGuiScreen(configScreen);
+					RecipesGui.displayGuiScreenWithoutClose(configScreen);
 				}
 			}
 			return true;

--- a/src/main/java/mezz/jei/gui/ItemListOverlayInternal.java
+++ b/src/main/java/mezz/jei/gui/ItemListOverlayInternal.java
@@ -329,7 +329,8 @@ public class ItemListOverlayInternal implements IShowsRecipeFocuses, IMouseHandl
 		if (Config.isDeleteItemsInCheatModeActive()) {
 			EntityPlayer player = minecraft.player;
 			if (!player.inventory.getItemStack().isEmpty()) {
-				return true;
+				JeiRuntime runtime = Internal.getRuntime();
+				return runtime == null || !runtime.getRecipesGui().isOpen();
 			}
 		}
 		return false;


### PR DESCRIPTION
This PR changes RecipesGui to not call GuiScreen#onGuiClosed() on the current screen if it is a GuiContainer when itself is opened.

I have analyzed a sample of mod GuiContainers and I am confident that there will not be unintended consequences of this change within conventional mods so long as it is guaranteed RecipesGui will return to the parentScreen eventually.