### PR TITLE
[1.10] Add a way to add ItemStacks to JEI during runtime (cherry-pick)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ curse_project_id=238222
 
 version_major=3
 version_minor=14
-version_patch=3
+version_patch=4

--- a/src/main/java/mezz/jei/ModIngredientRegistration.java
+++ b/src/main/java/mezz/jei/ModIngredientRegistration.java
@@ -3,10 +3,12 @@ package mezz.jei;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRenderer;
 import mezz.jei.api.ingredients.IModIngredientRegistration;
@@ -54,17 +56,16 @@ public class ModIngredientRegistration implements IModIngredientRegistration {
 	}
 
 	public IngredientRegistry createIngredientRegistry() {
-		ImmutableMap.Builder<Class, ImmutableList> ingredientsMapBuilder = ImmutableMap.builder();
+		Map<Class, List> ingredientsMap = new IdentityHashMap<Class, List>();
 		for (Class ingredientClass : allIngredientsMap.keySet()) {
 			Collection ingredients = allIngredientsMap.get(ingredientClass);
-			ImmutableList immutableIngredients = ImmutableList.copyOf(ingredients);
-			ingredientsMapBuilder.put(ingredientClass, immutableIngredients);
+			ingredientsMap.put(ingredientClass, Lists.newArrayList(ingredients));
 		}
 
 		return new IngredientRegistry(
-				ingredientsMapBuilder.build(),
-				ImmutableMap.copyOf(ingredientHelperMap),
-				ImmutableMap.copyOf(ingredientRendererMap)
+			ingredientsMap,
+			ImmutableMap.copyOf(ingredientHelperMap),
+			ImmutableMap.copyOf(ingredientRendererMap)
 		);
 	}
 }

--- a/src/main/java/mezz/jei/api/ingredients/IIngredientRegistry.java
+++ b/src/main/java/mezz/jei/api/ingredients/IIngredientRegistry.java
@@ -6,6 +6,8 @@ import mezz.jei.api.IItemRegistry;
 import mezz.jei.api.IModRegistry;
 import net.minecraft.item.ItemStack;
 
+import java.util.List;
+
 /**
  * The IIngredientRegistry is provided by JEI and has some useful functions related to recipe ingredients.
  * Get the instance from {@link IModRegistry#getIngredientRegistry()}.
@@ -54,4 +56,13 @@ public interface IIngredientRegistry {
 	 * Returns a list of all the ItemStacks that return true to isPotionIngredient.
 	 */
 	ImmutableList<ItemStack> getPotionIngredients();
+
+	/**
+	 * Add new ingredients to JEI at runtime.
+	 * Used by mods that have items created while the game is running, or use the server to define items.
+	 * Using this method will reload the ingredient list, do not call it unless necessary.
+	 *
+	 * @since JEI 3.14.4
+	 */
+	<V> void addIngredientsAtRuntime(Class<V> ingredientClass, List<V> ingredients);
 }

--- a/src/main/java/mezz/jei/plugins/jei/JEIInternalPlugin.java
+++ b/src/main/java/mezz/jei/plugins/jei/JEIInternalPlugin.java
@@ -43,7 +43,7 @@ public class JEIInternalPlugin extends BlankModPlugin {
 	@Override
 	public void registerIngredients(IModIngredientRegistration ingredientRegistration) {
 		if (Config.isDebugModeEnabled()) {
-			ingredientRegistration.register(DebugIngredient.class, DebugIngredientListFactory.create(), new DebugIngredientHelper(), new DebugIngredientRenderer());
+			ingredientRegistration.register(DebugIngredient.class, Collections.<DebugIngredient>emptyList(), new DebugIngredientHelper(), new DebugIngredientRenderer());
 		}
 	}
 
@@ -117,6 +117,9 @@ public class JEIInternalPlugin extends BlankModPlugin {
 
 		if (Config.isDebugModeEnabled()) {
 			jeiRuntime.getItemListOverlay().highlightStacks(Collections.singleton(new ItemStack(Items.STICK)));
+			if (ingredientRegistry != null) {
+				ingredientRegistry.addIngredientsAtRuntime(DebugIngredient.class, DebugIngredientListFactory.create());
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is a partial cherry-pick from commit https://github.com/mezz/JustEnoughItems/commit/d18a76f3683971b0fea06dea1fc91d56a96c0bd2 for the 1.11 branch It appears to work just fine.

Weird that you have method arguments marked `@Nullable` and then immediately check for not-null...

The deprecated `ItemRegistry` still uses immutable collections, for compatibility.