### PR TITLE
Add support for anvil recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ out/
 build/*
 /bin/
 changelog.html
+/classes

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ curse_project_id=238222
 
 version_major=4
 version_minor=2
-version_patch=5
+version_patch=6

--- a/src/main/java/mezz/jei/api/IModRegistry.java
+++ b/src/main/java/mezz/jei/api/IModRegistry.java
@@ -96,6 +96,7 @@ public interface IModRegistry {
 	 * @param leftInput The itemStack placed on the left slot.
 	 * @param rightInputs The itemStack(s) placed on the right slot.
 	 * @param outputs The resulting itemStack(s).
+	 * @since JEI 4.2.6
 	 */
 	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs);
 

--- a/src/main/java/mezz/jei/api/IModRegistry.java
+++ b/src/main/java/mezz/jei/api/IModRegistry.java
@@ -94,15 +94,12 @@ public interface IModRegistry {
 	/**
 	 * Adds an anvil recipe for the given inputs and output.
 	 * @param leftInput The itemStack placed on the left slot.
-	 * @param rightInput The itemStack placed on the right slot.
-	 * @param output The resulting itemStack.
+	 * @param rightInputs The itemStack(s) placed on the right slot.
+	 * @param outputs The resulting itemStack(s).
 	 * @param levelsCost The cost, in experience levels, that will be required in order to pick up the item.
 	 *                   Optional: If not specified, the cost text will not display on the recipe.
 	 */
-	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost);
-	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output);
-	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInput, List<ItemStack> output, int levelsCost);
-	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInput, List<ItemStack> output);
+	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost);
 
 	/**
 	 * Get the registry for setting up recipe transfer.

--- a/src/main/java/mezz/jei/api/IModRegistry.java
+++ b/src/main/java/mezz/jei/api/IModRegistry.java
@@ -96,9 +96,8 @@ public interface IModRegistry {
 	 * @param leftInput The itemStack placed on the left slot.
 	 * @param rightInput The itemStack placed on the right slot.
 	 * @param output The resulting itemStack.
-	 * @param levelsCost Optional.
-	 *                   The cost, in experience levels, that will be required in order to pick up the item.
-	 *                   If not used
+	 * @param levelsCost The cost, in experience levels, that will be required in order to pick up the item.
+	 *                   Optional: If not specified, the cost text will not display on the recipe.
 	 */
 	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost);
 	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output);

--- a/src/main/java/mezz/jei/api/IModRegistry.java
+++ b/src/main/java/mezz/jei/api/IModRegistry.java
@@ -101,6 +101,8 @@ public interface IModRegistry {
 	 */
 	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost);
 	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output);
+	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInput, List<ItemStack> output, int levelsCost);
+	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInput, List<ItemStack> output);
 
 	/**
 	 * Get the registry for setting up recipe transfer.

--- a/src/main/java/mezz/jei/api/IModRegistry.java
+++ b/src/main/java/mezz/jei/api/IModRegistry.java
@@ -92,6 +92,18 @@ public interface IModRegistry {
 	void addDescription(List<ItemStack> itemStacks, String... descriptionKeys);
 
 	/**
+	 * Adds an anvil recipe for the given inputs and output.
+	 * @param leftInput The itemStack placed on the left slot.
+	 * @param rightInput The itemStack placed on the right slot.
+	 * @param output The resulting itemStack.
+	 * @param levelsCost Optional.
+	 *                   The cost, in experience levels, that will be required in order to pick up the item.
+	 *                   If not used
+	 */
+	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost);
+	void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output);
+
+	/**
 	 * Get the registry for setting up recipe transfer.
 	 */
 	IRecipeTransferRegistry getRecipeTransferRegistry();

--- a/src/main/java/mezz/jei/api/IModRegistry.java
+++ b/src/main/java/mezz/jei/api/IModRegistry.java
@@ -96,10 +96,8 @@ public interface IModRegistry {
 	 * @param leftInput The itemStack placed on the left slot.
 	 * @param rightInputs The itemStack(s) placed on the right slot.
 	 * @param outputs The resulting itemStack(s).
-	 * @param levelsCost The cost, in experience levels, that will be required in order to pick up the item.
-	 *                   Optional: If not specified, the cost text will not display on the recipe.
 	 */
-	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost);
+	void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs);
 
 	/**
 	 * Get the registry for setting up recipe transfer.

--- a/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
+++ b/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
@@ -61,7 +61,7 @@ public class VanillaRecipeCategoryUid {
 	/**
 	 * The anvil recipe category.
 	 * <p>
-	 * This is a built-in category, you can add new recipes with {@link IModRegistry#addAnvilRecipe(ItemStack, List, List, int)}}
+	 * This is a built-in category, you can add new recipes with {@link IModRegistry#addAnvilRecipe(ItemStack, List, List)}}
 	 */
 	public static final String ANVIL = "minecraft.anvil";
 

--- a/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
+++ b/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
@@ -61,11 +61,7 @@ public class VanillaRecipeCategoryUid {
 	/**
 	 * The anvil recipe category.
 	 * <p>
-	 * This is a built-in category, you can add new recipes with
-	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack, int)}},
-	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack)}},
-	 * {@link IModRegistry#addAnvilRecipe(ItemStack, List, List, int)}}, or
-	 * {@link IModRegistry#addAnvilRecipe(ItemStack, List, List)}}
+	 * This is a built-in category, you can add new recipes with {@link IModRegistry#addAnvilRecipe(ItemStack, List, List, int)}}
 	 */
 	public static final String ANVIL = "minecraft.anvil";
 

--- a/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
+++ b/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
@@ -60,6 +60,10 @@ public class VanillaRecipeCategoryUid {
 
 	/**
 	 * The anvil recipe category.
+	 * <p>
+	 * This is a built-in category, you can add new recipes with
+	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack, int)}} or
+	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack)}}
 	 */
 	public static final String ANVIL = "minecraft.anvil";
 

--- a/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
+++ b/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
@@ -59,6 +59,11 @@ public class VanillaRecipeCategoryUid {
 	public static final String BREWING = "minecraft.brewing";
 
 	/**
+	 * The anvil recipe category.
+	 */
+	public static final String ANVIL = "minecraft.anvil";
+
+	/**
 	 * The JEI description recipe category.
 	 * <p>
 	 * This is a built-in category, you can add new recipes with

--- a/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
+++ b/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
@@ -62,8 +62,10 @@ public class VanillaRecipeCategoryUid {
 	 * The anvil recipe category.
 	 * <p>
 	 * This is a built-in category, you can add new recipes with
-	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack, int)}} or
-	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack)}}
+	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack, int)}},
+	 * {@link IModRegistry#addAnvilRecipe(ItemStack, ItemStack, ItemStack)}},
+	 * {@link IModRegistry#addAnvilRecipe(ItemStack, List, List, int)}}, or
+	 * {@link IModRegistry#addAnvilRecipe(ItemStack, List, List)}}
 	 */
 	public static final String ANVIL = "minecraft.anvil";
 

--- a/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
+++ b/src/main/java/mezz/jei/api/recipe/VanillaRecipeCategoryUid.java
@@ -62,6 +62,7 @@ public class VanillaRecipeCategoryUid {
 	 * The anvil recipe category.
 	 * <p>
 	 * This is a built-in category, you can add new recipes with {@link IModRegistry#addAnvilRecipe(ItemStack, List, List)}}
+	 * @since JEI 4.2.6
 	 */
 	public static final String ANVIL = "minecraft.anvil";
 

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
@@ -141,7 +141,7 @@ public class VanillaPlugin extends BlankModPlugin {
 		recipeTransferRegistry.addRecipeTransferHandler(ContainerFurnace.class, VanillaRecipeCategoryUid.SMELTING, 0, 1, 3, 36);
 		recipeTransferRegistry.addRecipeTransferHandler(ContainerFurnace.class, VanillaRecipeCategoryUid.FUEL, 1, 1, 3, 36);
 		recipeTransferRegistry.addRecipeTransferHandler(ContainerBrewingStand.class, VanillaRecipeCategoryUid.BREWING, 0, 4, 5, 36);
-		recipeTransferRegistry.addRecipeTransferHandler(ContainerRepair.class, VanillaRecipeCategoryUid.ANVIL, 0, 2, 3, 4 * 9);
+		recipeTransferRegistry.addRecipeTransferHandler(ContainerRepair.class, VanillaRecipeCategoryUid.ANVIL, 0, 2, 3, 36);
 
 		registry.addRecipeCategoryCraftingItem(new ItemStack(Blocks.CRAFTING_TABLE), VanillaRecipeCategoryUid.CRAFTING);
 		registry.addRecipeCategoryCraftingItem(new ItemStack(Blocks.FURNACE), VanillaRecipeCategoryUid.SMELTING, VanillaRecipeCategoryUid.FUEL);

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
@@ -14,6 +14,9 @@ import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.IModIngredientRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.api.recipe.transfer.IRecipeTransferRegistry;
+import mezz.jei.plugins.vanilla.anvil.AnvilRecipeCategory;
+import mezz.jei.plugins.vanilla.anvil.AnvilRecipeHandler;
+import mezz.jei.plugins.vanilla.anvil.AnvilRecipeMaker;
 import mezz.jei.plugins.vanilla.brewing.BrewingRecipeCategory;
 import mezz.jei.plugins.vanilla.brewing.BrewingRecipeHandler;
 import mezz.jei.plugins.vanilla.brewing.BrewingRecipeMaker;
@@ -39,6 +42,7 @@ import mezz.jei.plugins.vanilla.ingredients.ItemStackListFactory;
 import mezz.jei.plugins.vanilla.ingredients.ItemStackRenderer;
 import mezz.jei.transfer.PlayerRecipeTransferHandler;
 import mezz.jei.util.StackHelper;
+import net.minecraft.client.gui.GuiRepair;
 import net.minecraft.client.gui.inventory.GuiBrewingStand;
 import net.minecraft.client.gui.inventory.GuiCrafting;
 import net.minecraft.client.gui.inventory.GuiFurnace;
@@ -47,6 +51,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.ContainerBrewingStand;
 import net.minecraft.inventory.ContainerFurnace;
+import net.minecraft.inventory.ContainerRepair;
 import net.minecraft.inventory.ContainerWorkbench;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemBanner;
@@ -107,7 +112,8 @@ public class VanillaPlugin extends BlankModPlugin {
 				new CraftingRecipeCategory(guiHelper),
 				new FurnaceFuelCategory(guiHelper),
 				new FurnaceSmeltingCategory(guiHelper),
-				new BrewingRecipeCategory(guiHelper)
+				new BrewingRecipeCategory(guiHelper),
+				new AnvilRecipeCategory(guiHelper)
 		);
 
 		registry.addRecipeHandlers(
@@ -118,13 +124,15 @@ public class VanillaPlugin extends BlankModPlugin {
 				new TippedArrowRecipeHandler(),
 				new FuelRecipeHandler(),
 				new SmeltingRecipeHandler(),
-				new BrewingRecipeHandler()
+				new BrewingRecipeHandler(),
+				new AnvilRecipeHandler()
 		);
 
 		registry.addRecipeClickArea(GuiCrafting.class, 88, 32, 28, 23, VanillaRecipeCategoryUid.CRAFTING);
 		registry.addRecipeClickArea(GuiInventory.class, 137, 29, 10, 13, VanillaRecipeCategoryUid.CRAFTING);
 		registry.addRecipeClickArea(GuiBrewingStand.class, 97, 16, 14, 30, VanillaRecipeCategoryUid.BREWING);
 		registry.addRecipeClickArea(GuiFurnace.class, 78, 32, 28, 23, VanillaRecipeCategoryUid.SMELTING, VanillaRecipeCategoryUid.FUEL);
+		registry.addRecipeClickArea(GuiRepair.class, 102, 48, 22, 15, VanillaRecipeCategoryUid.ANVIL);
 
 		IRecipeTransferRegistry recipeTransferRegistry = registry.getRecipeTransferRegistry();
 
@@ -133,16 +141,19 @@ public class VanillaPlugin extends BlankModPlugin {
 		recipeTransferRegistry.addRecipeTransferHandler(ContainerFurnace.class, VanillaRecipeCategoryUid.SMELTING, 0, 1, 3, 36);
 		recipeTransferRegistry.addRecipeTransferHandler(ContainerFurnace.class, VanillaRecipeCategoryUid.FUEL, 1, 1, 3, 36);
 		recipeTransferRegistry.addRecipeTransferHandler(ContainerBrewingStand.class, VanillaRecipeCategoryUid.BREWING, 0, 4, 5, 36);
+		recipeTransferRegistry.addRecipeTransferHandler(ContainerRepair.class, VanillaRecipeCategoryUid.ANVIL, 0, 2, 3, 4 * 9);
 
 		registry.addRecipeCategoryCraftingItem(new ItemStack(Blocks.CRAFTING_TABLE), VanillaRecipeCategoryUid.CRAFTING);
 		registry.addRecipeCategoryCraftingItem(new ItemStack(Blocks.FURNACE), VanillaRecipeCategoryUid.SMELTING, VanillaRecipeCategoryUid.FUEL);
 		registry.addRecipeCategoryCraftingItem(new ItemStack(Items.BREWING_STAND), VanillaRecipeCategoryUid.BREWING);
+		registry.addRecipeCategoryCraftingItem(new ItemStack(Blocks.ANVIL), VanillaRecipeCategoryUid.ANVIL);
 
 		registry.addRecipes(CraftingManager.getInstance().getRecipeList());
 		registry.addRecipes(SmeltingRecipeMaker.getFurnaceRecipes(jeiHelpers));
 		registry.addRecipes(FuelRecipeMaker.getFuelRecipes(ingredientRegistry, jeiHelpers));
 		registry.addRecipes(BrewingRecipeMaker.getBrewingRecipes(ingredientRegistry));
 		registry.addRecipes(TippedArrowRecipeMaker.getTippedArrowRecipes());
+		registry.addRecipes(AnvilRecipeMaker.getVanillaAnvilRecipes());
 
 		IIngredientBlacklist ingredientBlacklist = registry.getJeiHelpers().getIngredientBlacklist();
 		// Game freezes when loading player skulls, see https://bugs.mojang.com/browse/MC-65587

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
@@ -153,7 +153,8 @@ public class VanillaPlugin extends BlankModPlugin {
 		registry.addRecipes(FuelRecipeMaker.getFuelRecipes(ingredientRegistry, jeiHelpers));
 		registry.addRecipes(BrewingRecipeMaker.getBrewingRecipes(ingredientRegistry));
 		registry.addRecipes(TippedArrowRecipeMaker.getTippedArrowRecipes());
-		registry.addRecipes(AnvilRecipeMaker.getVanillaAnvilRecipes());
+
+		AnvilRecipeMaker.registerVanillaAnvilRecipes(registry);
 
 		IIngredientBlacklist ingredientBlacklist = registry.getJeiHelpers().getIngredientBlacklist();
 		// Game freezes when loading player skulls, see https://bugs.mojang.com/browse/MC-65587

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
@@ -12,8 +12,8 @@ import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nonnull;
 
-public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper>
-{
+public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper> {
+
     @Nonnull
     private final IDrawable background;
 

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
@@ -43,5 +43,7 @@ public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper>
 		guiItemStacks.init(2, false, 117, 6);
 
 		guiItemStacks.set(ingredients);
+
+		recipeWrapper.setCurrentIngredients(guiItemStacks.getGuiIngredients());
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
@@ -10,11 +10,8 @@ import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
-
 public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper> {
 
-    @Nonnull
     private final IDrawable background;
 
     public AnvilRecipeCategory(IGuiHelper guiHelper) {
@@ -23,22 +20,22 @@ public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper>
     }
 
     @Override
-    public @Nonnull String getUid() {
+    public String getUid() {
         return VanillaRecipeCategoryUid.ANVIL;
     }
 
     @Override
-    public @Nonnull String getTitle() {
+    public String getTitle() {
         return Blocks.ANVIL.getLocalizedName();
     }
 
     @Override
-    public @Nonnull IDrawable getBackground() {
+    public IDrawable getBackground() {
         return background;
     }
 
     @Override
-    public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull AnvilRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+    public void setRecipe(IRecipeLayout recipeLayout, AnvilRecipeWrapper recipeWrapper, IIngredients ingredients) {
         IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
 
         guiItemStacks.init(0, true, 10, 6);

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
@@ -12,36 +12,36 @@ import net.minecraft.util.ResourceLocation;
 
 public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper> {
 
-    private final IDrawable background;
+	private final IDrawable background;
 
-    public AnvilRecipeCategory(IGuiHelper guiHelper) {
-        ResourceLocation backgroundLocation = new ResourceLocation("textures/gui/container/anvil.png");
-        background = guiHelper.createDrawable(backgroundLocation, 16, 40, 145, 37);
-    }
+	public AnvilRecipeCategory(IGuiHelper guiHelper) {
+		ResourceLocation backgroundLocation = new ResourceLocation("textures/gui/container/anvil.png");
+		background = guiHelper.createDrawable(backgroundLocation, 16, 40, 145, 37);
+	}
 
-    @Override
-    public String getUid() {
-        return VanillaRecipeCategoryUid.ANVIL;
-    }
+	@Override
+	public String getUid() {
+		return VanillaRecipeCategoryUid.ANVIL;
+	}
 
-    @Override
-    public String getTitle() {
-        return Blocks.ANVIL.getLocalizedName();
-    }
+	@Override
+	public String getTitle() {
+		return Blocks.ANVIL.getLocalizedName();
+	}
 
-    @Override
-    public IDrawable getBackground() {
-        return background;
-    }
+	@Override
+	public IDrawable getBackground() {
+		return background;
+	}
 
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, AnvilRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
+	@Override
+	public void setRecipe(IRecipeLayout recipeLayout, AnvilRecipeWrapper recipeWrapper, IIngredients ingredients) {
+		IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
 
-        guiItemStacks.init(0, true, 10, 6);
-        guiItemStacks.init(1, true, 59, 6);
-        guiItemStacks.init(2, false, 117, 6);
+		guiItemStacks.init(0, true, 10, 6);
+		guiItemStacks.init(1, true, 59, 6);
+		guiItemStacks.init(2, false, 117, 6);
 
-        guiItemStacks.set(ingredients);
-    }
+		guiItemStacks.set(ingredients);
+	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
@@ -1,0 +1,50 @@
+package mezz.jei.plugins.vanilla.anvil;
+
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.BlankRecipeCategory;
+import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nonnull;
+
+public class AnvilRecipeCategory extends BlankRecipeCategory<AnvilRecipeWrapper>
+{
+    @Nonnull
+    private final IDrawable background;
+
+    public AnvilRecipeCategory(IGuiHelper guiHelper) {
+        ResourceLocation backgroundLocation = new ResourceLocation("textures/gui/container/anvil.png");
+        background = guiHelper.createDrawable(backgroundLocation, 16, 40, 145, 37);
+    }
+
+    @Override
+    public @Nonnull String getUid() {
+        return VanillaRecipeCategoryUid.ANVIL;
+    }
+
+    @Override
+    public @Nonnull String getTitle() {
+        return Blocks.ANVIL.getLocalizedName();
+    }
+
+    @Override
+    public @Nonnull IDrawable getBackground() {
+        return background;
+    }
+
+    @Override
+    public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull AnvilRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+        IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
+
+        guiItemStacks.init(0, true, 10, 6);
+        guiItemStacks.init(1, true, 59, 6);
+        guiItemStacks.init(2, false, 117, 6);
+
+        guiItemStacks.set(ingredients);
+    }
+}

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
@@ -4,33 +4,25 @@ import mezz.jei.api.recipe.IRecipeHandler;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 
-import javax.annotation.Nonnull;
-
 public class AnvilRecipeHandler implements IRecipeHandler<AnvilRecipeWrapper> {
 
     @Override
-    public
-    @Nonnull
-    Class<AnvilRecipeWrapper> getRecipeClass() {
+    public Class<AnvilRecipeWrapper> getRecipeClass() {
         return AnvilRecipeWrapper.class;
     }
 
     @Override
-    public
-    @Nonnull
-    String getRecipeCategoryUid(@Nonnull AnvilRecipeWrapper recipe) {
+    public String getRecipeCategoryUid(AnvilRecipeWrapper recipe) {
         return VanillaRecipeCategoryUid.ANVIL;
     }
 
     @Override
-    public
-    @Nonnull
-    IRecipeWrapper getRecipeWrapper(@Nonnull AnvilRecipeWrapper recipe) {
+    public IRecipeWrapper getRecipeWrapper(AnvilRecipeWrapper recipe) {
         return recipe;
     }
 
     @Override
-    public boolean isRecipeValid(@Nonnull AnvilRecipeWrapper recipe) {
+    public boolean isRecipeValid(AnvilRecipeWrapper recipe) {
         return true;
     }
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
@@ -1,0 +1,40 @@
+package mezz.jei.plugins.vanilla.anvil;
+
+import mezz.jei.api.recipe.IRecipeHandler;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
+
+import javax.annotation.Nonnull;
+
+public class AnvilRecipeHandler implements IRecipeHandler<AnvilRecipeWrapper>
+{
+    @Override
+    public
+    @Nonnull
+    Class<AnvilRecipeWrapper> getRecipeClass()
+    {
+        return AnvilRecipeWrapper.class;
+    }
+
+    @Override
+    public
+    @Nonnull
+    String getRecipeCategoryUid(@Nonnull AnvilRecipeWrapper recipe)
+    {
+        return VanillaRecipeCategoryUid.ANVIL;
+    }
+
+    @Override
+    public
+    @Nonnull
+    IRecipeWrapper getRecipeWrapper(@Nonnull AnvilRecipeWrapper recipe)
+    {
+        return recipe;
+    }
+
+    @Override
+    public boolean isRecipeValid(@Nonnull AnvilRecipeWrapper recipe)
+    {
+        return true;
+    }
+}

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
@@ -6,35 +6,31 @@ import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 
 import javax.annotation.Nonnull;
 
-public class AnvilRecipeHandler implements IRecipeHandler<AnvilRecipeWrapper>
-{
+public class AnvilRecipeHandler implements IRecipeHandler<AnvilRecipeWrapper> {
+
     @Override
     public
     @Nonnull
-    Class<AnvilRecipeWrapper> getRecipeClass()
-    {
+    Class<AnvilRecipeWrapper> getRecipeClass() {
         return AnvilRecipeWrapper.class;
     }
 
     @Override
     public
     @Nonnull
-    String getRecipeCategoryUid(@Nonnull AnvilRecipeWrapper recipe)
-    {
+    String getRecipeCategoryUid(@Nonnull AnvilRecipeWrapper recipe) {
         return VanillaRecipeCategoryUid.ANVIL;
     }
 
     @Override
     public
     @Nonnull
-    IRecipeWrapper getRecipeWrapper(@Nonnull AnvilRecipeWrapper recipe)
-    {
+    IRecipeWrapper getRecipeWrapper(@Nonnull AnvilRecipeWrapper recipe) {
         return recipe;
     }
 
     @Override
-    public boolean isRecipeValid(@Nonnull AnvilRecipeWrapper recipe)
-    {
+    public boolean isRecipeValid(@Nonnull AnvilRecipeWrapper recipe) {
         return true;
     }
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeHandler.java
@@ -6,23 +6,23 @@ import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 
 public class AnvilRecipeHandler implements IRecipeHandler<AnvilRecipeWrapper> {
 
-    @Override
-    public Class<AnvilRecipeWrapper> getRecipeClass() {
-        return AnvilRecipeWrapper.class;
-    }
+	@Override
+	public Class<AnvilRecipeWrapper> getRecipeClass() {
+		return AnvilRecipeWrapper.class;
+	}
 
-    @Override
-    public String getRecipeCategoryUid(AnvilRecipeWrapper recipe) {
-        return VanillaRecipeCategoryUid.ANVIL;
-    }
+	@Override
+	public String getRecipeCategoryUid(AnvilRecipeWrapper recipe) {
+		return VanillaRecipeCategoryUid.ANVIL;
+	}
 
-    @Override
-    public IRecipeWrapper getRecipeWrapper(AnvilRecipeWrapper recipe) {
-        return recipe;
-    }
+	@Override
+	public IRecipeWrapper getRecipeWrapper(AnvilRecipeWrapper recipe) {
+		return recipe;
+	}
 
-    @Override
-    public boolean isRecipeValid(AnvilRecipeWrapper recipe) {
-        return true;
-    }
+	@Override
+	public boolean isRecipeValid(AnvilRecipeWrapper recipe) {
+		return true;
+	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -2,7 +2,6 @@ package mezz.jei.plugins.vanilla.anvil;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
-import javafx.util.Pair;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.util.Log;
 import net.minecraft.enchantment.Enchantment;
@@ -12,6 +11,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collections;
 import java.util.List;
@@ -52,8 +52,6 @@ public class AnvilRecipeMaker {
 		}
 	}
 
-	private static <T1, T2> Pair<T1, T2> pairOf(T1 left, T2 right) { return new Pair<T1, T2>(left, right); }
-
 	@SuppressWarnings("unchecked")
 	private static void registerRepairRecipes(IModRegistry registry) {
 		ItemStack repairWood = new ItemStack(Blocks.PLANKS, 1, OreDictionary.WILDCARD_VALUE);
@@ -63,62 +61,62 @@ public class AnvilRecipeMaker {
 		ItemStack repairDiamond = new ItemStack(Items.DIAMOND);
 		ItemStack repairLeather = new ItemStack(Items.LEATHER);
 		List<Pair<ItemStack,ItemStack>> items = Lists.newArrayList(
-				pairOf(new ItemStack(Items.WOODEN_SWORD), repairWood),
-				pairOf(new ItemStack(Items.WOODEN_PICKAXE), repairWood),
-				pairOf(new ItemStack(Items.WOODEN_AXE), repairWood),
-				pairOf(new ItemStack(Items.WOODEN_SHOVEL), repairWood),
-				pairOf(new ItemStack(Items.WOODEN_HOE), repairWood),
-				pairOf(new ItemStack(Items.STONE_SWORD), repairStone),
-				pairOf(new ItemStack(Items.STONE_PICKAXE), repairStone),
-				pairOf(new ItemStack(Items.STONE_AXE), repairStone),
-				pairOf(new ItemStack(Items.STONE_SHOVEL), repairStone),
-				pairOf(new ItemStack(Items.STONE_HOE), repairStone),
-				pairOf(new ItemStack(Items.LEATHER_HELMET), repairLeather),
-				pairOf(new ItemStack(Items.LEATHER_CHESTPLATE), repairLeather),
-				pairOf(new ItemStack(Items.LEATHER_LEGGINGS), repairLeather),
-				pairOf(new ItemStack(Items.LEATHER_BOOTS), repairLeather),
-				pairOf(new ItemStack(Items.IRON_SWORD), repairIron),
-				pairOf(new ItemStack(Items.IRON_PICKAXE), repairIron),
-				pairOf(new ItemStack(Items.IRON_AXE), repairIron),
-				pairOf(new ItemStack(Items.IRON_SHOVEL), repairIron),
-				pairOf(new ItemStack(Items.IRON_HOE), repairIron),
-				pairOf(new ItemStack(Items.IRON_HELMET), repairIron),
-				pairOf(new ItemStack(Items.IRON_CHESTPLATE), repairIron),
-				pairOf(new ItemStack(Items.IRON_LEGGINGS), repairIron),
-				pairOf(new ItemStack(Items.IRON_BOOTS), repairIron),
-				pairOf(new ItemStack(Items.CHAINMAIL_HELMET), repairIron),
-				pairOf(new ItemStack(Items.CHAINMAIL_CHESTPLATE), repairIron),
-				pairOf(new ItemStack(Items.CHAINMAIL_LEGGINGS), repairIron),
-				pairOf(new ItemStack(Items.CHAINMAIL_BOOTS), repairIron),
-				pairOf(new ItemStack(Items.GOLDEN_SWORD), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_PICKAXE), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_AXE), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_SHOVEL), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_HOE), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_HELMET), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_CHESTPLATE), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_LEGGINGS), repairGold),
-				pairOf(new ItemStack(Items.GOLDEN_BOOTS), repairGold),
-				pairOf(new ItemStack(Items.DIAMOND_SWORD), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_PICKAXE), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_AXE), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_SHOVEL), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_HOE), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_HELMET), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_CHESTPLATE), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_LEGGINGS), repairDiamond),
-				pairOf(new ItemStack(Items.DIAMOND_BOOTS), repairDiamond),
-				pairOf(new ItemStack(Items.SHIELD), repairWood),
-				pairOf(new ItemStack(Items.ELYTRA), repairLeather)
+				Pair.of(new ItemStack(Items.WOODEN_SWORD), repairWood),
+				Pair.of(new ItemStack(Items.WOODEN_PICKAXE), repairWood),
+				Pair.of(new ItemStack(Items.WOODEN_AXE), repairWood),
+				Pair.of(new ItemStack(Items.WOODEN_SHOVEL), repairWood),
+				Pair.of(new ItemStack(Items.WOODEN_HOE), repairWood),
+				Pair.of(new ItemStack(Items.STONE_SWORD), repairStone),
+				Pair.of(new ItemStack(Items.STONE_PICKAXE), repairStone),
+				Pair.of(new ItemStack(Items.STONE_AXE), repairStone),
+				Pair.of(new ItemStack(Items.STONE_SHOVEL), repairStone),
+				Pair.of(new ItemStack(Items.STONE_HOE), repairStone),
+				Pair.of(new ItemStack(Items.LEATHER_HELMET), repairLeather),
+				Pair.of(new ItemStack(Items.LEATHER_CHESTPLATE), repairLeather),
+				Pair.of(new ItemStack(Items.LEATHER_LEGGINGS), repairLeather),
+				Pair.of(new ItemStack(Items.LEATHER_BOOTS), repairLeather),
+				Pair.of(new ItemStack(Items.IRON_SWORD), repairIron),
+				Pair.of(new ItemStack(Items.IRON_PICKAXE), repairIron),
+				Pair.of(new ItemStack(Items.IRON_AXE), repairIron),
+				Pair.of(new ItemStack(Items.IRON_SHOVEL), repairIron),
+				Pair.of(new ItemStack(Items.IRON_HOE), repairIron),
+				Pair.of(new ItemStack(Items.IRON_HELMET), repairIron),
+				Pair.of(new ItemStack(Items.IRON_CHESTPLATE), repairIron),
+				Pair.of(new ItemStack(Items.IRON_LEGGINGS), repairIron),
+				Pair.of(new ItemStack(Items.IRON_BOOTS), repairIron),
+				Pair.of(new ItemStack(Items.CHAINMAIL_HELMET), repairIron),
+				Pair.of(new ItemStack(Items.CHAINMAIL_CHESTPLATE), repairIron),
+				Pair.of(new ItemStack(Items.CHAINMAIL_LEGGINGS), repairIron),
+				Pair.of(new ItemStack(Items.CHAINMAIL_BOOTS), repairIron),
+				Pair.of(new ItemStack(Items.GOLDEN_SWORD), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_PICKAXE), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_AXE), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_SHOVEL), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_HOE), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_HELMET), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_CHESTPLATE), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_LEGGINGS), repairGold),
+				Pair.of(new ItemStack(Items.GOLDEN_BOOTS), repairGold),
+				Pair.of(new ItemStack(Items.DIAMOND_SWORD), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_PICKAXE), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_AXE), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_SHOVEL), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_HOE), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_HELMET), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_CHESTPLATE), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_LEGGINGS), repairDiamond),
+				Pair.of(new ItemStack(Items.DIAMOND_BOOTS), repairDiamond),
+				Pair.of(new ItemStack(Items.SHIELD), repairWood),
+				Pair.of(new ItemStack(Items.ELYTRA), repairLeather)
 				);
 		for (Pair<ItemStack,ItemStack> entry : items) {
-			ItemStack damaged1 = entry.getKey().copy();
+			ItemStack damaged1 = entry.getLeft().copy();
 			damaged1.setItemDamage(damaged1.getMaxDamage() * 3 / 4);
-			ItemStack damaged2 = entry.getKey().copy();
+			ItemStack damaged2 = entry.getLeft().copy();
 			damaged2.setItemDamage(damaged2.getMaxDamage() / 2);
-			ItemStack damaged3 = entry.getKey().copy();
+			ItemStack damaged3 = entry.getLeft().copy();
 			damaged3.setItemDamage(damaged2.getMaxDamage() / 4);
-			registry.addAnvilRecipe(damaged2, entry.getValue(), damaged3);
+			registry.addAnvilRecipe(damaged2, entry.getRight(), damaged3);
 			registry.addAnvilRecipe(damaged1, damaged2, damaged3);
 		}
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -24,12 +24,12 @@ public class AnvilRecipeMaker {
 		Stopwatch sw = Stopwatch.createStarted();
 		registerRepairRecipes(registry);
 		sw.stop();
-		Log.info("Registered vanilla repair recipes in %s ms", sw.elapsed(TimeUnit.MILLISECONDS));
+		Log.info("Registered vanilla repair recipes in {} ms", sw.elapsed(TimeUnit.MILLISECONDS));
 		sw.reset();
 		sw.start();
 		registerBookEnchantmentRecipes(registry);
 		sw.stop();
-		Log.info("Registered enchantment recipes in %s ms", sw.elapsed(TimeUnit.MILLISECONDS));
+		Log.info("Registered enchantment recipes in {} ms", sw.elapsed(TimeUnit.MILLISECONDS));
 	}
 
 	private static void registerBookEnchantmentRecipes(IModRegistry registry) {
@@ -39,14 +39,18 @@ public class AnvilRecipeMaker {
 		for (ItemStack ingredient : ingredients) {
 			for (Enchantment enchantment : enchantments) {
 				if (enchantment.canApply(ingredient)) {
+					List<ItemStack> perLevelBooks = Lists.newArrayList();
+					List<ItemStack> perLevelOutputs = Lists.newArrayList();
 					for (int level = 1; level <= enchantment.getMaxLevel(); level++) {
 						ItemStack withEnchant = ingredient.copy();
 						ItemStack bookEnchant = book.copy();
 						Map<Enchantment, Integer> enchMap = Collections.singletonMap(enchantment, level);
 						EnchantmentHelper.setEnchantments(enchMap, withEnchant);
 						EnchantmentHelper.setEnchantments(enchMap, bookEnchant);
-						registry.addAnvilRecipe(ingredient, bookEnchant, withEnchant);
+						perLevelBooks.add(bookEnchant);
+						perLevelOutputs.add(withEnchant);
 					}
+					registry.addAnvilRecipe(ingredient, perLevelBooks, perLevelOutputs);
 				}
 			}
 		}
@@ -111,13 +115,13 @@ public class AnvilRecipeMaker {
 				);
 		for (Pair<ItemStack,ItemStack> entry : items) {
 			ItemStack damaged1 = entry.getLeft().copy();
-			damaged1.setItemDamage(damaged1.getMaxDamage() * 3 / 4);
+			damaged1.setItemDamage(damaged1.getMaxDamage());
 			ItemStack damaged2 = entry.getLeft().copy();
-			damaged2.setItemDamage(damaged2.getMaxDamage() / 2);
+			damaged2.setItemDamage(damaged2.getMaxDamage() * 3 / 4);
 			ItemStack damaged3 = entry.getLeft().copy();
-			damaged3.setItemDamage(damaged2.getMaxDamage() / 4);
-			registry.addAnvilRecipe(damaged2, entry.getRight(), damaged3);
-			registry.addAnvilRecipe(damaged1, damaged2, damaged3);
+			damaged3.setItemDamage(damaged3.getMaxDamage() * 2 / 4);
+			registry.addAnvilRecipe(damaged1, entry.getRight(), damaged2);
+			registry.addAnvilRecipe(damaged2, damaged2, damaged3);
 		}
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -2,6 +2,7 @@ package mezz.jei.plugins.vanilla.anvil;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.util.Log;
 import net.minecraft.enchantment.Enchantment;
@@ -11,7 +12,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.OreDictionary;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,78 +50,107 @@ public class AnvilRecipeMaker {
 						perLevelBooks.add(bookEnchant);
 						perLevelOutputs.add(withEnchant);
 					}
-					registry.addAnvilRecipe(ingredient, perLevelBooks, perLevelOutputs);
+					registry.addAnvilRecipe(ingredient, perLevelBooks, perLevelOutputs, 0);
 				}
 			}
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private static void registerRepairRecipes(IModRegistry registry) {
+		Map<ItemStack,List<ItemStack>> items = Maps.newHashMap();
+
 		ItemStack repairWood = new ItemStack(Blocks.PLANKS, 1, OreDictionary.WILDCARD_VALUE);
+		items.put(repairWood, Lists.newArrayList(
+				new ItemStack(Items.WOODEN_SWORD),
+				new ItemStack(Items.WOODEN_PICKAXE),
+				new ItemStack(Items.WOODEN_AXE),
+				new ItemStack(Items.WOODEN_SHOVEL),
+				new ItemStack(Items.WOODEN_HOE),
+				new ItemStack(Items.SHIELD)
+		));
+
 		ItemStack repairStone = new ItemStack(Blocks.COBBLESTONE);
-		ItemStack repairIron = new ItemStack(Items.IRON_INGOT);
-		ItemStack repairGold = new ItemStack(Items.GOLD_INGOT);
-		ItemStack repairDiamond = new ItemStack(Items.DIAMOND);
+		items.put(repairStone, Lists.newArrayList(
+				new ItemStack(Items.STONE_SWORD),
+				new ItemStack(Items.STONE_PICKAXE),
+				new ItemStack(Items.STONE_AXE),
+				new ItemStack(Items.STONE_SHOVEL),
+				new ItemStack(Items.STONE_HOE)
+		));
+
 		ItemStack repairLeather = new ItemStack(Items.LEATHER);
-		List<Pair<ItemStack,ItemStack>> items = Lists.newArrayList(
-				Pair.of(new ItemStack(Items.WOODEN_SWORD), repairWood),
-				Pair.of(new ItemStack(Items.WOODEN_PICKAXE), repairWood),
-				Pair.of(new ItemStack(Items.WOODEN_AXE), repairWood),
-				Pair.of(new ItemStack(Items.WOODEN_SHOVEL), repairWood),
-				Pair.of(new ItemStack(Items.WOODEN_HOE), repairWood),
-				Pair.of(new ItemStack(Items.STONE_SWORD), repairStone),
-				Pair.of(new ItemStack(Items.STONE_PICKAXE), repairStone),
-				Pair.of(new ItemStack(Items.STONE_AXE), repairStone),
-				Pair.of(new ItemStack(Items.STONE_SHOVEL), repairStone),
-				Pair.of(new ItemStack(Items.STONE_HOE), repairStone),
-				Pair.of(new ItemStack(Items.LEATHER_HELMET), repairLeather),
-				Pair.of(new ItemStack(Items.LEATHER_CHESTPLATE), repairLeather),
-				Pair.of(new ItemStack(Items.LEATHER_LEGGINGS), repairLeather),
-				Pair.of(new ItemStack(Items.LEATHER_BOOTS), repairLeather),
-				Pair.of(new ItemStack(Items.IRON_SWORD), repairIron),
-				Pair.of(new ItemStack(Items.IRON_PICKAXE), repairIron),
-				Pair.of(new ItemStack(Items.IRON_AXE), repairIron),
-				Pair.of(new ItemStack(Items.IRON_SHOVEL), repairIron),
-				Pair.of(new ItemStack(Items.IRON_HOE), repairIron),
-				Pair.of(new ItemStack(Items.IRON_HELMET), repairIron),
-				Pair.of(new ItemStack(Items.IRON_CHESTPLATE), repairIron),
-				Pair.of(new ItemStack(Items.IRON_LEGGINGS), repairIron),
-				Pair.of(new ItemStack(Items.IRON_BOOTS), repairIron),
-				Pair.of(new ItemStack(Items.CHAINMAIL_HELMET), repairIron),
-				Pair.of(new ItemStack(Items.CHAINMAIL_CHESTPLATE), repairIron),
-				Pair.of(new ItemStack(Items.CHAINMAIL_LEGGINGS), repairIron),
-				Pair.of(new ItemStack(Items.CHAINMAIL_BOOTS), repairIron),
-				Pair.of(new ItemStack(Items.GOLDEN_SWORD), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_PICKAXE), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_AXE), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_SHOVEL), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_HOE), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_HELMET), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_CHESTPLATE), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_LEGGINGS), repairGold),
-				Pair.of(new ItemStack(Items.GOLDEN_BOOTS), repairGold),
-				Pair.of(new ItemStack(Items.DIAMOND_SWORD), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_PICKAXE), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_AXE), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_SHOVEL), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_HOE), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_HELMET), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_CHESTPLATE), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_LEGGINGS), repairDiamond),
-				Pair.of(new ItemStack(Items.DIAMOND_BOOTS), repairDiamond),
-				Pair.of(new ItemStack(Items.SHIELD), repairWood),
-				Pair.of(new ItemStack(Items.ELYTRA), repairLeather)
-				);
-		for (Pair<ItemStack,ItemStack> entry : items) {
-			ItemStack damaged1 = entry.getLeft().copy();
-			damaged1.setItemDamage(damaged1.getMaxDamage());
-			ItemStack damaged2 = entry.getLeft().copy();
-			damaged2.setItemDamage(damaged2.getMaxDamage() * 3 / 4);
-			ItemStack damaged3 = entry.getLeft().copy();
-			damaged3.setItemDamage(damaged3.getMaxDamage() * 2 / 4);
-			registry.addAnvilRecipe(damaged1, entry.getRight(), damaged2);
-			registry.addAnvilRecipe(damaged2, damaged2, damaged3);
+		items.put(repairLeather, Lists.newArrayList(
+				new ItemStack(Items.LEATHER_HELMET),
+				new ItemStack(Items.LEATHER_CHESTPLATE),
+				new ItemStack(Items.LEATHER_LEGGINGS),
+				new ItemStack(Items.LEATHER_BOOTS),
+				new ItemStack(Items.ELYTRA)
+		));
+
+		ItemStack repairIron = new ItemStack(Items.IRON_INGOT);
+		items.put(repairIron, Lists.newArrayList(
+				new ItemStack(Items.IRON_SWORD),
+				new ItemStack(Items.IRON_PICKAXE),
+				new ItemStack(Items.IRON_AXE),
+				new ItemStack(Items.IRON_SHOVEL),
+				new ItemStack(Items.IRON_HOE),
+				new ItemStack(Items.IRON_HELMET),
+				new ItemStack(Items.IRON_CHESTPLATE),
+				new ItemStack(Items.IRON_LEGGINGS),
+				new ItemStack(Items.IRON_BOOTS),
+				new ItemStack(Items.CHAINMAIL_HELMET),
+				new ItemStack(Items.CHAINMAIL_CHESTPLATE),
+				new ItemStack(Items.CHAINMAIL_LEGGINGS),
+				new ItemStack(Items.CHAINMAIL_BOOTS)
+		));
+
+		ItemStack repairGold = new ItemStack(Items.GOLD_INGOT);
+		items.put(repairGold, Lists.newArrayList(
+				new ItemStack(Items.GOLDEN_SWORD),
+				new ItemStack(Items.GOLDEN_PICKAXE),
+				new ItemStack(Items.GOLDEN_AXE),
+				new ItemStack(Items.GOLDEN_SHOVEL),
+				new ItemStack(Items.GOLDEN_HOE),
+				new ItemStack(Items.GOLDEN_HELMET),
+				new ItemStack(Items.GOLDEN_CHESTPLATE),
+				new ItemStack(Items.GOLDEN_LEGGINGS),
+				new ItemStack(Items.GOLDEN_BOOTS)
+		));
+
+		ItemStack repairDiamond = new ItemStack(Items.DIAMOND);
+		items.put(repairDiamond, Lists.newArrayList(
+				new ItemStack(Items.DIAMOND_SWORD),
+				new ItemStack(Items.DIAMOND_PICKAXE),
+				new ItemStack(Items.DIAMOND_AXE),
+				new ItemStack(Items.DIAMOND_SHOVEL),
+				new ItemStack(Items.DIAMOND_HOE),
+				new ItemStack(Items.DIAMOND_HELMET),
+				new ItemStack(Items.DIAMOND_CHESTPLATE),
+				new ItemStack(Items.DIAMOND_LEGGINGS),
+				new ItemStack(Items.DIAMOND_BOOTS)
+		));
+
+		for (Map.Entry<ItemStack,List<ItemStack>> entry : items.entrySet()) {
+
+			ItemStack repairMaterial = entry.getKey();
+
+			for (ItemStack ingredient : entry.getValue()) {
+
+				ItemStack damaged1 = ingredient.copy();
+				damaged1.setItemDamage(damaged1.getMaxDamage());
+				ItemStack damaged2 = ingredient.copy();
+				damaged2.setItemDamage(damaged2.getMaxDamage() * 3 / 4);
+				ItemStack damaged3 = ingredient.copy();
+				damaged3.setItemDamage(damaged3.getMaxDamage() * 2 / 4);
+
+				// Repair with material
+				registry.addAnvilRecipe(damaged1, Collections.singletonList(repairMaterial),
+						Collections.singletonList(damaged2), 0);
+
+				// Repair with another of the same
+				registry.addAnvilRecipe(damaged2, Collections.singletonList(damaged2),
+						Collections.singletonList(damaged3), 0);
+			}
 		}
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -1,0 +1,40 @@
+package mezz.jei.plugins.vanilla.anvil;
+
+import com.google.common.collect.Lists;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.init.Enchantments;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AnvilRecipeMaker
+{
+    public static List<AnvilRecipeWrapper> getVanillaAnvilRecipes()
+    {
+        List<AnvilRecipeWrapper> recipes = Lists.newArrayList();
+        addBookEnchantmentRecipes(recipes);
+        addRepairRecipes(recipes);
+        return recipes;
+    }
+
+    public static void addBookEnchantmentRecipes(List<AnvilRecipeWrapper> recipes)
+    {
+        // TODO
+
+        ItemStack original = new ItemStack(Items.DIAMOND_SWORD);
+        ItemStack book = new ItemStack(Items.ENCHANTED_BOOK);
+        ItemStack withEnchant = new ItemStack(Items.DIAMOND_SWORD);
+        EnchantmentHelper.setEnchantments(Collections.singletonMap(Enchantments.SHARPNESS, 5), withEnchant);
+        EnchantmentHelper.setEnchantments(Collections.singletonMap(Enchantments.SHARPNESS, 5), book);
+
+        recipes.add(new AnvilRecipeWrapper(original, book, withEnchant, 5));
+    }
+
+    public static void addRepairRecipes(List<AnvilRecipeWrapper> recipes)
+    {
+        // TODO
+    }
+}

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -4,11 +4,15 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.util.FakeClientPlayer;
+import mezz.jei.util.FakeClientWorld;
 import mezz.jei.util.Log;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.inventory.ContainerRepair;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.OreDictionary;
@@ -50,7 +54,7 @@ public class AnvilRecipeMaker {
 						perLevelBooks.add(bookEnchant);
 						perLevelOutputs.add(withEnchant);
 					}
-					registry.addAnvilRecipe(ingredient, perLevelBooks, perLevelOutputs, 0);
+					registry.addAnvilRecipe(ingredient, perLevelBooks, perLevelOutputs);
 				}
 			}
 		}
@@ -145,12 +149,22 @@ public class AnvilRecipeMaker {
 
 				// Repair with material
 				registry.addAnvilRecipe(damaged1, Collections.singletonList(repairMaterial),
-						Collections.singletonList(damaged2), 0);
+						Collections.singletonList(damaged2));
 
 				// Repair with another of the same
 				registry.addAnvilRecipe(damaged2, Collections.singletonList(damaged2),
-						Collections.singletonList(damaged3), 0);
+						Collections.singletonList(damaged3));
 			}
 		}
+	}
+
+	public static int findLevelsCost(ItemStack leftStack, ItemStack rightStack)
+	{
+		FakeClientPlayer fakePlayer = FakeClientPlayer.getInstance();
+		InventoryPlayer fakeInventory = new InventoryPlayer(fakePlayer);
+		ContainerRepair repair = new ContainerRepair(fakeInventory, FakeClientWorld.getInstance(), fakePlayer);
+		repair.inventorySlots.get(0).putStack(leftStack);
+		repair.inventorySlots.get(1).putStack(rightStack);
+		return repair.maximumCost;
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -1,37 +1,105 @@
 package mezz.jei.plugins.vanilla.anvil;
 
 import com.google.common.collect.Lists;
+import javafx.util.Pair;
+import mezz.jei.api.IModRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Enchantments;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
 
 import java.util.Collections;
 import java.util.List;
 
 public class AnvilRecipeMaker {
 
-    public static List<AnvilRecipeWrapper> getVanillaAnvilRecipes() {
+	public static void registerVanillaAnvilRecipes(IModRegistry registry) {
+		registerBookEnchantmentRecipes(registry);
+		registerRepairRecipes(registry);
+	}
 
-        List<AnvilRecipeWrapper> recipes = Lists.newArrayList();
-        addBookEnchantmentRecipes(recipes);
-        addRepairRecipes(recipes);
-        return recipes;
-    }
+	private static void registerBookEnchantmentRecipes(IModRegistry registry) {
+		// TODO
 
-    public static void addBookEnchantmentRecipes(List<AnvilRecipeWrapper> recipes) {
-        // TODO
+		ItemStack original = new ItemStack(Items.DIAMOND_SWORD);
+		ItemStack book = new ItemStack(Items.ENCHANTED_BOOK);
+		ItemStack withEnchant = new ItemStack(Items.DIAMOND_SWORD);
+		EnchantmentHelper.setEnchantments(Collections.singletonMap(Enchantments.SHARPNESS, 5), withEnchant);
+		EnchantmentHelper.setEnchantments(Collections.singletonMap(Enchantments.SHARPNESS, 5), book);
 
-        ItemStack original = new ItemStack(Items.DIAMOND_SWORD);
-        ItemStack book = new ItemStack(Items.ENCHANTED_BOOK);
-        ItemStack withEnchant = new ItemStack(Items.DIAMOND_SWORD);
-        EnchantmentHelper.setEnchantments(Collections.singletonMap(Enchantments.SHARPNESS, 5), withEnchant);
-        EnchantmentHelper.setEnchantments(Collections.singletonMap(Enchantments.SHARPNESS, 5), book);
+		registry.addAnvilRecipe(original, book, withEnchant, 5);
+	}
 
-        recipes.add(new AnvilRecipeWrapper(original, book, withEnchant, 5));
-    }
+	private static <T1, T2> Pair<T1, T2> pairOf(T1 left, T2 right) { return new Pair<T1, T2>(left, right); }
 
-    public static void addRepairRecipes(List<AnvilRecipeWrapper> recipes) {
-        // TODO
-    }
+	@SuppressWarnings("unchecked")
+	private static void registerRepairRecipes(IModRegistry registry) {
+		ItemStack repairWood = new ItemStack(Blocks.PLANKS, 1, OreDictionary.WILDCARD_VALUE);
+		ItemStack repairStone = new ItemStack(Blocks.COBBLESTONE);
+		ItemStack repairIron = new ItemStack(Items.IRON_INGOT);
+		ItemStack repairGold = new ItemStack(Items.GOLD_INGOT);
+		ItemStack repairDiamond = new ItemStack(Items.DIAMOND);
+		ItemStack repairLeather = new ItemStack(Items.LEATHER);
+		List<Pair<ItemStack,ItemStack>> items = Lists.newArrayList(
+				pairOf(new ItemStack(Items.WOODEN_SWORD), repairWood),
+				pairOf(new ItemStack(Items.WOODEN_PICKAXE), repairWood),
+				pairOf(new ItemStack(Items.WOODEN_AXE), repairWood),
+				pairOf(new ItemStack(Items.WOODEN_SHOVEL), repairWood),
+				pairOf(new ItemStack(Items.WOODEN_HOE), repairWood),
+				pairOf(new ItemStack(Items.STONE_SWORD), repairStone),
+				pairOf(new ItemStack(Items.STONE_PICKAXE), repairStone),
+				pairOf(new ItemStack(Items.STONE_AXE), repairStone),
+				pairOf(new ItemStack(Items.STONE_SHOVEL), repairStone),
+				pairOf(new ItemStack(Items.STONE_HOE), repairStone),
+				pairOf(new ItemStack(Items.LEATHER_HELMET), repairLeather),
+				pairOf(new ItemStack(Items.LEATHER_CHESTPLATE), repairLeather),
+				pairOf(new ItemStack(Items.LEATHER_LEGGINGS), repairLeather),
+				pairOf(new ItemStack(Items.LEATHER_BOOTS), repairLeather),
+				pairOf(new ItemStack(Items.IRON_SWORD), repairIron),
+				pairOf(new ItemStack(Items.IRON_PICKAXE), repairIron),
+				pairOf(new ItemStack(Items.IRON_AXE), repairIron),
+				pairOf(new ItemStack(Items.IRON_SHOVEL), repairIron),
+				pairOf(new ItemStack(Items.IRON_HOE), repairIron),
+				pairOf(new ItemStack(Items.IRON_HELMET), repairIron),
+				pairOf(new ItemStack(Items.IRON_CHESTPLATE), repairIron),
+				pairOf(new ItemStack(Items.IRON_LEGGINGS), repairIron),
+				pairOf(new ItemStack(Items.IRON_BOOTS), repairIron),
+				pairOf(new ItemStack(Items.CHAINMAIL_HELMET), repairIron),
+				pairOf(new ItemStack(Items.CHAINMAIL_CHESTPLATE), repairIron),
+				pairOf(new ItemStack(Items.CHAINMAIL_LEGGINGS), repairIron),
+				pairOf(new ItemStack(Items.CHAINMAIL_BOOTS), repairIron),
+				pairOf(new ItemStack(Items.GOLDEN_SWORD), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_PICKAXE), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_AXE), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_SHOVEL), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_HOE), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_HELMET), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_CHESTPLATE), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_LEGGINGS), repairGold),
+				pairOf(new ItemStack(Items.GOLDEN_BOOTS), repairGold),
+				pairOf(new ItemStack(Items.DIAMOND_SWORD), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_PICKAXE), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_AXE), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_SHOVEL), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_HOE), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_HELMET), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_CHESTPLATE), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_LEGGINGS), repairDiamond),
+				pairOf(new ItemStack(Items.DIAMOND_BOOTS), repairDiamond),
+				pairOf(new ItemStack(Items.SHIELD), repairWood),
+				pairOf(new ItemStack(Items.ELYTRA), repairLeather)
+				);
+		for (Pair<ItemStack,ItemStack> entry : items) {
+			ItemStack damaged1 = entry.getKey().copy();
+			damaged1.setItemDamage(damaged1.getMaxDamage() * 3 / 4);
+			ItemStack damaged2 = entry.getKey().copy();
+			damaged2.setItemDamage(damaged2.getMaxDamage() / 2);
+			ItemStack damaged3 = entry.getKey().copy();
+			damaged3.setItemDamage(damaged2.getMaxDamage() / 4);
+			registry.addAnvilRecipe(damaged2, entry.getValue(), damaged3);
+			registry.addAnvilRecipe(damaged1, damaged2, damaged3);
+		}
+	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -6,22 +6,20 @@ import net.minecraft.init.Enchantments;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class AnvilRecipeMaker
-{
-    public static List<AnvilRecipeWrapper> getVanillaAnvilRecipes()
-    {
+public class AnvilRecipeMaker {
+
+    public static List<AnvilRecipeWrapper> getVanillaAnvilRecipes() {
+
         List<AnvilRecipeWrapper> recipes = Lists.newArrayList();
         addBookEnchantmentRecipes(recipes);
         addRepairRecipes(recipes);
         return recipes;
     }
 
-    public static void addBookEnchantmentRecipes(List<AnvilRecipeWrapper> recipes)
-    {
+    public static void addBookEnchantmentRecipes(List<AnvilRecipeWrapper> recipes) {
         // TODO
 
         ItemStack original = new ItemStack(Items.DIAMOND_SWORD);
@@ -33,8 +31,7 @@ public class AnvilRecipeMaker
         recipes.add(new AnvilRecipeWrapper(original, book, withEnchant, 5));
     }
 
-    public static void addRepairRecipes(List<AnvilRecipeWrapper> recipes)
-    {
+    public static void addRepairRecipes(List<AnvilRecipeWrapper> recipes) {
         // TODO
     }
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -8,11 +8,12 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class AnvilRecipeWrapper extends BlankRecipeWrapper {
-	private final List<ItemStack> inputs;
-	private final ItemStack output;
+	private final List<List<ItemStack>> inputs;
+	private final List<List<ItemStack>> output;
 	private final int cost;
 
 	public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
@@ -20,8 +21,17 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
 	}
 
 	public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost) {
-		this.inputs = Arrays.asList(leftInput, rightInput);
-		this.output = output;
+		this(leftInput, Collections.singletonList(rightInput), Collections.singletonList(output), levelsCost);
+	}
+
+	public AnvilRecipeWrapper(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+		this(leftInput, rightInputs, outputs, -1);
+	}
+
+	@SuppressWarnings("unchecked")
+	public AnvilRecipeWrapper(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost) {
+		this.inputs = Arrays.asList(Collections.singletonList(leftInput), rightInputs);
+		this.output = Collections.singletonList(outputs);
 		this.cost = levelsCost;
 	}
 
@@ -61,7 +71,7 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
 
 	@Override
 	public void getIngredients(IIngredients ingredients) {
-		ingredients.setInputs(ItemStack.class, inputs);
-		ingredients.setOutput(ItemStack.class, output);
+		ingredients.setInputLists(ItemStack.class, inputs);
+		ingredients.setOutputLists(ItemStack.class, output);
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -1,5 +1,6 @@
 package mezz.jei.plugins.vanilla.anvil;
 
+import com.google.common.collect.Lists;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import net.minecraft.client.Minecraft;
@@ -7,7 +8,6 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -17,7 +17,10 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
 	private final int cost;
 
 	public AnvilRecipeWrapper(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost) {
-		this.inputs = Arrays.asList(Collections.singletonList(leftInput), rightInputs);
+		this.inputs = Lists.newArrayList();
+		this.inputs.add(Collections.singletonList(leftInput));
+		this.inputs.add(rightInputs);
+
 		this.output = Collections.singletonList(outputs);
 		this.cost = levelsCost;
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 public class AnvilRecipeWrapper extends BlankRecipeWrapper {
@@ -28,7 +27,7 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
     }
 
     @Override
-    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+    public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
 
         if (cost >= 0) {
             // GuiRepair'text special shadow
@@ -63,7 +62,7 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
     }
 
     @Override
-    public void getIngredients(@Nonnull IIngredients ingredients) {
+    public void getIngredients(IIngredients ingredients) {
         ingredients.setInputs(ItemStack.class, Arrays.asList(leftInput, rightInput));
         ingredients.setOutput(ItemStack.class, output);
     }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -16,19 +16,6 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
 	private final List<List<ItemStack>> output;
 	private final int cost;
 
-	public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
-		this(leftInput, rightInput, output, -1);
-	}
-
-	public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost) {
-		this(leftInput, Collections.singletonList(rightInput), Collections.singletonList(output), levelsCost);
-	}
-
-	public AnvilRecipeWrapper(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-		this(leftInput, rightInputs, outputs, -1);
-	}
-
-	@SuppressWarnings("unchecked")
 	public AnvilRecipeWrapper(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost) {
 		this.inputs = Arrays.asList(Collections.singletonList(leftInput), rightInputs);
 		this.output = Collections.singletonList(outputs);

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -10,20 +10,17 @@ import net.minecraft.item.ItemStack;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 
-public class AnvilRecipeWrapper extends BlankRecipeWrapper
-{
+public class AnvilRecipeWrapper extends BlankRecipeWrapper {
     private final ItemStack leftInput;
     private final ItemStack rightInput;
     private final ItemStack output;
     private final int cost;
 
-    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output)
-    {
+    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
         this(leftInput, rightInput, output, -1);
     }
 
-    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int experienceCost)
-    {
+    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int experienceCost) {
         this.leftInput = leftInput;
         this.rightInput = rightInput;
         this.output = output;
@@ -31,20 +28,17 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper
     }
 
     @Override
-    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY)
-    {
-        if (cost >= 0)
-        {
+    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+
+        if (cost >= 0) {
             // GuiRepair'text special shadow
             int mainColor = 0xFF80FF20;
             String text = I18n.format("container.repair.cost", cost);
 
-            if (cost >= 40)
-            {
+            if (cost >= 40) {
                 mainColor = 0xFFFF6060;
             }
-            else if (cost > minecraft.player.experienceLevel && !minecraft.player.capabilities.isCreativeMode)
-            {
+            else if (cost > minecraft.player.experienceLevel && !minecraft.player.capabilities.isCreativeMode) {
                 mainColor = 0xFFFF6060;
                 //mainColor = 0xFFFFFF40;
             }
@@ -54,13 +48,11 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper
             int x = 145 - 2 - width;
             int y = 27;
 
-            if (minecraft.fontRendererObj.getUnicodeFlag())
-            {
+            if (minecraft.fontRendererObj.getUnicodeFlag()) {
                 Gui.drawRect(x-2, y-2, x+width+2, y+10,0xFF000000);
                 Gui.drawRect(x-1, y-1, x+width+1, y+9,0xFF3B3B3B);
             }
-            else
-            {
+            else {
                 minecraft.fontRendererObj.drawString(text, x+1, y, shadowColor);
                 minecraft.fontRendererObj.drawString(text, x, y+1, shadowColor);
                 minecraft.fontRendererObj.drawString(text, x+1, y+1, shadowColor);
@@ -71,8 +63,7 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper
     }
 
     @Override
-    public void getIngredients(@Nonnull IIngredients ingredients)
-    {
+    public void getIngredients(@Nonnull IIngredients ingredients) {
         ingredients.setInputs(ItemStack.class, Arrays.asList(leftInput, rightInput));
         ingredients.setOutput(ItemStack.class, output);
     }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -8,10 +8,10 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class AnvilRecipeWrapper extends BlankRecipeWrapper {
-    private final ItemStack leftInput;
-    private final ItemStack rightInput;
+    private final List<ItemStack> inputs;
     private final ItemStack output;
     private final int cost;
 
@@ -20,8 +20,7 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
     }
 
     public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int experienceCost) {
-        this.leftInput = leftInput;
-        this.rightInput = rightInput;
+        this.inputs = Arrays.asList(leftInput, rightInput);
         this.output = output;
         this.cost = experienceCost;
     }
@@ -30,16 +29,13 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
     public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
 
         if (cost >= 0) {
-            // GuiRepair'text special shadow
-            int mainColor = 0xFF80FF20;
             String text = I18n.format("container.repair.cost", cost);
 
-            if (cost >= 40) {
+            int mainColor = 0xFF80FF20;
+            if ((cost >= 40 || cost > minecraft.player.experienceLevel)
+                    && !minecraft.player.capabilities.isCreativeMode) {
+                // Show red if the player doesn't have enough levels
                 mainColor = 0xFFFF6060;
-            }
-            else if (cost > minecraft.player.experienceLevel && !minecraft.player.capabilities.isCreativeMode) {
-                mainColor = 0xFFFF6060;
-                //mainColor = 0xFFFFFF40;
             }
 
             int shadowColor = 0xFF000000 | (mainColor & 0xFCFCFC) >> 2;
@@ -63,7 +59,7 @@ public class AnvilRecipeWrapper extends BlankRecipeWrapper {
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setInputs(ItemStack.class, Arrays.asList(leftInput, rightInput));
+        ingredients.setInputs(ItemStack.class, inputs);
         ingredients.setOutput(ItemStack.class, output);
     }
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -11,55 +11,57 @@ import java.util.Arrays;
 import java.util.List;
 
 public class AnvilRecipeWrapper extends BlankRecipeWrapper {
-    private final List<ItemStack> inputs;
-    private final ItemStack output;
-    private final int cost;
+	private final List<ItemStack> inputs;
+	private final ItemStack output;
+	private final int cost;
 
-    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
-        this(leftInput, rightInput, output, -1);
-    }
+	public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
+		this(leftInput, rightInput, output, -1);
+	}
 
-    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int experienceCost) {
-        this.inputs = Arrays.asList(leftInput, rightInput);
-        this.output = output;
-        this.cost = experienceCost;
-    }
+	public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost) {
+		this.inputs = Arrays.asList(leftInput, rightInput);
+		this.output = output;
+		this.cost = levelsCost;
+	}
 
-    @Override
-    public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+	@Override
+	public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+		if (cost >= 0) {
+			String text = I18n.format("container.repair.cost", cost);
 
-        if (cost >= 0) {
-            String text = I18n.format("container.repair.cost", cost);
+			int mainColor = 0xFF80FF20;
+			if ((cost >= 40 || cost > minecraft.player.experienceLevel)
+					&& !minecraft.player.capabilities.isCreativeMode) {
+				// Show red if the player doesn't have enough levels
+				mainColor = 0xFFFF6060;
+			}
 
-            int mainColor = 0xFF80FF20;
-            if ((cost >= 40 || cost > minecraft.player.experienceLevel)
-                    && !minecraft.player.capabilities.isCreativeMode) {
-                // Show red if the player doesn't have enough levels
-                mainColor = 0xFFFF6060;
-            }
+			drawRepairCost(minecraft, text, mainColor, recipeWidth);
+		}
+	}
 
-            int shadowColor = 0xFF000000 | (mainColor & 0xFCFCFC) >> 2;
-            int width = minecraft.fontRendererObj.getStringWidth(text);
-            int x = 145 - 2 - width;
-            int y = 27;
+	private void drawRepairCost(Minecraft minecraft, String text, int mainColor, int recipeWidth) {
+		int shadowColor = 0xFF000000 | (mainColor & 0xFCFCFC) >> 2;
+		int width = minecraft.fontRendererObj.getStringWidth(text);
+		int x = recipeWidth - 2 - width;
+		int y = 27;
 
-            if (minecraft.fontRendererObj.getUnicodeFlag()) {
-                Gui.drawRect(x-2, y-2, x+width+2, y+10,0xFF000000);
-                Gui.drawRect(x-1, y-1, x+width+1, y+9,0xFF3B3B3B);
-            }
-            else {
-                minecraft.fontRendererObj.drawString(text, x+1, y, shadowColor);
-                minecraft.fontRendererObj.drawString(text, x, y+1, shadowColor);
-                minecraft.fontRendererObj.drawString(text, x+1, y+1, shadowColor);
-            }
+		if (minecraft.fontRendererObj.getUnicodeFlag()) {
+			Gui.drawRect(x - 2, y - 2, x + width + 2, y + 10, 0xFF000000);
+			Gui.drawRect(x - 1, y - 1, x + width + 1, y + 9, 0xFF3B3B3B);
+		} else {
+			minecraft.fontRendererObj.drawString(text, x + 1, y, shadowColor);
+			minecraft.fontRendererObj.drawString(text, x, y + 1, shadowColor);
+			minecraft.fontRendererObj.drawString(text, x + 1, y + 1, shadowColor);
+		}
 
-            minecraft.fontRendererObj.drawString(text, x, y, mainColor);
-        }
-    }
+		minecraft.fontRendererObj.drawString(text, x, y, mainColor);
+	}
 
-    @Override
-    public void getIngredients(IIngredients ingredients) {
-        ingredients.setInputs(ItemStack.class, inputs);
-        ingredients.setOutput(ItemStack.class, output);
-    }
+	@Override
+	public void getIngredients(IIngredients ingredients) {
+		ingredients.setInputs(ItemStack.class, inputs);
+		ingredients.setOutput(ItemStack.class, output);
+	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -1,0 +1,79 @@
+package mezz.jei.plugins.vanilla.anvil;
+
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.BlankRecipeWrapper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+
+public class AnvilRecipeWrapper extends BlankRecipeWrapper
+{
+    private final ItemStack leftInput;
+    private final ItemStack rightInput;
+    private final ItemStack output;
+    private final int cost;
+
+    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output)
+    {
+        this(leftInput, rightInput, output, -1);
+    }
+
+    public AnvilRecipeWrapper(ItemStack leftInput, ItemStack rightInput, ItemStack output, int experienceCost)
+    {
+        this.leftInput = leftInput;
+        this.rightInput = rightInput;
+        this.output = output;
+        this.cost = experienceCost;
+    }
+
+    @Override
+    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY)
+    {
+        if (cost >= 0)
+        {
+            // GuiRepair'text special shadow
+            int mainColor = 0xFF80FF20;
+            String text = I18n.format("container.repair.cost", cost);
+
+            if (cost >= 40)
+            {
+                mainColor = 0xFFFF6060;
+            }
+            else if (cost > minecraft.player.experienceLevel && !minecraft.player.capabilities.isCreativeMode)
+            {
+                mainColor = 0xFFFF6060;
+                //mainColor = 0xFFFFFF40;
+            }
+
+            int shadowColor = 0xFF000000 | (mainColor & 0xFCFCFC) >> 2;
+            int width = minecraft.fontRendererObj.getStringWidth(text);
+            int x = 145 - 2 - width;
+            int y = 27;
+
+            if (minecraft.fontRendererObj.getUnicodeFlag())
+            {
+                Gui.drawRect(x-2, y-2, x+width+2, y+10,0xFF000000);
+                Gui.drawRect(x-1, y-1, x+width+1, y+9,0xFF3B3B3B);
+            }
+            else
+            {
+                minecraft.fontRendererObj.drawString(text, x+1, y, shadowColor);
+                minecraft.fontRendererObj.drawString(text, x, y+1, shadowColor);
+                minecraft.fontRendererObj.drawString(text, x+1, y+1, shadowColor);
+            }
+
+            minecraft.fontRendererObj.drawString(text, x, y, mainColor);
+        }
+    }
+
+    @Override
+    public void getIngredients(@Nonnull IIngredients ingredients)
+    {
+        ingredients.setInputs(ItemStack.class, Arrays.asList(leftInput, rightInput));
+        ingredients.setOutput(ItemStack.class, output);
+    }
+}

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/package-info.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/package-info.java
@@ -1,0 +1,9 @@
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package mezz.jei.plugins.vanilla.anvil;
+
+import mcp.MethodsReturnNonnullByDefault;
+import mezz.jei.util.FieldsAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/mezz/jei/util/ModRegistry.java
+++ b/src/main/java/mezz/jei/util/ModRegistry.java
@@ -139,11 +139,11 @@ public class ModRegistry implements IModRegistry {
 	}
 
 	@Override
-	public void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost) {
+	public void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
 		Preconditions.checkNotNull(rightInputs, "Tried to add an anvil recipe with a null rightInputs list");
 		Preconditions.checkNotNull(outputs, "Tried to add an anvil recipe with a null outputs list");
-		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInputs, outputs, levelsCost));
+		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInputs, outputs));
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/util/ModRegistry.java
+++ b/src/main/java/mezz/jei/util/ModRegistry.java
@@ -155,6 +155,22 @@ public class ModRegistry implements IModRegistry {
 	}
 
 	@Override
+	public void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost) {
+		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
+		Preconditions.checkNotNull(rightInputs, "Tried to add an anvil recipe with a null rightInputs list");
+		Preconditions.checkNotNull(outputs, "Tried to add an anvil recipe with a null outputs list");
+		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInputs, outputs, levelsCost));
+	}
+
+	@Override
+	public void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
+		Preconditions.checkNotNull(rightInputs, "Tried to add an anvil recipe with a null rightInputs list");
+		Preconditions.checkNotNull(outputs, "Tried to add an anvil recipe with a null outputs list");
+		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInputs, outputs));
+	}
+
+	@Override
 	public IRecipeTransferRegistry getRecipeTransferRegistry() {
 		return recipeTransferRegistry;
 	}

--- a/src/main/java/mezz/jei/util/ModRegistry.java
+++ b/src/main/java/mezz/jei/util/ModRegistry.java
@@ -25,6 +25,7 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
 import mezz.jei.api.recipe.transfer.IRecipeTransferRegistry;
 import mezz.jei.gui.recipes.RecipeClickableArea;
 import mezz.jei.plugins.jei.description.ItemDescriptionRecipe;
+import mezz.jei.plugins.vanilla.anvil.AnvilRecipeWrapper;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
@@ -135,6 +136,22 @@ public class ModRegistry implements IModRegistry {
 		Preconditions.checkArgument(descriptionKeys.length > 0, "descriptionKeys cannot be empty");
 
 		addDescription(Collections.singletonList(itemStack), descriptionKeys);
+	}
+
+	@Override
+	public void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost) {
+		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
+		Preconditions.checkNotNull(rightInput, "Tried to add an anvil recipe with a null rightInput");
+		Preconditions.checkNotNull(output, "Tried to add an anvil recipe with a null output");
+		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInput, output, levelsCost));
+	}
+
+	@Override
+	public void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
+		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
+		Preconditions.checkNotNull(rightInput, "Tried to add an anvil recipe with a null rightInput");
+		Preconditions.checkNotNull(output, "Tried to add an anvil recipe with a null output");
+		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInput, output));
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/util/ModRegistry.java
+++ b/src/main/java/mezz/jei/util/ModRegistry.java
@@ -139,35 +139,11 @@ public class ModRegistry implements IModRegistry {
 	}
 
 	@Override
-	public void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output, int levelsCost) {
-		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
-		Preconditions.checkNotNull(rightInput, "Tried to add an anvil recipe with a null rightInput");
-		Preconditions.checkNotNull(output, "Tried to add an anvil recipe with a null output");
-		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInput, output, levelsCost));
-	}
-
-	@Override
-	public void addAnvilRecipe(ItemStack leftInput, ItemStack rightInput, ItemStack output) {
-		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
-		Preconditions.checkNotNull(rightInput, "Tried to add an anvil recipe with a null rightInput");
-		Preconditions.checkNotNull(output, "Tried to add an anvil recipe with a null output");
-		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInput, output));
-	}
-
-	@Override
 	public void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs, int levelsCost) {
 		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
 		Preconditions.checkNotNull(rightInputs, "Tried to add an anvil recipe with a null rightInputs list");
 		Preconditions.checkNotNull(outputs, "Tried to add an anvil recipe with a null outputs list");
 		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInputs, outputs, levelsCost));
-	}
-
-	@Override
-	public void addAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-		Preconditions.checkNotNull(leftInput, "Tried to add an anvil recipe with a null leftInput");
-		Preconditions.checkNotNull(rightInputs, "Tried to add an anvil recipe with a null rightInputs list");
-		Preconditions.checkNotNull(outputs, "Tried to add an anvil recipe with a null outputs list");
-		this.recipes.add(new AnvilRecipeWrapper(leftInput, rightInputs, outputs));
 	}
 
 	@Override


### PR DESCRIPTION
> [11:52] (gigaherz): morning ppl
> [11:52] (gigaherz): does JEI come with a template for anvil recipes?
> [11:53] (@mezz): nope, it should though. you can PR if you are feeling motivated

So here it is.

I decided not to attempt generating recipe wrapper instances for the vanilla book enchanting and repair, due to how those are hardcoded:
- For books, I'd need to test each possible item against each possible enchantment, and see if they are allowed. This is somewhat doable, but it seems ugly.
- For repair, Minecraft calls `Item#getIsRepairable(ItemStack,ItemStack)`, with the contents of the anvil slots, and returns true if the material matches the tool. There is no way to figure out the right combinations besides a a nested loop and matching all items against all items.

I'm open to suggestions.