### PR TITLE
Adds search filter for resource ids, Implements #202

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ curse_project_id=238222
 
 version_major=4
 version_minor=3
-version_patch=1
+version_patch=2

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -59,6 +59,12 @@ public interface IIngredientHelper<V> {
 	 */
 	Iterable<Color> getColors(V ingredient);
 
+
+	/**
+	 * Return the resource id of the given ingredient.
+	 */
+	String getResourceId(V ingredient);
+
 	/**
 	 * An action for when a player is in cheat mode and clicks an ingredient in the list.
 	 * <p>

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -62,6 +62,8 @@ public interface IIngredientHelper<V> {
 
 	/**
 	 * Return the resource id of the given ingredient.
+	 *
+	 * @since JEI 4.3.2
 	 */
 	String getResourceId(V ingredient);
 

--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -143,6 +143,10 @@ public final class Config {
 		return values.colorSearchMode;
 	}
 
+	public static SearchMode getResourceIdSearchMode() {
+		return values.resourceIdSearchMode;
+	}
+
 	public enum SearchMode {
 		ENABLED, REQUIRE_PREFIX, DISABLED
 	}
@@ -302,6 +306,7 @@ public final class Config {
 		values.oreDictSearchMode = config.getEnum("oreDictSearchMode", CATEGORY_SEARCH, defaultValues.oreDictSearchMode, searchModes);
 		values.creativeTabSearchMode = config.getEnum("creativeTabSearchMode", CATEGORY_SEARCH, defaultValues.creativeTabSearchMode, searchModes);
 		values.colorSearchMode = config.getEnum("colorSearchMode", CATEGORY_SEARCH, defaultValues.colorSearchMode, searchModes);
+		values.resourceIdSearchMode = config.getEnum("resourceIdSearchMode", CATEGORY_SEARCH, defaultValues.resourceIdSearchMode, searchModes);
 		if (config.getCategory(CATEGORY_SEARCH).hasChanged()) {
 			needsReload = true;
 		}

--- a/src/main/java/mezz/jei/config/ConfigValues.java
+++ b/src/main/java/mezz/jei/config/ConfigValues.java
@@ -13,6 +13,7 @@ public class ConfigValues {
 	public Config.SearchMode oreDictSearchMode = Config.SearchMode.REQUIRE_PREFIX;
 	public Config.SearchMode creativeTabSearchMode = Config.SearchMode.REQUIRE_PREFIX;
 	public Config.SearchMode colorSearchMode = Config.SearchMode.DISABLED;
+	public Config.SearchMode resourceIdSearchMode = Config.SearchMode.DISABLED;
 
 	// per-world
 	public boolean overlayEnabled = true;

--- a/src/main/java/mezz/jei/gui/ingredients/IIngredientListElement.java
+++ b/src/main/java/mezz/jei/gui/ingredients/IIngredientListElement.java
@@ -20,4 +20,6 @@ public interface IIngredientListElement<V> {
 	String getCreativeTabsString();
 
 	String getColorString();
+
+	String getResourceId();
 }

--- a/src/main/java/mezz/jei/ingredients/IngredientFilterInternals.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilterInternals.java
@@ -26,6 +26,7 @@ public class IngredientFilterInternals {
 	private final GeneralizedSuffixTree oreDictTree;
 	private final GeneralizedSuffixTree creativeTabTree;
 	private final GeneralizedSuffixTree colorTree;
+	private final GeneralizedSuffixTree resourceIdTree;
 	private final Map<Character, GeneralizedSuffixTree> prefixedSearchTrees = new HashMap<Character, GeneralizedSuffixTree>();
 
 	@Nullable
@@ -47,6 +48,7 @@ public class IngredientFilterInternals {
 		this.prefixedSearchTrees.put('$', this.oreDictTree = new GeneralizedSuffixTree());
 		this.prefixedSearchTrees.put('%', this.creativeTabTree = new GeneralizedSuffixTree());
 		this.prefixedSearchTrees.put('^', this.colorTree = new GeneralizedSuffixTree());
+		this.prefixedSearchTrees.put('&', this.resourceIdTree = new GeneralizedSuffixTree());
 
 		buildSuffixTrees(ingredientList);
 	}
@@ -106,6 +108,15 @@ public class IngredientFilterInternals {
 				colorTree.put(colorString, i);
 				if (colorSearchMode == Config.SearchMode.ENABLED) {
 					searchTree.put(colorString, i);
+				}
+			}
+
+			Config.SearchMode idSearchMode = Config.getResourceIdSearchMode();
+			if (idSearchMode != Config.SearchMode.DISABLED) {
+				String resourceIdString = element.getResourceId();
+				resourceIdTree.put(resourceIdString, i);
+				if (idSearchMode == Config.SearchMode.ENABLED) {
+					searchTree.put(resourceIdString, i);
 				}
 			}
 		}

--- a/src/main/java/mezz/jei/ingredients/IngredientListElement.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientListElement.java
@@ -26,6 +26,7 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 	private final String oreDictString;
 	private final String creativeTabsString;
 	private final String colorString;
+	private final String resourceId;
 
 	@Nullable
 	public static <V> IngredientListElement<V> create(V ingredient, IIngredientHelper<V> ingredientHelper, IIngredientRenderer<V> ingredientRenderer) {
@@ -59,6 +60,8 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 		} else {
 			this.colorString = "";
 		}
+
+		this.resourceId = ingredientHelper.getResourceId(ingredient);
 
 		if (ingredient instanceof ItemStack) {
 			ItemStack itemStack = (ItemStack) ingredient;
@@ -128,5 +131,10 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 	@Override
 	public String getColorString() {
 		return colorString;
+	}
+
+	@Override
+	public String getResourceId() {
+		return resourceId;
 	}
 }

--- a/src/main/java/mezz/jei/ingredients/IngredientListElement.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientListElement.java
@@ -61,7 +61,15 @@ public class IngredientListElement<V> implements IIngredientListElement<V> {
 			this.colorString = "";
 		}
 
-		this.resourceId = ingredientHelper.getResourceId(ingredient);
+		String resourceIdTry;
+		try {
+			resourceIdTry = ingredientHelper.getResourceId(ingredient);
+		} catch (AbstractMethodError ignored) {
+			// Since older IIngredientHelpers won't have the new getResourceId, we'll be using getUniqueId
+			resourceIdTry = ingredientHelper.getUniqueId(ingredient);
+		}
+
+		this.resourceId = resourceIdTry;
 
 		if (ingredient instanceof ItemStack) {
 			ItemStack itemStack = (ItemStack) ingredient;

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -55,6 +55,11 @@ public class DebugIngredientHelper implements IIngredientHelper<DebugIngredient>
 	}
 
 	@Override
+	public String getResourceId(DebugIngredient ingredient) {
+		return "JEI:debug_" + ingredient.getNumber();
+	}
+
+	@Override
 	public ItemStack cheatIngredient(DebugIngredient ingredient, boolean fullStack) {
 		CommandUtilServer.writeChatMessage(Minecraft.getMinecraft().player, "Debug ingredients cannot be cheated", TextFormatting.RED);
 		return ItemStack.EMPTY;

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -56,7 +56,7 @@ public class DebugIngredientHelper implements IIngredientHelper<DebugIngredient>
 
 	@Override
 	public String getResourceId(DebugIngredient ingredient) {
-		return "JEI:debug_" + ingredient.getNumber();
+		return "debug_" + ingredient.getNumber();
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/FluidStackHelper.java
@@ -82,6 +82,16 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 	}
 
 	@Override
+	public String getResourceId(FluidStack ingredient) {
+		String defaultFluidName = FluidRegistry.getDefaultFluidName(ingredient.getFluid());
+		if (defaultFluidName == null) {
+			return "";
+		}
+		ResourceLocation fluidResourceName = new ResourceLocation(defaultFluidName);
+		return fluidResourceName.toString();
+	}
+
+	@Override
 	public ItemStack cheatIngredient(FluidStack ingredient, boolean fullStack) {
 		Fluid fluid = ingredient.getFluid();
 		if (fluid == FluidRegistry.WATER) {

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/FluidStackHelper.java
@@ -88,7 +88,7 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 			return "";
 		}
 		ResourceLocation fluidResourceName = new ResourceLocation(defaultFluidName);
-		return fluidResourceName.toString();
+		return fluidResourceName.getResourcePath();
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/ItemStackHelper.java
@@ -78,7 +78,7 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 			throw new IllegalStateException("item.getRegistryName() returned null for: " + stackInfo);
 		}
 
-		return itemName.toString();
+		return itemName.getResourcePath();
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/ItemStackHelper.java
@@ -68,6 +68,20 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 	}
 
 	@Override
+	public String getResourceId(ItemStack ingredient) {
+		ErrorUtil.checkNotEmpty(ingredient);
+
+		Item item = ingredient.getItem();
+		ResourceLocation itemName = item.getRegistryName();
+		if (itemName == null) {
+			String stackInfo = getErrorInfo(ingredient);
+			throw new IllegalStateException("item.getRegistryName() returned null for: " + stackInfo);
+		}
+
+		return itemName.toString();
+	}
+
+	@Override
 	public ItemStack cheatIngredient(ItemStack ingredient, boolean fullStack) {
 		return ingredient;
 	}

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -66,6 +66,8 @@ config.jei.search.creativeTabSearchMode=%%CreativeTab
 config.jei.search.creativeTabSearchMode.comment=Search mode for Creative Tab Names (prefix: %)
 config.jei.search.colorSearchMode=^Color
 config.jei.search.colorSearchMode.comment=Search mode for Item Colors (prefix: ^)
+config.jei.search.resourceIdSearchMode=&ResourceId
+config.jei.search.resourceIdSearchMode.comment=Search mode for resources ids (prefix: &)
 
 config.jei.advanced=Advanced
 config.jei.advanced.comment=Advanced config options to change the way JEI functions.


### PR DESCRIPTION
This will require a version bump as there are changes to the api (see `IIngredientHelper`).
It takes the whole resource id for now. Not sure if it should be that or just the resource path as there already is a mod id filter. (eg. `&minecraft` will now also give all blocks under the minecraft resource id and thus gives overlap with `@minecraft`).

It is set to disabled on default as I don't see a lot of people using it. The used prefix is `&` as proposed in #202 .