### PR TITLE
Made unique identifiers care more about wildcard metadata

### DIFF
--- a/src/main/java/mezz/jei/startup/StackHelper.java
+++ b/src/main/java/mezz/jei/startup/StackHelper.java
@@ -371,13 +371,12 @@ public class StackHelper implements IStackHelper {
 
 		StringBuilder itemKey = new StringBuilder(itemName.toString());
 
-		if (mode != UidMode.WILDCARD) {
+		int metadata = stack.getMetadata();
+		if (mode != UidMode.WILDCARD && metadata != OreDictionary.WILDCARD_VALUE) {
 			String subtypeInfo = subtypeRegistry.getSubtypeInfo(stack);
 			if (subtypeInfo != null) {
 				itemKey.append(':').append(subtypeInfo);
 			} else {
-				int metadata = stack.getMetadata();
-
 				if (mode == UidMode.FULL) {
 					itemKey.append(':').append(metadata);
 
@@ -392,7 +391,7 @@ public class StackHelper implements IStackHelper {
 					if (!nbtTagCompound.hasNoTags()) {
 						itemKey.append(':').append(nbtTagCompound);
 					}
-				} else if (metadata != OreDictionary.WILDCARD_VALUE && stack.getHasSubtypes()) {
+				} else if (stack.getHasSubtypes()) {
 					itemKey.append(':').append(metadata);
 				}
 			}


### PR DESCRIPTION
Changed so when getting an unified identifier cares more about the that the items metadata is a wildcard meaning that the item should be wildcarded. 
The reason behind this is that there is currently no way of adding an item to the blacklist through the api that's a fully wildcard, the subinfo is still added to the items that have it registered and not making so they are wildcarded.
Currently you can only add those items trough the config or via the gui into the config as wildcard.

Another solution could be to add a method to the api for adding wildcard items.