### PR TITLE
Added a safety check for BasicRecipeTransferInfo

### DIFF
--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferInfo.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferInfo.java
@@ -53,8 +53,10 @@ public class BasicRecipeTransferInfo<C extends Container> implements IRecipeTran
 	public List<Slot> getInventorySlots(C container) {
 		List<Slot> slots = new ArrayList<Slot>();
 		for (int i = inventorySlotStart; i < inventorySlotStart + inventorySlotCount; i++) {
-			Slot slot = container.getSlot(i);
-			slots.add(slot);
+			if (i < container.inventorySlots.size()) {
+				Slot slot = container.getSlot(i);
+				slots.add(slot);
+			}
 		}
 		return slots;
 	}


### PR DESCRIPTION
This prevents many unwanted crashes for bigger inventories, because values can exceed the slot limit and will throw an IndexOutOfBoundsException.