### PR TITLE
Added seperate overlay draw call to IRecipeLayoutDrawable

### DIFF
--- a/src/api/java/mezz/jei/api/gui/IRecipeLayoutDrawable.java
+++ b/src/api/java/mezz/jei/api/gui/IRecipeLayoutDrawable.java
@@ -26,6 +26,16 @@ public interface IRecipeLayoutDrawable extends IRecipeLayout {
 	void draw(Minecraft minecraft, int mouseX, int mouseY);
 
 	/**
+	 * Draw the recipe without tool overlay's such as item tool tips
+	 */
+	void drawRecipe(Minecraft minecraft, int mouseX, int mouseY);
+
+	/**
+	 * Draw recipe overlay's such as item tool tips
+	 */
+	void drawOverlay(Minecraft minecraft, int mouseX, int mouseY);
+
+	/**
 	 * Returns true if the mouse is hovering over the recipe.
 	 * Hovered recipes should be drawn after other recipes to have the drawn tooltips overlap other elements properly.
 	 */

--- a/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
+++ b/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
@@ -147,6 +147,40 @@ public class GuiIngredient<T> extends Gui implements IGuiIngredient<T> {
 		}
 	}
 
+	public void drawToolTipOnly(Minecraft minecraft, int xOffset, int yOffset, int mouseX, int mouseY) {
+		T value = getDisplayedIngredient();
+		if (value != null) {
+			try {
+				GlStateManager.disableDepth();
+
+				List<String> tooltip = LegacyUtil.getTooltip(ingredientRenderer, minecraft, value, minecraft.gameSettings.advancedItemTooltips);
+				tooltip = ForgeModIdHelper.getInstance().addModNameToIngredientTooltip(tooltip, value, ingredientHelper);
+
+				if (tooltipCallback != null) {
+					tooltipCallback.onTooltip(slotIndex, input, value, tooltip);
+				}
+
+				FontRenderer fontRenderer = ingredientRenderer.getFontRenderer(minecraft, value);
+				if (value instanceof ItemStack) {
+					//noinspection unchecked
+					Collection<ItemStack> itemStacks = (Collection<ItemStack>) this.allIngredients;
+					String oreDictEquivalent = Internal.getStackHelper().getOreDictEquivalent(itemStacks);
+					if (oreDictEquivalent != null) {
+						final String acceptsAny = String.format(oreDictionaryIngredient, oreDictEquivalent);
+						tooltip.add(TextFormatting.GRAY + acceptsAny);
+					}
+					TooltipRenderer.drawHoveringText((ItemStack) value, minecraft, tooltip, xOffset + mouseX, yOffset + mouseY, fontRenderer);
+				} else {
+					TooltipRenderer.drawHoveringText(minecraft, tooltip, xOffset + mouseX, yOffset + mouseY, fontRenderer);
+				}
+
+				GlStateManager.enableDepth();
+			} catch (RuntimeException e) {
+				Log.error("Exception when rendering tooltip on {}.", value, e);
+			}
+		}
+	}
+
 	@Override
 	public void drawHighlight(Minecraft minecraft, Color color, int xOffset, int yOffset) {
 		int x = rect.x + xOffset + xPadding;

--- a/src/main/java/mezz/jei/gui/ingredients/GuiIngredientGroup.java
+++ b/src/main/java/mezz/jei/gui/ingredients/GuiIngredientGroup.java
@@ -160,6 +160,16 @@ public class GuiIngredientGroup<T> implements IGuiIngredientGroup<T> {
 	}
 
 	@Nullable
+	public GuiIngredient<T> getHoveredIngredient(int xOffset, int yOffset, int mouseX, int mouseY) {
+		for (GuiIngredient<T> ingredient : guiIngredients.values()) {
+			if (ingredient.isMouseOver(xOffset, yOffset, mouseX, mouseY)) {
+				return ingredient;
+			}
+		}
+		return null;
+	}
+
+	@Nullable
 	public GuiIngredient<T> draw(Minecraft minecraft, int xOffset, int yOffset, int mouseX, int mouseY) {
 		GuiIngredient<T> hovered = null;
 		for (GuiIngredient<T> ingredient : guiIngredients.values()) {

--- a/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
@@ -43,6 +43,9 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 	@Override
 	public void drawButton(Minecraft mc, int mouseX, int mouseY) {
 		super.drawButton(mc, mouseX, mouseY);
+	}
+
+	public void drawToolTip(Minecraft mc, int mouseX, int mouseY) {
 		if (hovered && visible) {
 			if (recipeTransferError != null) {
 				recipeTransferError.showError(mc, mouseX, mouseY, recipeLayout, recipeLayout.getPosX(), recipeLayout.getPosY());


### PR DESCRIPTION
With the way IRecipeLayoutDrawable currently works recipe tool tips are drawn in the same render call as the main recipe. The issue with this is if you have more that one recipe in the screen or you are rendering other items after the recipe the recipe tool tips will render under those other gui elements.
This pull request does not affect the original draw code (So not a breaking change) But it adds 2 new draw calls. one to render the recipe background and ingredients. The other to render the recipe overlay. This allows you to render recipe tool tips in a seperate render pass.