### PR TITLE
Added separate overlay draw call to IRecipeLayoutDrawable

### DIFF
--- a/src/api/java/mezz/jei/api/gui/IRecipeLayoutDrawable.java
+++ b/src/api/java/mezz/jei/api/gui/IRecipeLayoutDrawable.java
@@ -26,6 +26,16 @@ public interface IRecipeLayoutDrawable extends IRecipeLayout {
 	void draw(Minecraft minecraft, int mouseX, int mouseY);
 
 	/**
+	 * Draw the recipe without tool overlay's such as item tool tips
+	 */
+	void drawRecipe(Minecraft minecraft, int mouseX, int mouseY);
+
+	/**
+	 * Draw recipe overlay's such as item tool tips
+	 */
+	void drawOverlay(Minecraft minecraft, int mouseX, int mouseY);
+
+	/**
 	 * Returns true if the mouse is hovering over the recipe.
 	 * Hovered recipes should be drawn after other recipes to have the drawn tooltips overlap other elements properly.
 	 */

--- a/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
+++ b/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
@@ -157,6 +157,43 @@ public class GuiIngredient<T> extends Gui implements IGuiIngredient<T> {
 		GlStateManager.color(1f, 1f, 1f, 1f);
 	}
 
+	public void drawToolTipOnly(Minecraft minecraft, int xOffset, int yOffset, int mouseX, int mouseY) {
+		T value = getDisplayedIngredient();
+		if (value != null) {
+			try {
+				GlStateManager.disableDepth();
+				RenderHelper.disableStandardItemLighting();
+
+				ITooltipFlag.TooltipFlags tooltipFlag = minecraft.gameSettings.advancedItemTooltips ? ITooltipFlag.TooltipFlags.ADVANCED : ITooltipFlag.TooltipFlags.NORMAL;
+				List<String> tooltip = ingredientRenderer.getTooltip(minecraft, value, tooltipFlag);
+				tooltip = ForgeModIdHelper.getInstance().addModNameToIngredientTooltip(tooltip, value, ingredientHelper);
+
+				if (tooltipCallback != null) {
+					tooltipCallback.onTooltip(slotIndex, input, value, tooltip);
+				}
+
+				FontRenderer fontRenderer = ingredientRenderer.getFontRenderer(minecraft, value);
+				if (value instanceof ItemStack) {
+					//noinspection unchecked
+					Collection<ItemStack> itemStacks = (Collection<ItemStack>) this.allIngredients;
+					String oreDictEquivalent = Internal.getStackHelper().getOreDictEquivalent(itemStacks);
+					if (oreDictEquivalent != null) {
+						final String acceptsAny = String.format(oreDictionaryIngredient, oreDictEquivalent);
+						tooltip.add(TextFormatting.GRAY + acceptsAny);
+					}
+					TooltipRenderer.drawHoveringText((ItemStack) value, minecraft, tooltip, xOffset + mouseX, yOffset + mouseY, fontRenderer);
+				} else {
+					TooltipRenderer.drawHoveringText(minecraft, tooltip, xOffset + mouseX, yOffset + mouseY, fontRenderer);
+				}
+
+				GlStateManager.enableDepth();
+			} catch (RuntimeException e) {
+				Log.get().error("Exception when rendering tooltip on {}.", value, e);
+			}
+		}
+	}
+
+
 	private void drawTooltip(Minecraft minecraft, int xOffset, int yOffset, int mouseX, int mouseY, T value) {
 		try {
 			GlStateManager.disableDepth();

--- a/src/main/java/mezz/jei/gui/ingredients/GuiIngredientGroup.java
+++ b/src/main/java/mezz/jei/gui/ingredients/GuiIngredientGroup.java
@@ -160,6 +160,16 @@ public class GuiIngredientGroup<T> implements IGuiIngredientGroup<T> {
 	}
 
 	@Nullable
+	public GuiIngredient<T> getHoveredIngredient(int xOffset, int yOffset, int mouseX, int mouseY) {
+		for (GuiIngredient<T> ingredient : guiIngredients.values()) {
+			if (ingredient.isMouseOver(xOffset, yOffset, mouseX, mouseY)) {
+				return ingredient;
+			}
+		}
+		return null;
+	}
+
+	@Nullable
 	public GuiIngredient<T> draw(Minecraft minecraft, int xOffset, int yOffset, int mouseX, int mouseY) {
 		GuiIngredient<T> hovered = null;
 		for (GuiIngredient<T> ingredient : guiIngredients.values()) {

--- a/src/main/java/mezz/jei/gui/recipes/RecipeLayout.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeLayout.java
@@ -1,7 +1,8 @@
 package mezz.jei.gui.recipes;
 
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Rectangle;
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;

--- a/src/main/java/mezz/jei/gui/recipes/RecipeLayout.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeLayout.java
@@ -1,7 +1,7 @@
 package mezz.jei.gui.recipes;
 
 import javax.annotation.Nullable;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -45,6 +45,7 @@ public class RecipeLayout implements IRecipeLayoutDrawable {
 	private final IRecipeWrapper recipeWrapper;
 	@Nullable
 	private final IFocus<?> focus;
+	private final Color highlightColor = new Color(0x7FFFFFFF, true);
 	@Nullable
 	private ShapelessIcon shapelessIcon;
 
@@ -153,6 +154,7 @@ public class RecipeLayout implements IRecipeLayoutDrawable {
 		if (recipeTransferButton != null) {
 			float partialTicks = minecraft.getRenderPartialTicks();
 			recipeTransferButton.drawButton(minecraft, mouseX, mouseY, partialTicks);
+			recipeTransferButton.drawToolTip(minecraft, mouseX, mouseY);
 		}
 		GlStateManager.disableBlend();
 		GlStateManager.disableLighting();
@@ -161,6 +163,92 @@ public class RecipeLayout implements IRecipeLayoutDrawable {
 			hoveredIngredient.drawHovered(minecraft, posX, posY, recipeMouseX, recipeMouseY);
 		} else if (isMouseOver(mouseX, mouseY)) {
 			List<String> tooltipStrings = new ArrayList<>();
+			List<String> categoryTooltipStrings = LegacyUtil.getTooltipStrings(recipeCategory, recipeMouseX, recipeMouseY);
+			tooltipStrings.addAll(categoryTooltipStrings);
+			List<String> wrapperTooltips = recipeWrapper.getTooltipStrings(recipeMouseX, recipeMouseY);
+			//noinspection ConstantConditions
+			if (wrapperTooltips != null) {
+				tooltipStrings.addAll(wrapperTooltips);
+			}
+			if (tooltipStrings.isEmpty() && shapelessIcon != null) {
+				tooltipStrings = shapelessIcon.getTooltipStrings(recipeMouseX, recipeMouseY);
+			}
+			if (tooltipStrings != null && !tooltipStrings.isEmpty()) {
+				TooltipRenderer.drawHoveringText(minecraft, tooltipStrings, mouseX, mouseY);
+			}
+		}
+
+		GlStateManager.disableAlpha();
+	}
+
+	@Override
+	public void drawRecipe(Minecraft minecraft, int mouseX, int mouseY) {
+		IDrawable background = recipeCategory.getBackground();
+
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.disableLighting();
+		GlStateManager.enableAlpha();
+
+		final int recipeMouseX = mouseX - posX;
+		final int recipeMouseY = mouseY - posY;
+
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(posX, posY, 0.0F);
+		{
+			background.draw(minecraft);
+			recipeCategory.drawExtras(minecraft);
+			recipeWrapper.drawInfo(minecraft, background.getWidth(), background.getHeight(), recipeMouseX, recipeMouseY);
+			// drawExtras and drawInfo often render text which messes with the color, this clears it
+			GlStateManager.color(1, 1, 1, 1);
+			if (shapelessIcon != null) {
+				shapelessIcon.draw(minecraft, background.getWidth());
+			}
+		}
+		GlStateManager.popMatrix();
+
+		for (GuiIngredientGroup guiIngredientGroup : guiIngredientGroups.values()) {
+			GuiIngredient hovered = guiIngredientGroup.draw(minecraft, posX, posY, mouseX, mouseY);
+			if (hovered != null) {
+				hovered.draw(minecraft, posX, posY);
+				hovered.drawHighlight(minecraft, highlightColor, posX, posY);
+			}
+		}
+		if (recipeTransferButton != null) {
+			float partialTicks = minecraft.getRenderPartialTicks();
+			recipeTransferButton.drawButton(minecraft, mouseX, mouseY, partialTicks);
+		}
+
+		GlStateManager.disableBlend();
+		GlStateManager.disableLighting();
+		GlStateManager.disableAlpha();
+	}
+
+	@Override
+	public void drawOverlay(Minecraft minecraft, int mouseX, int mouseY) {
+		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+		GlStateManager.disableLighting();
+		GlStateManager.enableAlpha();
+
+		final int recipeMouseX = mouseX - posX;
+		final int recipeMouseY = mouseY - posY;
+
+		GuiIngredient hoveredIngredient = null;
+		for (GuiIngredientGroup guiIngredientGroup : guiIngredientGroups.values()) {
+			GuiIngredient hovered = guiIngredientGroup.getHoveredIngredient(posX, posY, mouseX, mouseY);
+			if (hovered != null) {
+				hoveredIngredient = hovered;
+			}
+		}
+		if (recipeTransferButton != null) {
+			recipeTransferButton.drawToolTip(minecraft, mouseX, mouseY);
+		}
+		GlStateManager.disableBlend();
+		GlStateManager.disableLighting();
+
+		if (hoveredIngredient != null) {
+			hoveredIngredient.drawToolTipOnly(minecraft, posX, posY, recipeMouseX, recipeMouseY);
+		} else if (isMouseOver(mouseX, mouseY)) {
+			List<String> tooltipStrings = new ArrayList<String>();
 			List<String> categoryTooltipStrings = LegacyUtil.getTooltipStrings(recipeCategory, recipeMouseX, recipeMouseY);
 			tooltipStrings.addAll(categoryTooltipStrings);
 			List<String> wrapperTooltips = recipeWrapper.getTooltipStrings(recipeMouseX, recipeMouseY);

--- a/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
@@ -1,7 +1,5 @@
 package mezz.jei.gui.recipes;
 
-import javax.annotation.Nullable;
-
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import mezz.jei.config.Constants;
@@ -12,6 +10,8 @@ import mezz.jei.transfer.RecipeTransferUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
+
+import javax.annotation.Nullable;
 
 public class RecipeTransferButton extends GuiIconButtonSmall {
 	private final RecipeLayout recipeLayout;
@@ -43,6 +43,9 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 	@Override
 	public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks) {
 		super.drawButton(mc, mouseX, mouseY, partialTicks);
+	}
+
+	public void drawToolTip(Minecraft mc, int mouseX, int mouseY) {
 		if (hovered && visible) {
 			if (recipeTransferError != null) {
 				recipeTransferError.showError(mc, mouseX, mouseY, recipeLayout, recipeLayout.getPosX(), recipeLayout.getPosY());

--- a/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
@@ -1,5 +1,7 @@
 package mezz.jei.gui.recipes;
 
+import javax.annotation.Nullable;
+
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import mezz.jei.config.Constants;
@@ -10,8 +12,6 @@ import mezz.jei.transfer.RecipeTransferUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
-
-import javax.annotation.Nullable;
 
 public class RecipeTransferButton extends GuiIconButtonSmall {
 	private final RecipeLayout recipeLayout;


### PR DESCRIPTION
With the way IRecipeLayoutDrawable currently works recipe tool tips are drawn in the same render call as the main recipe. The issue with this is if you have more that one recipe in the screen or you are rendering other items after the recipe the recipe tool tips will render under those other gui elements.
This pull request does not affect the original draw code (So not a breaking change) But it adds 2 new draw calls. one to render the recipe background and ingredients. The other to render the recipe overlay. This allows you to render recipe tool tips in a seperate render pass.