### PR TITLE
Added Check for disabled brewing recipes

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/brewing/BrewingRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/brewing/BrewingRecipeMaker.java
@@ -29,6 +29,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 public class BrewingRecipeMaker {
 
 	private final Set<Class> unhandledRecipeClasses = new HashSet<>();
+	private final Set<BrewingRecipeWrapper> disabledRecipes = new HashSet<>();
 	private final IIngredientRegistry ingredientRegistry;
 
 	public static List<BrewingRecipeWrapper> getBrewingRecipes(IIngredientRegistry ingredientRegistry) {
@@ -92,8 +93,12 @@ public class BrewingRecipeMaker {
 				}
 
 				BrewingRecipeWrapper recipe = new BrewingRecipeWrapper(Collections.singletonList(potionIngredient), potionInput.copy(), potionOutput);
-				if (!recipes.contains(recipe)) {
-					recipes.add(recipe);
+				if (!recipes.contains(recipe) && !disabledRecipes.contains(recipe)) {
+					if (BrewingRecipeRegistry.hasOutput(potionInput, potionIngredient)) {
+						recipes.add(recipe);
+					} else {
+						disabledRecipes.add(recipe);
+					}
 					newPotions.add(potionOutput);
 				}
 			}


### PR DESCRIPTION
### What this PR does
It adds a check to the Potion finder to check if the recipe actually can be brewed before putting it into the recipes list. It also adds all removed recipes into a private static Set

### What is this good for?
If a mod changes how vanilla potions are brewed JEI would still show them as it uses the PotionHelper. With the additional call, removed recipes won't be registered