### PR TITLE
Boolean to ignore set restriction when transferring recipe items.

### DIFF
--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferInfo.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferInfo.java
@@ -38,4 +38,11 @@ public interface IRecipeTransferInfo<C extends Container> {
 	 * Return a list of slots that the transfer can use to get items for crafting, or place leftover items.
 	 */
 	List<Slot> getInventorySlots(C container);
+
+	/**
+	 * Return false if the recipe transfer should attempt to place as many items as possible for all slots, even if one slot has less.
+	 */
+	default boolean requireCompleteSets() {
+		return true;
+	}
 }

--- a/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java
+++ b/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java
@@ -16,14 +16,14 @@ public class PacketRecipeTransfer extends PacketJei {
 	public final List<Integer> craftingSlots;
 	public final List<Integer> inventorySlots;
 	private final boolean maxTransfer;
-	private final boolean ignoreTransferLimit;
+	private final boolean requireCompleteSets;
 
-	public PacketRecipeTransfer(Map<Integer, Integer> recipeMap, List<Integer> craftingSlots, List<Integer> inventorySlots, boolean maxTransfer, boolean ignoreTransferLimit) {
+	public PacketRecipeTransfer(Map<Integer, Integer> recipeMap, List<Integer> craftingSlots, List<Integer> inventorySlots, boolean maxTransfer, boolean requireCompleteSets) {
 		this.recipeMap = recipeMap;
 		this.craftingSlots = craftingSlots;
 		this.inventorySlots = inventorySlots;
 		this.maxTransfer = maxTransfer;
-		this.ignoreTransferLimit = ignoreTransferLimit;
+		this.requireCompleteSets = requireCompleteSets;
 	}
 
 	@Override
@@ -50,7 +50,7 @@ public class PacketRecipeTransfer extends PacketJei {
 		}
 
 		buf.writeBoolean(maxTransfer);
-		buf.writeBoolean(ignoreTransferLimit);
+		buf.writeBoolean(requireCompleteSets);
 	}
 
 	public static void readPacketData(PacketBuffer buf, EntityPlayer player) {

--- a/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java
+++ b/src/main/java/mezz/jei/network/packets/PacketRecipeTransfer.java
@@ -16,12 +16,14 @@ public class PacketRecipeTransfer extends PacketJei {
 	public final List<Integer> craftingSlots;
 	public final List<Integer> inventorySlots;
 	private final boolean maxTransfer;
+	private final boolean ignoreTransferLimit;
 
-	public PacketRecipeTransfer(Map<Integer, Integer> recipeMap, List<Integer> craftingSlots, List<Integer> inventorySlots, boolean maxTransfer) {
+	public PacketRecipeTransfer(Map<Integer, Integer> recipeMap, List<Integer> craftingSlots, List<Integer> inventorySlots, boolean maxTransfer, boolean ignoreTransferLimit) {
 		this.recipeMap = recipeMap;
 		this.craftingSlots = craftingSlots;
 		this.inventorySlots = inventorySlots;
 		this.maxTransfer = maxTransfer;
+		this.ignoreTransferLimit = ignoreTransferLimit;
 	}
 
 	@Override
@@ -48,6 +50,7 @@ public class PacketRecipeTransfer extends PacketJei {
 		}
 
 		buf.writeBoolean(maxTransfer);
+		buf.writeBoolean(ignoreTransferLimit);
 	}
 
 	public static void readPacketData(PacketBuffer buf, EntityPlayer player) {
@@ -73,8 +76,9 @@ public class PacketRecipeTransfer extends PacketJei {
 			inventorySlots.add(slotIndex);
 		}
 		boolean maxTransfer = buf.readBoolean();
+		boolean requireCompleteSets = buf.readBoolean();
 
-		BasicRecipeTransferHandlerServer.setItems(player, recipeMap, craftingSlots, inventorySlots, maxTransfer);
+		BasicRecipeTransferHandlerServer.setItems(player, recipeMap, craftingSlots, inventorySlots, maxTransfer, requireCompleteSets);
 	}
 
 }

--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandler.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandler.java
@@ -130,8 +130,10 @@ public class BasicRecipeTransferHandler<C extends Container> implements IRecipeT
 			}
 		}
 
+		boolean requireCompleteSets = transferHelper.requireCompleteSets();
+
 		if (doTransfer) {
-			PacketRecipeTransfer packet = new PacketRecipeTransfer(matchingItemsResult.matchingItems, craftingSlotIndexes, inventorySlotIndexes, maxTransfer);
+			PacketRecipeTransfer packet = new PacketRecipeTransfer(matchingItemsResult.matchingItems, craftingSlotIndexes, inventorySlotIndexes, maxTransfer, requireCompleteSets);
 			JustEnoughItems.getProxy().sendPacketToServer(packet);
 		}
 

--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandler.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandler.java
@@ -130,10 +130,8 @@ public class BasicRecipeTransferHandler<C extends Container> implements IRecipeT
 			}
 		}
 
-		boolean requireCompleteSets = transferHelper.requireCompleteSets();
-
 		if (doTransfer) {
-			PacketRecipeTransfer packet = new PacketRecipeTransfer(matchingItemsResult.matchingItems, craftingSlotIndexes, inventorySlotIndexes, maxTransfer, requireCompleteSets);
+			PacketRecipeTransfer packet = new PacketRecipeTransfer(matchingItemsResult.matchingItems, craftingSlotIndexes, inventorySlotIndexes, maxTransfer, transferHelper.requireCompleteSets());
 			JustEnoughItems.getProxy().sendPacketToServer(packet);
 		}
 

--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
@@ -98,7 +98,12 @@ public final class BasicRecipeTransferHandlerServer {
 
 			// This map holds the original contents of a slot we have removed items from. This is used if we don't
 			// have enough items to complete a whole set, we can roll back the items that were removed.
-			final Map<Slot, ItemStack> originalSlotContents = new HashMap<>();
+			Map<Slot, ItemStack> originalSlotContents = null;
+
+			if (transferAsCompleteSets) {
+				// We only need to create a new map for each set iteration if we're transferring as complete sets.
+				originalSlotContents = new HashMap<>();
+			}
 
 			// This map holds items found for each set iteration. Its contents are added to the result map
 			// after each complete set iteration. If we are transferring as complete sets, this allows
@@ -137,7 +142,7 @@ public final class BasicRecipeTransferHandlerServer {
 				} else { // the item was found and the stack limit has not been reached
 
 					// Keep a copy of the slot's original contents in case we need to roll back.
-					if (transferAsCompleteSets && !originalSlotContents.containsKey(slot)) {
+					if (originalSlotContents != null && !originalSlotContents.containsKey(slot)) {
 						originalSlotContents.put(slot, slot.getStack().copy());
 					}
 

--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
@@ -136,8 +136,8 @@ public final class BasicRecipeTransferHandlerServer {
 
 				} else { // the item was found and the stack limit has not been reached
 
-          // Keep a copy of the slots original contents in case we need to roll back.
-          if (!originalSlotContents.containsKey(slot)) {
+          // Keep a copy of the slot's original contents in case we need to roll back.
+          if (transferAsCompleteSets && !originalSlotContents.containsKey(slot)) {
             originalSlotContents.put(slot, slot.getStack().copy());
           }
 

--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
@@ -33,14 +33,14 @@ public final class BasicRecipeTransferHandlerServer {
 		}
 
 		// Transfer as many items as possible only if it has been explicitly requested by the implementation
-    // and a max-transfer operation has been requested by the player.
+		// and a max-transfer operation has been requested by the player.
 		boolean transferAsCompleteSets = requireCompleteSets || !maxTransfer;
 
-    Map<Integer, ItemStack> toTransfer = removeItemsFromInventory(container, slotMap, craftingSlots, inventorySlots, transferAsCompleteSets, maxTransfer);
+		Map<Integer, ItemStack> toTransfer = removeItemsFromInventory(container, slotMap, craftingSlots, inventorySlots, transferAsCompleteSets, maxTransfer);
 
-    if (toTransfer.isEmpty()) {
-      return;
-    }
+		if (toTransfer.isEmpty()) {
+			return;
+		}
 
 		// clear the crafting grid
 		List<ItemStack> clearedCraftingItems = new ArrayList<>();
@@ -124,42 +124,42 @@ public final class BasicRecipeTransferHandlerServer {
 					// We can't find any more items to fulfill the requirements or the maximum stack size for this item
 					// has been reached.
 
-          if (transferAsCompleteSets) {
-            // Since the full set requirement wasn't satisfied, we need to roll back any
-            // slot changes we've made during this set iteration.
-            for (Map.Entry<Slot, ItemStack> slotEntry : originalSlotContents.entrySet()) {
-              ItemStack stack = slotEntry.getValue();
-              slotEntry.getKey().putStack(stack);
-            }
-            break loopSets;
-          }
+					if (transferAsCompleteSets) {
+						// Since the full set requirement wasn't satisfied, we need to roll back any
+						// slot changes we've made during this set iteration.
+						for (Map.Entry<Slot, ItemStack> slotEntry : originalSlotContents.entrySet()) {
+							ItemStack stack = slotEntry.getValue();
+							slotEntry.getKey().putStack(stack);
+						}
+						break loopSets;
+					}
 
 				} else { // the item was found and the stack limit has not been reached
 
-          // Keep a copy of the slot's original contents in case we need to roll back.
-          if (transferAsCompleteSets && !originalSlotContents.containsKey(slot)) {
-            originalSlotContents.put(slot, slot.getStack().copy());
-          }
+					// Keep a copy of the slot's original contents in case we need to roll back.
+					if (transferAsCompleteSets && !originalSlotContents.containsKey(slot)) {
+						originalSlotContents.put(slot, slot.getStack().copy());
+					}
 
-          // Reduce the size of the found slot.
-          ItemStack removedItemStack = slot.decrStackSize(1);
-          foundItemsInSet.put(entry.getKey(), removedItemStack);
+					// Reduce the size of the found slot.
+					ItemStack removedItemStack = slot.decrStackSize(1);
+					foundItemsInSet.put(entry.getKey(), removedItemStack);
 
-          noItemsFound = false;
-        }
-      }
+					noItemsFound = false;
+				}
+			}
 
-      // Merge the contents of the temporary map with the result map.
-      for (Map.Entry<Integer, ItemStack> entry : foundItemsInSet.entrySet()) {
-        ItemStack resultItemStack = result.get(entry.getKey());
+			// Merge the contents of the temporary map with the result map.
+			for (Map.Entry<Integer, ItemStack> entry : foundItemsInSet.entrySet()) {
+				ItemStack resultItemStack = result.get(entry.getKey());
 
-        if (resultItemStack == null) {
-          result.put(entry.getKey(), entry.getValue());
+				if (resultItemStack == null) {
+					result.put(entry.getKey(), entry.getValue());
 
-        } else {
-          resultItemStack.grow(1);
-        }
-      }
+				} else {
+					resultItemStack.grow(1);
+				}
+			}
 
 			if (!maxTransfer || noItemsFound) {
 				// If max transfer is not requested by the player this will exit the loop after trying one set.

--- a/src/main/java/mezz/jei/transfer/PlayerRecipeTransferHandler.java
+++ b/src/main/java/mezz/jei/transfer/PlayerRecipeTransferHandler.java
@@ -163,7 +163,7 @@ public class PlayerRecipeTransferHandler implements IRecipeTransferHandler<Conta
 		}
 
 		if (doTransfer) {
-			PacketRecipeTransfer packet = new PacketRecipeTransfer(matchingItemsResult.matchingItems, craftingSlotIndexes, inventorySlotIndexes, maxTransfer);
+			PacketRecipeTransfer packet = new PacketRecipeTransfer(matchingItemsResult.matchingItems, craftingSlotIndexes, inventorySlotIndexes, maxTransfer, false);
 			JustEnoughItems.getProxy().sendPacketToServer(packet);
 		}
 


### PR DESCRIPTION
PR in response to [https://github.com/mezz/JustEnoughItems/issues/1067](https://github.com/mezz/JustEnoughItems/issues/1067)

### What

This PR introduces a default interface method in [IRecipeTransferInfo](https://github.com/mezz/JustEnoughItems/pull/1068/files/b8fcabe53c232cf3a6449e15263ec8625560201e#diff-5e703c41e725492759df7818691265b1) that returns a boolean and can be overridden by implementations that want to transfer as many items as possible into the crafting slots.

The [PacketRecipeTransfer](https://github.com/mezz/JustEnoughItems/pull/1068/files/b8fcabe53c232cf3a6449e15263ec8625560201e#diff-a7dd13e632d5333ff541cd0aa19c3799) has been altered to carry the boolean flag to the server.

The recipe transfer logic contained in [BasicRecipeTransferHandlerServer](https://github.com/mezz/JustEnoughItems/pull/1068/files/b8fcabe53c232cf3a6449e15263ec8625560201e#diff-d60e3f216533fe7a914066833895f1c9) has been slightly altered to branch based on this new flag. Now, instead of keeping track of how many items were removed as complete sets, the items removed are tracked in a map and all the existing logic still applies.

The [PlayerRecipeTransferHandler](https://github.com/mezz/JustEnoughItems/pull/1068/files/b8fcabe53c232cf3a6449e15263ec8625560201e#diff-ee589af180f346a253fcb54efd4db614) sends a packet with the new flag hardcoded to false.

### Why

This is useful for implementing a container that doesn't need to have a complete set of recipe items transferred and instead wants to transfer as many items as it can even if one slot has fewer items. See this issue: [https://github.com/mezz/JustEnoughItems/issues/1067](https://github.com/mezz/JustEnoughItems/issues/1067)