### PR TITLE
Add a hook for getting the hovered ingredient in the recipe gui

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ curse_project_id=238222
 
 version_major=4
 version_minor=13
-version_patch=0
+version_patch=1

--- a/src/api/java/mezz/jei/api/IRecipesGui.java
+++ b/src/api/java/mezz/jei/api/IRecipesGui.java
@@ -1,8 +1,9 @@
 package mezz.jei.api;
 
-import java.util.List;
-
 import mezz.jei.api.recipe.IFocus;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * JEI's gui for displaying recipes. Use this interface to open recipes.
@@ -26,4 +27,11 @@ public interface IRecipesGui {
 	 * @param recipeCategoryUids a list of categories to display, in order. Must not be empty.
 	 */
 	void showCategories(List<String> recipeCategoryUids);
+
+	/**
+	 * @return the ingredient that's currently under the mouse in this gui, or null if there is none.
+	 * @since JEI 4.13.1
+	 */
+	@Nullable
+	Object getIngredientUnderMouse();
 }

--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -399,6 +399,16 @@ public class RecipesGui extends GuiScreen implements IRecipesGui, IShowsRecipeFo
 		}
 	}
 
+	@Nullable
+	@Override
+	public Object getIngredientUnderMouse() {
+		IClickedIngredient<?> ingredient = getIngredientUnderMouse(MouseHelper.getX(), MouseHelper.getY());
+		if (ingredient != null) {
+			return ingredient.getValue();
+		}
+		return null;
+	}
+
 	public void back() {
 		logic.back();
 	}


### PR DESCRIPTION
Resolves #1357. The hook is simple, just wrapping the existing internal method that takes position arguments to avoid copying the logic. I hope the version bump was appropriate, seems like the few PRs done in the past that extended the API did that, so...