### PR TITLE
Add support for anvil recipe left side being a list

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ curse_project_id=238222
 
 version_major=4
 version_minor=14
-version_patch=0
+version_patch=1

--- a/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
@@ -19,23 +19,23 @@ import java.util.List;
  */
 public interface IVanillaRecipeFactory {
 
-    /**
+	/**
 	 * @deprecated Use {@link #createAnvilRecipe(List, List, List)}.
 	 */
-    @Deprecated
+	@Deprecated
 	default IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-        return createAnvilRecipe(Collections.singletonList(leftInput), rightInputs, outputs);
-    }
-    
-    /**
-     * Adds an anvil recipe for the given inputs and output.
-     *
-     * @param leftInputs   The itemStack(s) placed on the left slot.
-     * @param rightInputs The itemStack(s) placed on the right slot.
-     * @param outputs     The resulting itemStack(s).
-     * @return the {@link IRecipeWrapper} for this recipe.
-     */
-    IRecipeWrapper createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs);
+		return createAnvilRecipe(Collections.singletonList(leftInput), rightInputs, outputs);
+	}
+
+	/**
+	 * Adds an anvil recipe for the given inputs and output.
+	 *
+	 * @param leftInputs   The itemStack(s) placed on the left slot.
+	 * @param rightInputs The itemStack(s) placed on the right slot.
+	 * @param outputs     The resulting itemStack(s).
+	 * @return the {@link IRecipeWrapper} for this recipe.
+	 */
+	IRecipeWrapper createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs);
 
 	/**
 	 * Create a new smelting recipe.

--- a/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
@@ -18,7 +18,6 @@ import java.util.List;
  * @since JEI 4.5.0
  */
 public interface IVanillaRecipeFactory {
-
 	/**
 	 * Adds an anvil recipe for the given inputs and output.
 	 *

--- a/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -17,15 +18,24 @@ import java.util.List;
  * @since JEI 4.5.0
  */
 public interface IVanillaRecipeFactory {
-	/**
-	 * Adds an anvil recipe for the given inputs and output.
-	 *
-	 * @param leftInput   The itemStack placed on the left slot.
-	 * @param rightInputs The itemStack(s) placed on the right slot.
-	 * @param outputs     The resulting itemStack(s).
-	 * @return the {@link IRecipeWrapper} for this recipe.
+
+    /**
+	 * @deprecated Use {@link #createAnvilRecipe(List, List, List)}.
 	 */
-	IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs);
+    @Deprecated
+	default IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+        return createAnvilRecipe(Collections.singletonList(leftInput), rightInputs, outputs);
+    }
+    
+    /**
+     * Adds an anvil recipe for the given inputs and output.
+     *
+     * @param leftInputs   The itemStack(s) placed on the left slot.
+     * @param rightInputs The itemStack(s) placed on the right slot.
+     * @param outputs     The resulting itemStack(s).
+     * @return the {@link IRecipeWrapper} for this recipe.
+     */
+    IRecipeWrapper createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs);
 
 	/**
 	 * Create a new smelting recipe.

--- a/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
@@ -27,14 +27,13 @@ public interface IVanillaRecipeFactory {
 	 * @param outputs     The resulting itemStack(s).
 	 * @return the {@link IRecipeWrapper} for this recipe.
 	 */
-	default IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-		return createAnvilRecipe(Collections.singletonList(leftInput), rightInputs, outputs);
-	}
+	IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs);
 
 	/**
 	 * Adds an anvil recipe for the given inputs and output.
+	 * The number of inputs in the left and right side must match.
 	 *
-	 * @param leftInputs   The itemStack(s) placed on the left slot.
+	 * @param leftInputs  The itemStack(s) placed on the left slot.
 	 * @param rightInputs The itemStack(s) placed on the right slot.
 	 * @param outputs     The resulting itemStack(s).
 	 * @return the {@link IRecipeWrapper} for this recipe.

--- a/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
@@ -20,9 +20,13 @@ import java.util.List;
 public interface IVanillaRecipeFactory {
 
 	/**
-	 * @deprecated Use {@link #createAnvilRecipe(List, List, List)}.
+	 * Adds an anvil recipe for the given inputs and output.
+	 *
+	 * @param leftInput   The itemStack placed on the left slot.
+	 * @param rightInputs The itemStack(s) placed on the right slot.
+	 * @param outputs     The resulting itemStack(s).
+	 * @return the {@link IRecipeWrapper} for this recipe.
 	 */
-	@Deprecated
 	default IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		return createAnvilRecipe(Collections.singletonList(leftInput), rightInputs, outputs);
 	}
@@ -34,6 +38,7 @@ public interface IVanillaRecipeFactory {
 	 * @param rightInputs The itemStack(s) placed on the right slot.
 	 * @param outputs     The resulting itemStack(s).
 	 * @return the {@link IRecipeWrapper} for this recipe.
+	 * @since JEI 4.14.1
 	 */
 	IRecipeWrapper createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs);
 

--- a/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/IVanillaRecipeFactory.java
@@ -6,7 +6,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -17,7 +17,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");
 		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
-	    Preconditions.checkArgument(leftInputs.size() == rightInputs.size(), "Both input sizes must match.");
+		Preconditions.checkArgument(leftInputs.size() == rightInputs.size(), "Both input sizes must match.");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
 		return new AnvilRecipeWrapper(leftInputs, rightInputs, outputs);

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -17,6 +17,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");
 		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
+	    Preconditions.checkArgument(leftInputs.size() == rightInputs.size(), "Both input sizes must match.");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
 		return new AnvilRecipeWrapper(leftInputs, rightInputs, outputs);

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -13,13 +13,13 @@ import net.minecraft.item.ItemStack;
 
 public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 	@Override
-	public IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-		ErrorUtil.checkNotEmpty(leftInput, "leftInput");
+	public IRecipeWrapper createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");
 		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
-		return new AnvilRecipeWrapper(leftInput, rightInputs, outputs);
+		return new AnvilRecipeWrapper(leftInputs, rightInputs, outputs);
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -14,13 +14,13 @@ import net.minecraft.item.ItemStack;
 
 public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 	@Override
-	public IRecipeWrapper createAnvilRecipe(ItemStack leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs) {
-		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");
+	public IRecipeWrapper createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+		ErrorUtil.checkNotEmpty(leftInput, "leftInput");
 		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
-		return new AnvilRecipeWrapper(Collections.singletonList(leftInputs), rightInputs, outputs);
+		return new AnvilRecipeWrapper(Collections.singletonList(leftInput), rightInputs, outputs);
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -1,5 +1,6 @@
 package mezz.jei.plugins.vanilla;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
@@ -12,6 +13,16 @@ import mezz.jei.util.ErrorUtil;
 import net.minecraft.item.ItemStack;
 
 public class VanillaRecipeFactory implements IVanillaRecipeFactory {
+	@Override
+	public IRecipeWrapper createAnvilRecipe(ItemStack leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");
+		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
+		ErrorUtil.checkNotEmpty(outputs, "outputs");
+		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
+
+		return new AnvilRecipeWrapper(Collections.singletonList(leftInputs), rightInputs, outputs);
+	}
+
 	@Override
 	public IRecipeWrapper createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeWrapper.java
@@ -27,9 +27,9 @@ public class AnvilRecipeWrapper implements IRecipeWrapper {
 	private ItemStack lastRightStack;
 	private int lastCost;
 
-	public AnvilRecipeWrapper(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
+	public AnvilRecipeWrapper(List<ItemStack> leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		this.inputs = Lists.newArrayList();
-		this.inputs.add(Collections.singletonList(leftInput));
+		this.inputs.add(leftInput);
 		this.inputs.add(rightInputs);
 
 		this.output = Collections.singletonList(outputs);

--- a/src/main/java/mezz/jei/startup/ModRegistry.java
+++ b/src/main/java/mezz/jei/startup/ModRegistry.java
@@ -288,7 +288,7 @@ public class ModRegistry implements IModRegistry, IRecipeCategoryRegistration {
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		Preconditions.checkArgument(rightInputs.size() == outputs.size(), "Input and output sizes must match.");
 
-		AnvilRecipeWrapper anvilRecipeWrapper = new AnvilRecipeWrapper(leftInput, rightInputs, outputs);
+		AnvilRecipeWrapper anvilRecipeWrapper = new AnvilRecipeWrapper(Collections.singletonList(leftInput), rightInputs, outputs);
 		addRecipes(Collections.singletonList(anvilRecipeWrapper), VanillaRecipeCategoryUid.ANVIL);
 	}
 


### PR DESCRIPTION
This is a purely virtual restriction, and it works fine as long as the lists are of the same size, which is checked by the factory.

Needed in EIO for darksteel upgrade recipes, I wish for them to be pinned to the upgrade (right side) and not the armor/tool (left side):

![](https://cdn.discordapp.com/attachments/358816844477497346/518909972113784847/unknown.png)