### PR TITLE
Added shortcut key for item hide mode

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -147,24 +147,24 @@ public final class Config {
 		}
 	}
 
-	public static boolean isHideModeEnabled() {
-		return values.hideModeEnabled;
+	public static boolean isEditModeEnabled() {
+		return values.editModeEnabled;
 	}
 
-	public static void toggleHideModeEnabled() {
-		values.hideModeEnabled = !values.hideModeEnabled;
+	public static void toggleEditModeEnabled() {
+		values.editModeEnabled = !values.editModeEnabled;
 		if (worldConfig != null) {
 			NetworkManager networkManager = FMLClientHandler.instance().getClientToServerNetworkManager();
 			final String worldCategory = ServerInfo.getWorldUid(networkManager);
-			Property property = worldConfig.get(worldCategory, "editEnabled", defaultValues.hideModeEnabled);
-			property.set(values.hideModeEnabled);
+			Property property = worldConfig.get(worldCategory, "editEnabled", defaultValues.editModeEnabled);
+			property.set(values.editModeEnabled);
 
 			if (worldConfig.hasChanged()) {
 				worldConfig.save();
 			}
 		}
 
-		MinecraftForge.EVENT_BUS.post(new EditModeToggleEvent(values.hideModeEnabled));
+		MinecraftForge.EVENT_BUS.post(new EditModeToggleEvent(values.editModeEnabled));
 	}
 
 	public static boolean isDebugModeEnabled() {
@@ -488,12 +488,12 @@ public final class Config {
 		property.setComment(Translator.translateToLocal("config.jei.mode.cheatItemsEnabled.comment"));
 		values.cheatItemsEnabled = property.getBoolean();
 
-		property = worldConfig.get(worldCategory, "editEnabled", defaultValues.hideModeEnabled);
+		property = worldConfig.get(worldCategory, "editEnabled", defaultValues.editModeEnabled);
 		property.setLanguageKey("config.jei.mode.editEnabled");
 		property.setComment(Translator.translateToLocal("config.jei.mode.editEnabled.comment"));
-		values.hideModeEnabled = property.getBoolean();
+		values.editModeEnabled = property.getBoolean();
 		if (property.hasChanged()) {
-			MinecraftForge.EVENT_BUS.post(new EditModeToggleEvent(values.hideModeEnabled));
+			MinecraftForge.EVENT_BUS.post(new EditModeToggleEvent(values.editModeEnabled));
 		}
 
 		property = worldConfig.get(worldCategory, "bookmarkOverlayEnabled", defaultValues.bookmarkOverlayEnabled);

--- a/src/main/java/mezz/jei/config/ConfigValues.java
+++ b/src/main/java/mezz/jei/config/ConfigValues.java
@@ -23,7 +23,7 @@ public class ConfigValues {
 	// per-world
 	public boolean overlayEnabled = true;
 	public boolean cheatItemsEnabled = false;
-	public boolean hideModeEnabled = false;
+	public boolean editModeEnabled = false;
 	public boolean bookmarkOverlayEnabled = true;
 	public String filterText = "";
 }

--- a/src/main/java/mezz/jei/config/KeyBindings.java
+++ b/src/main/java/mezz/jei/config/KeyBindings.java
@@ -17,6 +17,7 @@ public final class KeyBindings {
 	public static final KeyBinding toggleOverlay;
 	public static final KeyBinding focusSearch;
 	public static final KeyBinding toggleCheatMode;
+	public static final KeyBinding toggleEditMode;
 	public static final KeyBinding showRecipe;
 	public static final KeyBinding showUses;
 	public static final KeyBinding recipeBack;
@@ -31,6 +32,7 @@ public final class KeyBindings {
 			toggleOverlay = new KeyBinding("key.jei.toggleOverlay", KeyConflictContext.GUI, KeyModifier.CONTROL, Keyboard.KEY_O, categoryName),
 			focusSearch = new KeyBinding("key.jei.focusSearch", KeyConflictContext.GUI, KeyModifier.CONTROL, Keyboard.KEY_F, categoryName),
 			toggleCheatMode = new KeyBinding("key.jei.toggleCheatMode", KeyConflictContext.GUI, Keyboard.KEY_NONE, categoryName),
+			toggleEditMode = new KeyBinding("key.jei.toggleEditMode", KeyConflictContext.GUI, Keyboard.KEY_NONE, categoryName),
 			showRecipe = new KeyBinding("key.jei.showRecipe", KeyConflictContext.GUI, Keyboard.KEY_R, categoryName),
 			showUses = new KeyBinding("key.jei.showUses", KeyConflictContext.GUI, Keyboard.KEY_U, categoryName),
 			recipeBack = new KeyBinding("key.jei.recipeBack", KeyConflictContext.GUI, Keyboard.KEY_BACK, categoryName),

--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -304,16 +304,12 @@ public class IngredientListOverlay implements IIngredientListOverlay, IMouseHand
 				Config.toggleCheatItemsEnabled();
 				return true;
 			}
-			if(KeyBindings.toggleEditMode.isActiveAndMatches(eventKey)) {
+			if (KeyBindings.toggleEditMode.isActiveAndMatches(eventKey)) {
 				Config.toggleEditModeEnabled();
 				return true;
 			}
 			if (KeyBindings.focusSearch.isActiveAndMatches(eventKey)) {
 				setKeyboardFocus(true);
-				return true;
-			}
-			if(KeyBindings.toggleEditMode.isActiveAndMatches(eventKey)) {
-				Config.toggleEditModeEnabled();
 				return true;
 			}
 		}

--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -304,8 +304,16 @@ public class IngredientListOverlay implements IIngredientListOverlay, IMouseHand
 				Config.toggleCheatItemsEnabled();
 				return true;
 			}
+			if(KeyBindings.toggleEditMode.isActiveAndMatches(eventKey)) {
+				Config.toggleEditModeEnabled();
+				return true;
+			}
 			if (KeyBindings.focusSearch.isActiveAndMatches(eventKey)) {
 				setKeyboardFocus(true);
+				return true;
+			}
+			if(KeyBindings.toggleEditMode.isActiveAndMatches(eventKey)) {
+				Config.toggleEditModeEnabled();
 				return true;
 			}
 		}

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -182,7 +182,7 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 		IIngredientHelper<V> ingredientHelper = element.getIngredientHelper();
 		boolean visible = !blacklist.isIngredientBlacklistedByApi(ingredient, ingredientHelper) &&
 			ingredientHelper.isIngredientOnServer(ingredient) &&
-			(Config.isHideModeEnabled() || !Config.isIngredientOnConfigBlacklist(ingredient, ingredientHelper));
+			(Config.isEditModeEnabled() || !Config.isIngredientOnConfigBlacklist(ingredient, ingredientHelper));
 		if (element.isVisible() != visible) {
 			element.setVisible(visible);
 			this.filterCached = null;

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -117,7 +117,7 @@ public class InputHandler {
 
 	private boolean handleMouseClick(GuiScreen guiScreen, int mouseButton, int mouseX, int mouseY) {
 		IClickedIngredient<?> clicked = getFocusUnderMouseForClick(mouseX, mouseY);
-		if (Config.isHideModeEnabled() && clicked != null && handleClickEdit(clicked)) {
+		if (Config.isEditModeEnabled() && clicked != null && handleClickEdit(clicked)) {
 			return true;
 		}
 		if (ingredientListOverlay.handleMouseClicked(mouseX, mouseY, mouseButton)) {

--- a/src/main/java/mezz/jei/render/IngredientRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientRenderer.java
@@ -59,7 +59,7 @@ public class IngredientRenderer<T> {
 	}
 
 	public void renderSlow() {
-		if (Config.isHideModeEnabled()) {
+		if (Config.isEditModeEnabled()) {
 			renderEditMode(element, area, padding);
 		}
 
@@ -126,7 +126,7 @@ public class IngredientRenderer<T> {
 			addColorSearchInfoToTooltip(minecraft, element, tooltip, maxWidth);
 		}
 
-		if (Config.isHideModeEnabled()) {
+		if (Config.isEditModeEnabled()) {
 			addEditModeInfoToTooltip(minecraft, tooltip, maxWidth);
 		}
 

--- a/src/main/java/mezz/jei/render/ItemStackFastRenderer.java
+++ b/src/main/java/mezz/jei/render/ItemStackFastRenderer.java
@@ -43,7 +43,7 @@ public class ItemStackFastRenderer extends IngredientRenderer<ItemStack> {
 	}
 
 	private void uncheckedRenderItemAndEffectIntoGUI() {
-		if (Config.isHideModeEnabled()) {
+		if (Config.isEditModeEnabled()) {
 			renderEditMode(element, area, padding);
 			GlStateManager.enableBlend();
 		}

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -42,6 +42,7 @@ key.jei.showRecipe=Show Recipe
 key.jei.showUses=Show Uses
 key.jei.recipeBack=Show Previously Viewed Recipe
 key.jei.toggleCheatMode=Toggle Cheat Mode
+key.jei.toggleEditMode=Toggle Hide/Edit Mode
 key.jei.previousPage=Show Previous Page
 key.jei.nextPage=Show Next Page
 key.jei.bookmark=Add/Remove a Bookmarked Ingredient


### PR DESCRIPTION
• Created a shortcut key (default unbinded) that will allow users to toggle item hide/edit mode using a keybind.
• Added more consistency from Hide Mode declarations being used interchangably with Edit Mode.
  ◘Some of this caused a couple booleans to become unused. This is solved in this commit. 
 
Fixes #1529 