### PR TITLE
Fixed spelling mistake

### DIFF
--- a/src/main/resources/assets/jei/lang/ar_sa.json
+++ b/src/main/resources/assets/jei/lang/ar_sa.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/bg_bg.json
+++ b/src/main/resources/assets/jei/lang/bg_bg.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/cs_cz.json
+++ b/src/main/resources/assets/jei/lang/cs_cz.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Dřevěné dveře ti umožní blokovat příšery před vstupem do budovy.\\nTestovací věty.",
-  "description.jei.wooden.door.2": "Kliknutí na dveře změní jejich status a jejich visa versa.",
+  "description.jei.wooden.door.2": "Kliknutí na dveře změní jejich status a jejich vice versa.",
   "description.jei.wooden.door.3": "Dřevěné dveře mohou být otevřeny/zavřeny pomocí Redstone Obvodů."
 }

--- a/src/main/resources/assets/jei/lang/de_de.json
+++ b/src/main/resources/assets/jei/lang/de_de.json
@@ -121,6 +121,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/el_gr.json
+++ b/src/main/resources/assets/jei/lang/el_gr.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/en_au.json
+++ b/src/main/resources/assets/jei/lang/en_au.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/en_us.json
+++ b/src/main/resources/assets/jei/lang/en_us.json
@@ -122,6 +122,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/es_es.json
+++ b/src/main/resources/assets/jei/lang/es_es.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/fi_fi.json
+++ b/src/main/resources/assets/jei/lang/fi_fi.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/fr_fr.json
+++ b/src/main/resources/assets/jei/lang/fr_fr.json
@@ -121,6 +121,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/he_il.json
+++ b/src/main/resources/assets/jei/lang/he_il.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/it_it.json
+++ b/src/main/resources/assets/jei/lang/it_it.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/ja_jp.json
+++ b/src/main/resources/assets/jei/lang/ja_jp.json
@@ -121,6 +121,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/ko_kr.json
+++ b/src/main/resources/assets/jei/lang/ko_kr.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/lt_lt.json
+++ b/src/main/resources/assets/jei/lang/lt_lt.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/nb_no.json
+++ b/src/main/resources/assets/jei/lang/nb_no.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/pl_pl.json
+++ b/src/main/resources/assets/jei/lang/pl_pl.json
@@ -122,6 +122,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/ru_ru.json
+++ b/src/main/resources/assets/jei/lang/ru_ru.json
@@ -121,6 +121,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/sv_se.json
+++ b/src/main/resources/assets/jei/lang/sv_se.json
@@ -121,6 +121,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/tr_tr.json
+++ b/src/main/resources/assets/jei/lang/tr_tr.json
@@ -111,6 +111,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/uk_ua.json
+++ b/src/main/resources/assets/jei/lang/uk_ua.json
@@ -113,6 +113,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/zh_cn.json
+++ b/src/main/resources/assets/jei/lang/zh_cn.json
@@ -122,6 +122,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }

--- a/src/main/resources/assets/jei/lang/zh_tw.json
+++ b/src/main/resources/assets/jei/lang/zh_tw.json
@@ -121,6 +121,6 @@
 
   "_comment": "DEBUG (for debug mode, do not need translation)",
   "description.jei.wooden.door.1": "Wooden Doors allow you to block monsters from entering your building.\\nTesting sentences.",
-  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and visa versa.",
+  "description.jei.wooden.door.2": "Clicking on a door changes its state from open to closed and vice versa.",
   "description.jei.wooden.door.3": "Wooden Doors can be opened/closed via Redstone Circuits."
 }


### PR DESCRIPTION
In this commit I fixed spelling mistake of "vice versa" in nearly all language files in the `1.13` branch (in other branches this issue still exists).