### PR TITLE
Initial memory usage optimization proposal

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -179,6 +179,10 @@ public final class Config {
 		return values.centerSearchBarEnabled;
 	}
 
+	public static boolean isOptimizeMemoryUsage() {
+		return values.optimizeMemoryUsage;
+	}
+
 	public static GiveMode getGiveMode() {
 		return values.giveMode;
 	}
@@ -398,6 +402,8 @@ public final class Config {
 		categoryAdvanced.remove("maxSubtypes");
 
 		values.centerSearchBarEnabled = config.getBoolean(CATEGORY_ADVANCED, "centerSearchBarEnabled", defaultValues.centerSearchBarEnabled);
+
+		values.optimizeMemoryUsage = config.getBoolean(CATEGORY_ADVANCED, "optimizeMemoryUsage", defaultValues.optimizeMemoryUsage);
 
 		values.giveMode = config.getEnum("giveMode", CATEGORY_ADVANCED, defaultValues.giveMode, GiveMode.values());
 

--- a/src/main/java/mezz/jei/config/ConfigValues.java
+++ b/src/main/java/mezz/jei/config/ConfigValues.java
@@ -6,6 +6,7 @@ public class ConfigValues {
 	// advanced
 	public boolean debugModeEnabled = false;
 	public boolean centerSearchBarEnabled = false;
+	public boolean optimizeMemoryUsage = true;
 	public GiveMode giveMode = GiveMode.MOUSE_PICKUP;
 	public String modNameFormat = Config.parseFriendlyModNameFormat(Config.defaultModNameFormatFriendly);
 	public int maxColumns = 100;

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -86,6 +86,13 @@ public class IngredientFilter implements IIngredientFilter, IIngredientGridSourc
 		this.prefixedSearchTrees.put(prefix, prefixedTree);
 	}
 
+	public void trimToSize() {
+		searchTree.trimToSize();
+		for (PrefixedSearchTree tree : prefixedSearchTrees.values()) {
+			tree.getTree().trimToSize();
+		}
+	}
+
 	public void addIngredients(NonNullList<IIngredientListElement> ingredients) {
 		ingredients.sort(IngredientListElementComparator.INSTANCE);
 		long modNameCount = ingredients.stream()

--- a/src/main/java/mezz/jei/startup/JeiStarter.java
+++ b/src/main/java/mezz/jei/startup/JeiStarter.java
@@ -114,6 +114,13 @@ public class JeiStarter {
 
 		sendRuntime(plugins, jeiRuntime);
 
+		// Some mods insist on adding ingredients at runtime, so we cannot optimize memory usage earlier than that.
+		if (Config.isOptimizeMemoryUsage()) {
+			timer.start("Optimizing memory usage");
+			ingredientFilter.trimToSize();
+			timer.stop();
+		}
+
 		LeftAreaDispatcher leftAreaDispatcher = new LeftAreaDispatcher(guiScreenHelper);
 		leftAreaDispatcher.addContent(bookmarkOverlay);
 

--- a/src/main/java/mezz/jei/suffixtree/GeneralizedSuffixTree.java
+++ b/src/main/java/mezz/jei/suffixtree/GeneralizedSuffixTree.java
@@ -16,6 +16,7 @@
 package mezz.jei.suffixtree;
 
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Objects;
@@ -387,7 +388,7 @@ public class GeneralizedSuffixTree implements ISearchTree {
 	}
 
 	public void trimToSize() {
-		LinkedList<Node> nodes = new LinkedList<>();
+		ArrayDeque<Node> nodes = new ArrayDeque<>(128);
 		nodes.add(root);
 		while (!nodes.isEmpty()) {
 			Node node = nodes.remove();

--- a/src/main/java/mezz/jei/suffixtree/GeneralizedSuffixTree.java
+++ b/src/main/java/mezz/jei/suffixtree/GeneralizedSuffixTree.java
@@ -16,6 +16,8 @@
 package mezz.jei.suffixtree;
 
 import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Objects;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -382,6 +384,22 @@ public class GeneralizedSuffixTree implements ISearchTree {
 
 	public int getHighestIndex() {
 		return highestIndex;
+	}
+
+	public void trimToSize() {
+		LinkedList<Node> nodes = new LinkedList<>();
+		nodes.add(root);
+		while (!nodes.isEmpty()) {
+			Node node = nodes.remove();
+			node.trimToSize();
+			Node suffix = node.getSuffix();
+			if (suffix != null) {
+				suffix.trimToSize();
+			}
+			for (Edge edge : node.edges()) {
+				nodes.add(edge.getDest());
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/mezz/jei/suffixtree/Node.java
+++ b/src/main/java/mezz/jei/suffixtree/Node.java
@@ -17,11 +17,17 @@ package mezz.jei.suffixtree;
 
 import javax.annotation.Nullable;
 
+import it.unimi.dsi.fastutil.chars.Char2ObjectArrayMap;
 import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
+import it.unimi.dsi.fastutil.chars.Char2ObjectMaps;
 import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.ObjectCollection;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * Represents a node of the generalized suffix tree graph
@@ -46,7 +52,7 @@ class Node {
 	/**
 	 * The set of edges starting from this node
 	 */
-	private final Char2ObjectMap<Edge> edges;
+	private Char2ObjectMap<Edge> edges;
 
 	/**
 	 * The suffix link as described in Ukkonen's paper.
@@ -113,7 +119,13 @@ class Node {
 	}
 
 	void addEdge(char ch, Edge e) {
-		edges.put(ch, e);
+		try {
+			edges.put(ch, e);
+		} catch (UnsupportedOperationException ex) {
+			// after trimToSize() call - fall back
+			edges = new Char2ObjectOpenHashMap<>(edges);
+			edges.put(ch, e);
+		}
 	}
 
 	@Nullable
@@ -137,5 +149,29 @@ class Node {
 	@Override
 	public String toString() {
 		return "Node: size:" + data.size() + " Edges: " + edges.toString();
+	}
+
+	ObjectCollection<Edge> edges() {
+		return edges.values();
+	}
+
+	void trimToSize() {
+		if (data instanceof IntArrayList) {
+			((IntArrayList) data).trim();
+		}
+		switch (edges.size()) {
+			case 0:
+				edges = Char2ObjectMaps.emptyMap();
+				break;
+			case 1:
+				Map.Entry<Character, Edge> entry = edges.entrySet().iterator().next();
+				edges = Char2ObjectMaps.singleton(entry.getKey(), entry.getValue());
+				break;
+			case 2:
+			case 3:
+			case 4:
+				edges = new Char2ObjectArrayMap<>(edges);
+				break;
+		}
 	}
 }

--- a/src/main/java/mezz/jei/suffixtree/Node.java
+++ b/src/main/java/mezz/jei/suffixtree/Node.java
@@ -25,6 +25,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.ObjectCollection;
+import mezz.jei.util.Log;
 
 import java.util.Collection;
 import java.util.Map;
@@ -123,6 +124,7 @@ class Node {
 			edges.put(ch, e);
 		} catch (UnsupportedOperationException ex) {
 			// after trimToSize() call - fall back
+			Log.get().warn("Mod added a tree entry after memory optimization!", ex);
 			edges = new Char2ObjectOpenHashMap<>(edges);
 			edges.put(ch, e);
 		}

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -101,6 +101,8 @@ config.jei.advanced.maxRecipeGuiHeight=Max Recipe GUI Height
 config.jei.advanced.maxRecipeGuiHeight.comment=The maximum height of the recipe GUI.
 config.jei.advanced.giveMode=Give Mode
 config.jei.advanced.giveMode.comment=Choose if JEI should give ingredients direct to the inventory (inventory) or pick them up with the mouse (mouse_pickup).
+config.jei.advanced.optimizeMemoryUsage=Optimize Memory Usage
+config.jei.advanced.optimizeMemoryUsage.comment=Enable JEI memory usage optimizations.
 
 # Hide Ingredients Mode
 gui.jei.editMode.description=JEI Hide Ingredients Mode:

--- a/src/main/resources/assets/jei/lang/pl_pl.lang
+++ b/src/main/resources/assets/jei/lang/pl_pl.lang
@@ -101,6 +101,8 @@ config.jei.advanced.maxRecipeGuiHeight=Maksymalna wysokość interfejsu
 config.jei.advanced.maxRecipeGuiHeight.comment=Maksymalna wysokość interfejsu z recepturami.
 config.jei.advanced.giveMode=Tryb dawania
 config.jei.advanced.giveMode.comment=Zdecyduj, czy JEI ma dawać składniki bezpośrednio do ekwipunku (inventory), czy chcesz zabierać i przenosić je samemu (mouse_pickup).
+config.jei.advanced.optimizeMemoryUsage=Optymalizacja zużycia pamięci
+config.jei.advanced.optimizeMemoryUsage.comment=Włącz optymalizacje zużycia pamięci przez JEI.
 
 # Hide Ingredients Mode
 gui.jei.editMode.description=Tryb ukrywania składników JEI:


### PR DESCRIPTION
This initial take on it reduces JEI's GeneralizedSuffixTree memory usage by 50-70% (depending on context); Enigmatica 2: Expert's in particular drops from 460MB to 165MB. The addition to load times is minimal - +30ms on a vanilla+JEI setup, +300-400ms on E2:E on my machine.

Personally, I would consider being even more "aggressive" in terms of the "edges" map size up to which we choose an ArrayMap over a HashMap; however, I am not sure how crucial performance is to that part of the code (an ArrayMap will always be significantly smaller RAM-wise, in this scenario, so perhaps always using it - plus an empty map singleton as used to not generate unneeded empty maps - would be the best approach), and the additional gains are only ~8MB in the "E2:E" scenario, so it might not be worth it in the end.