### PR TITLE
Fix display name acquisition

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -68,9 +68,8 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 	@Override
 	public String getDisplayName(ItemStack ingredient) {
 		ITextComponent displayNameTextComponent = ingredient.getDisplayName();
-		String displayName = displayNameTextComponent.getUnformattedComponentText();
-		ErrorUtil.checkNotNull(displayName, "itemStack.getDisplayName()");
-		return displayName;
+		ErrorUtil.checkNotNull(displayNameTextComponent, "itemStack.getDisplayName()");
+		return displayNameTextComponent.getString();
 	}
 
 	@Override


### PR DESCRIPTION
This PR corrects the usage of `ITextComponent#getUnformattedComponentText()` while `ITextComponent#getString()` (previously `ITextComponent#getUnformattedText()`) is the intended behavior. The former returns the contents of the specific text component not including siblings, leading to a potentially incomplete string.