### PR TITLE
fix: Received status code 501 from server: HTTPS Required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ compileJava {
 }
 
 repositories {
-	maven { url 'http://repo1.maven.org/maven2' }
+	maven { url 'https://repo1.maven.org/maven2' }
 }
 
 sourceSets {


### PR DESCRIPTION
fixed error (on running gradlew.bat):
FAILURE: Build failed with an exception. :_compileJava_1

* What went wrong:
A problem occurred configuring root project 'jei-1.14.4'.
> Could not resolve all files for configuration ':_compileJava_1'.
   > Could not resolve net.minecraft:client:1.14.4.
     Required by:
         project :
      > Could not resolve net.minecraft:client:1.14.4.
         > Could not get resource 'http://repo1.maven.org/maven2/net/minecraft/client/1.14.4/client-1.14.4.pom'.
            > Could not GET 'http://repo1.maven.org/maven2/net/minecraft/client/1.14.4/client-1.14.4.pom'. Received status code 501 from server: HTTPS Required