### PR TITLE
Update JEI to 1.15.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ compileJava {
 }
 
 repositories {
-	maven { url 'http://repo1.maven.org/maven2' }
+	maven { url 'https://repo1.maven.org/maven2' }
 }
 
 sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.daemon=false
 
-mcversion=1.15.1
-forgeversion=30.0.15
+mcversion=1.15.2
+forgeversion=31.0.0
 forgegroup=net.minecraftforge
-mcp_mappings=20191105-1.14.3
+mcp_mappings=20200122-1.15.1
 curse_project_id=238222
 
 version_major=6

--- a/src/main/java/mezz/jei/color/ColorGetter.java
+++ b/src/main/java/mezz/jei/color/ColorGetter.java
@@ -116,7 +116,7 @@ public final class ColorGetter {
 	private static List<Integer> getBlockColors(Block block, int colorCount) {
 		BlockState blockState = block.getDefaultState();
 		final BlockColors blockColors = Minecraft.getInstance().getBlockColors();
-		final int renderColor = blockColors.func_228054_a_(blockState, null, null, 0);
+		final int renderColor = blockColors.getColor(blockState, null, null, 0);
 		final TextureAtlasSprite textureAtlasSprite = getTextureAtlasSprite(blockState);
 		if (textureAtlasSprite == null) {
 			return Collections.emptyList();

--- a/src/main/java/mezz/jei/config/forge/Property.java
+++ b/src/main/java/mezz/jei/config/forge/Property.java
@@ -23,9 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-import net.minecraftforge.fml.client.config.IArrayEntry;
-import net.minecraftforge.fml.client.config.IConfigEntry;
-
 public class Property
 {
     public String getComment()
@@ -77,8 +74,9 @@ public class Property
     private String minValue;
     private String maxValue;
 
-    private Class<? extends IConfigEntry> configEntryClass = null;
-    private Class<? extends IArrayEntry> arrayEntryClass = null;
+    //TODO: Configs
+    //private Class<? extends IConfigEntry> configEntryClass = null;
+    //private Class<? extends IArrayEntry> arrayEntryClass = null;
 
     private boolean requiresWorldRestart = false;
     private boolean showInGui = true;
@@ -395,12 +393,12 @@ public class Property
         return this.isListLengthFixed;
     }
 
-
-    public Property setConfigEntryClass(Class<? extends IConfigEntry> clazz)
+    //TODO: Configs
+    /*public Property setConfigEntryClass(Class<? extends IConfigEntry> clazz)
     {
         this.configEntryClass = clazz;
         return this;
-    }
+    }*/
 
     /**
      * Gets the custom IConfigEntry class that should be used in place of the standard entry class for this Property type, or null if
@@ -408,7 +406,8 @@ public class Property
      *
      * @return a class that implements IConfigEntry
      */
-    public Class<? extends IConfigEntry> getConfigEntryClass()
+    //TODO: Configs
+    /*public Class<? extends IConfigEntry> getConfigEntryClass()
     {
         return this.configEntryClass;
     }
@@ -417,7 +416,7 @@ public class Property
     {
         this.arrayEntryClass = clazz;
         return this;
-    }
+    }*/
 
     /**
      * Gets the custom IArrayEntry class that should be used in place of the standard entry class for this Property type, or null if
@@ -425,10 +424,11 @@ public class Property
      *
      * @return a class that implements IArrayEntry
      */
-    public Class<? extends IArrayEntry> getArrayEntryClass()
+    //TODO: Configs
+    /*public Class<? extends IArrayEntry> getArrayEntryClass()
     {
         return this.arrayEntryClass;
-    }
+    }*/
 
     /**
      * Sets a regex Pattern object used to validate user input for formatted String or String[] properties.

--- a/src/main/java/mezz/jei/gui/TooltipRenderer.java
+++ b/src/main/java/mezz/jei/gui/TooltipRenderer.java
@@ -3,7 +3,7 @@ package mezz.jei.gui;
 import java.util.Collections;
 import java.util.List;
 
-import net.minecraftforge.fml.client.config.GuiUtils;
+import net.minecraftforge.fml.client.gui.GuiUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.item.ItemStack;
@@ -33,8 +33,8 @@ public final class TooltipRenderer {
 
 	public static void drawHoveringText(Object ingredient, List<String> textLines, int x, int y, int maxWidth, FontRenderer font) {
 		Minecraft minecraft = Minecraft.getInstance();
-		int scaledWidth = minecraft.func_228018_at_().getScaledWidth();
-		int scaledHeight = minecraft.func_228018_at_().getScaledHeight();
+		int scaledWidth = minecraft.getMainWindow().getScaledWidth();
+		int scaledHeight = minecraft.getMainWindow().getScaledHeight();
 		ItemStack itemStack = ingredient instanceof ItemStack ? (ItemStack) ingredient : ItemStack.EMPTY;
 		GuiUtils.drawHoveringText(itemStack, textLines, x, y, scaledWidth, scaledHeight, maxWidth, font);
 	}

--- a/src/main/java/mezz/jei/gui/elements/DrawableNineSliceTexture.java
+++ b/src/main/java/mezz/jei/gui/elements/DrawableNineSliceTexture.java
@@ -129,17 +129,17 @@ public class DrawableNineSliceTexture {
 	}
 
 	private static void draw(BufferBuilder bufferBuilder, float minU, double minV, float maxU, float maxV, int xOffset, int yOffset, int width, int height) {
-		bufferBuilder.func_225582_a_(xOffset, yOffset + height, 0)
-			.func_225583_a_(minU, maxV)
+		bufferBuilder.pos(xOffset, yOffset + height, 0)
+			.tex(minU, maxV)
 			.endVertex();
-		bufferBuilder.func_225582_a_(xOffset + width, yOffset + height, 0)
-			.func_225583_a_(maxU, maxV)
+		bufferBuilder.pos(xOffset + width, yOffset + height, 0)
+			.tex(maxU, maxV)
 			.endVertex();
-		bufferBuilder.func_225582_a_(xOffset + width, yOffset, 0)
-			.func_225583_a_(maxU, (float) minV)
+		bufferBuilder.pos(xOffset + width, yOffset, 0)
+			.tex(maxU, (float) minV)
 			.endVertex();
-		bufferBuilder.func_225582_a_(xOffset, yOffset, 0)
-			.func_225583_a_(minU, (float) minV)
+		bufferBuilder.pos(xOffset, yOffset, 0)
+			.tex(minU, (float) minV)
 			.endVertex();
 	}
 }

--- a/src/main/java/mezz/jei/gui/elements/DrawableResource.java
+++ b/src/main/java/mezz/jei/gui/elements/DrawableResource.java
@@ -70,10 +70,10 @@ public class DrawableResource implements IDrawableStatic {
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder bufferbuilder = tessellator.getBuffer();
 		bufferbuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
-		bufferbuilder.func_225582_a_(x, y + height, 0.0D).func_225583_a_(u * f, (v + (float)height) * f1).endVertex();
-		bufferbuilder.func_225582_a_(x + width, y + height, 0.0D).func_225583_a_((u + (float)width) * f, (v + (float)height) * f1).endVertex();
-		bufferbuilder.func_225582_a_(x + width, y, 0.0D).func_225583_a_((u + (float)width) * f, v * f1).endVertex();
-		bufferbuilder.func_225582_a_(x, y, 0.0D).func_225583_a_(u * f, v * f1).endVertex();
+		bufferbuilder.pos(x, y + height, 0.0D).tex(u * f, (v + (float)height) * f1).endVertex();
+		bufferbuilder.pos(x + width, y + height, 0.0D).tex((u + (float)width) * f, (v + (float)height) * f1).endVertex();
+		bufferbuilder.pos(x + width, y, 0.0D).tex((u + (float)width) * f, v * f1).endVertex();
+		bufferbuilder.pos(x, y, 0.0D).tex(u * f, v * f1).endVertex();
 		tessellator.draw();
 	}
 }

--- a/src/main/java/mezz/jei/gui/elements/DrawableSprite.java
+++ b/src/main/java/mezz/jei/gui/elements/DrawableSprite.java
@@ -82,17 +82,17 @@ public class DrawableSprite implements IDrawableStatic {
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder bufferBuilder = tessellator.getBuffer();
 		bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
-		bufferBuilder.func_225582_a_(x, y + height, 0)
-			.func_225583_a_(minU, maxV)
+		bufferBuilder.pos(x, y + height, 0)
+			.tex(minU, maxV)
 			.endVertex();
-		bufferBuilder.func_225582_a_(x + width, y + height, 0)
-			.func_225583_a_(maxU, maxV)
+		bufferBuilder.pos(x + width, y + height, 0)
+			.tex(maxU, maxV)
 			.endVertex();
-		bufferBuilder.func_225582_a_(x + width, y, 0)
-			.func_225583_a_(maxU, minV)
+		bufferBuilder.pos(x + width, y, 0)
+			.tex(maxU, minV)
 			.endVertex();
-		bufferBuilder.func_225582_a_(x, y, 0)
-			.func_225583_a_(minU, minV)
+		bufferBuilder.pos(x, y, 0)
+			.tex(minU, minV)
 			.endVertex();
 		tessellator.draw();
 	}

--- a/src/main/java/mezz/jei/gui/overlay/ConfigButton.java
+++ b/src/main/java/mezz/jei/gui/overlay/ConfigButton.java
@@ -60,7 +60,7 @@ public class ConfigButton extends GuiIconToggleButton {
 	@Override
 	protected boolean onMouseClicked(double mouseX, double mouseY, int mouseButton) {
 		if (worldConfig.isOverlayEnabled()) {
-			long windowHandle = Minecraft.getInstance().func_228018_at_().getHandle();
+			long windowHandle = Minecraft.getInstance().getMainWindow().getHandle();
 			if (InputMappings.isKeyDown(windowHandle, GLFW.GLFW_KEY_LEFT_CONTROL) || InputMappings.isKeyDown(windowHandle, GLFW.GLFW_KEY_RIGHT_CONTROL)) {
 				worldConfig.toggleCheatItemsEnabled();
 			} else {

--- a/src/main/java/mezz/jei/gui/recipes/ShapelessIcon.java
+++ b/src/main/java/mezz/jei/gui/recipes/ShapelessIcon.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraftforge.fml.client.config.HoverChecker;
+import net.minecraftforge.fml.client.gui.HoverChecker;
 
 import mezz.jei.Internal;
 import mezz.jei.api.gui.drawable.IDrawable;

--- a/src/main/java/mezz/jei/input/MouseUtil.java
+++ b/src/main/java/mezz/jei/input/MouseUtil.java
@@ -7,14 +7,14 @@ public final class MouseUtil {
 	public static double getX() {
 		Minecraft minecraft = Minecraft.getInstance();
 		MouseHelper mouseHelper = minecraft.mouseHelper;
-		double scale = (double) minecraft.func_228018_at_().getScaledWidth() / (double) minecraft.func_228018_at_().getWidth();
+		double scale = (double) minecraft.getMainWindow().getScaledWidth() / (double) minecraft.getMainWindow().getWidth();
 		return mouseHelper.getMouseX() * scale;
 	}
 
 	public static double getY() {
 		Minecraft minecraft = Minecraft.getInstance();
 		MouseHelper mouseHelper = minecraft.mouseHelper;
-		double scale = (double) minecraft.func_228018_at_().getScaledHeight() / (double) minecraft.func_228018_at_().getHeight();
+		double scale = (double) minecraft.getMainWindow().getScaledHeight() / (double) minecraft.getMainWindow().getHeight();
 		return mouseHelper.getMouseY() * scale;
 	}
 }

--- a/src/main/java/mezz/jei/plugins/debug/DebugRecipe.java
+++ b/src/main/java/mezz/jei/plugins/debug/DebugRecipe.java
@@ -1,20 +1,20 @@
 package mezz.jei.plugins.debug;
 
-import net.minecraftforge.fml.client.config.GuiButtonExt;
+import net.minecraftforge.fml.client.gui.widget.ExtendedButton;
 
 import mezz.jei.gui.HoverChecker;
 
 public class DebugRecipe {
-	private final GuiButtonExt button;
+	private final ExtendedButton button;
 	private final HoverChecker buttonHoverChecker;
 
 	public DebugRecipe() {
-		this.button = new GuiButtonExt(0, 0, 40, 20, "test", b -> {});
+		this.button = new ExtendedButton(0, 0, 40, 20, "test", b -> {});
 		this.buttonHoverChecker = new HoverChecker();
 		this.buttonHoverChecker.updateBounds(this.button);
 	}
 
-	public GuiButtonExt getButton() {
+	public ExtendedButton getButton() {
 		return button;
 	}
 

--- a/src/main/java/mezz/jei/plugins/debug/DebugRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/debug/DebugRecipeCategory.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import net.minecraftforge.fml.client.config.GuiButtonExt;
+import net.minecraftforge.fml.client.gui.widget.ExtendedButton;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraft.client.Minecraft;
@@ -123,7 +123,7 @@ public class DebugRecipeCategory implements IRecipeCategory<DebugRecipe> {
 			}
 		}
 
-		GuiButtonExt button = recipe.getButton();
+		ExtendedButton button = recipe.getButton();
 		button.render((int) mouseX, (int) mouseY, 0);
 	}
 
@@ -203,7 +203,7 @@ public class DebugRecipeCategory implements IRecipeCategory<DebugRecipe> {
 
 	@Override
 	public boolean handleClick(DebugRecipe recipe, double mouseX, double mouseY, int mouseButton) {
-		GuiButtonExt button = recipe.getButton();
+		ExtendedButton button = recipe.getButton();
 		if (mouseButton == 0 && button.mouseClicked(mouseX, mouseY, mouseButton)) {
 			Minecraft minecraft = Minecraft.getInstance();
 			ClientPlayerEntity player = minecraft.player;

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -213,7 +213,7 @@ public final class AnvilRecipeMaker {
 			RepairContainer repair = new RepairContainer(0, fakeInventory);
 			repair.inventorySlots.get(0).putStack(leftStack);
 			repair.inventorySlots.get(1).putStack(rightStack);
-			return repair.func_216976_f();
+			return repair.getMaximumCost();
 		} catch (RuntimeException e) {
 			String left = ErrorUtil.getItemStackInfo(leftStack);
 			String right = ErrorUtil.getItemStackInfo(rightStack);

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -73,7 +73,7 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 		ResourceLocation fluidStill = attributes.getStillTexture(ingredient);
 		if (fluidStill != null) {
 			Minecraft minecraft = Minecraft.getInstance();
-			TextureAtlasSprite fluidStillSprite = minecraft.func_228015_a_(PlayerContainer.field_226615_c_).apply(fluidStill);
+			TextureAtlasSprite fluidStillSprite = minecraft.getTextureGetter(PlayerContainer.LOCATION_BLOCKS_TEXTURE).apply(fluidStill);
 			int renderColor = attributes.getColor(ingredient);
 			return ColorGetter.getColors(fluidStillSprite, renderColor, 1);
 		}

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackRenderer.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackRenderer.java
@@ -137,7 +137,7 @@ public class FluidStackRenderer implements IIngredientRenderer<FluidStack> {
 		Fluid fluid = fluidStack.getFluid();
 		FluidAttributes attributes = fluid.getAttributes();
 		ResourceLocation fluidStill = attributes.getStillTexture(fluidStack);
-		return minecraft.func_228015_a_(PlayerContainer.field_226615_c_).apply(fluidStill);
+		return minecraft.getTextureGetter(PlayerContainer.LOCATION_BLOCKS_TEXTURE).apply(fluidStill);
 	}
 
 	private static void setGLColorFromInt(int color) {
@@ -160,10 +160,10 @@ public class FluidStackRenderer implements IIngredientRenderer<FluidStack> {
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder bufferBuilder = tessellator.getBuffer();
 		bufferBuilder.begin(7, DefaultVertexFormats.POSITION_TEX);
-		bufferBuilder.func_225582_a_(xCoord, yCoord + 16, zLevel).func_225583_a_((float) uMin, (float) vMax).endVertex();
-		bufferBuilder.func_225582_a_(xCoord + 16 - maskRight, yCoord + 16, zLevel).func_225583_a_((float) uMax, (float) vMax).endVertex();
-		bufferBuilder.func_225582_a_(xCoord + 16 - maskRight, yCoord + maskTop, zLevel).func_225583_a_((float) uMax, (float) vMin).endVertex();
-		bufferBuilder.func_225582_a_(xCoord, yCoord + maskTop, zLevel).func_225583_a_((float) uMin, (float) vMin).endVertex();
+		bufferBuilder.pos(xCoord, yCoord + 16, zLevel).tex((float) uMin, (float) vMax).endVertex();
+		bufferBuilder.pos(xCoord + 16 - maskRight, yCoord + 16, zLevel).tex((float) uMax, (float) vMax).endVertex();
+		bufferBuilder.pos(xCoord + 16 - maskRight, yCoord + maskTop, zLevel).tex((float) uMax, (float) vMin).endVertex();
+		bufferBuilder.pos(xCoord, yCoord + maskTop, zLevel).tex((float) uMin, (float) vMin).endVertex();
 		tessellator.draw();
 	}
 

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -155,7 +155,7 @@ public class IngredientListBatchRenderer {
 		itemRenderer.zLevel += 50.0F;
 
 		textureManager.bindTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE);
-		textureManager.func_229267_b_(AtlasTexture.LOCATION_BLOCKS_TEXTURE).setBlurMipmapDirect(false, false);
+		textureManager.getTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE).setBlurMipmapDirect(false, false);
 		RenderSystem.enableRescaleNormal();
 		RenderSystem.enableAlphaTest();
 		RenderSystem.alphaFunc(GL11.GL_GREATER, 0.1F);
@@ -170,11 +170,11 @@ public class IngredientListBatchRenderer {
 
 		// 2d Items
 		RenderSystem.disableLighting();
-		RenderHelper.func_227783_c_();
+		RenderHelper.setupGuiFlatDiffuseLighting();
 		for (ItemStackFastRenderer slot : renderItems2d) {
 			slot.renderItemAndEffectIntoGUI(editModeConfig, worldConfig);
 		}
-		RenderHelper.func_227784_d_();
+		RenderHelper.setupGui3DDiffuseLighting();
 
 		RenderSystem.disableAlphaTest();
 		RenderSystem.disableBlend();
@@ -182,7 +182,7 @@ public class IngredientListBatchRenderer {
 		RenderSystem.disableLighting();
 
 		textureManager.bindTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE);
-		textureManager.func_229267_b_(AtlasTexture.LOCATION_BLOCKS_TEXTURE).restoreLastBlurMipmap();
+		textureManager.getTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE).restoreLastBlurMipmap();
 
 		itemRenderer.zLevel -= 50.0F;
 

--- a/src/main/java/mezz/jei/render/IngredientListElementRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListElementRenderer.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraftforge.fml.client.config.GuiUtils;
+import net.minecraftforge.fml.client.gui.GuiUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.screen.Screen;

--- a/src/main/java/mezz/jei/render/ItemStackFastRenderer.java
+++ b/src/main/java/mezz/jei/render/ItemStackFastRenderer.java
@@ -53,13 +53,13 @@ public class ItemStackFastRenderer extends IngredientListElementRenderer<ItemSta
 		}
 
 		MatrixStack matrixStack = new MatrixStack();
-		matrixStack.func_227861_a_(area.getX() + padding + 16, area.getY() + padding, 150); //translate
-		matrixStack.func_227862_a_(16, -16, 16); //scale
-		matrixStack.func_227861_a_(-0.5, -0.5, -0.5); //translate
+		matrixStack.translate(area.getX() + padding + 16, area.getY() + padding, 150);
+		matrixStack.scale(16, -16, 16);
+		matrixStack.translate(-0.5, -0.5, -0.5);
 		Minecraft minecraft = Minecraft.getInstance();
 		ItemRenderer itemRenderer = minecraft.getItemRenderer();
-		IRenderTypeBuffer.Impl iRenderTypeBuffer = Minecraft.getInstance().func_228019_au_().func_228487_b_();
-		itemRenderer.func_229111_a_(itemStack, ItemCameraTransforms.TransformType.GUI, false, matrixStack, iRenderTypeBuffer, 15728880, OverlayTexture.field_229196_a_, bakedModel);
+		IRenderTypeBuffer.Impl iRenderTypeBuffer = minecraft.func_228019_au_().func_228487_b_();
+		itemRenderer.func_229111_a_(itemStack, ItemCameraTransforms.TransformType.GUI, false, matrixStack, iRenderTypeBuffer, 15728880, OverlayTexture.DEFAULT_LIGHT, bakedModel);
 		iRenderTypeBuffer.func_228461_a_();
 
 	}

--- a/src/main/java/mezz/jei/startup/ClientLifecycleHandler.java
+++ b/src/main/java/mezz/jei/startup/ClientLifecycleHandler.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.List;
 import java.util.function.Predicate;
 
-import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.event.world.WorldEvent;
@@ -76,9 +76,9 @@ public class ClientLifecycleHandler {
 		KeyBindings.init();
 
 		clientConfig.onPreInit();
-		EventBusHelper.addListener(ConfigChangedEvent.OnConfigChangedEvent.class, event -> {
+		EventBusHelper.addListener(ModConfig.Reloading.class, event -> {
 			modIdFormattingConfig.checkForModNameFormatOverride();
-			if (ModIds.JEI_ID.equals(event.getModID())) {
+			if (ModIds.JEI_ID.equals(event.getConfig().getModId())) {
 				if (clientConfig.syncAllConfig()) {
 					// todo
 				}

--- a/src/main/java/mezz/jei/util/CommandUtilServer.java
+++ b/src/main/java/mezz/jei/util/CommandUtilServer.java
@@ -113,7 +113,7 @@ public final class CommandUtilServer {
 			}
 			ItemStack itemStackCopy = itemStack.copy();
 			sender.inventory.setInventorySlotContents(hotbarSlot, itemStack);
-			sender.world.playSound(null, sender.func_226277_ct_(), sender.func_226278_cu_(), sender.func_226281_cx_(), SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((sender.getRNG().nextFloat() - sender.getRNG().nextFloat()) * 0.7F + 1.0F) * 2.0F);
+			sender.world.playSound(null, sender.getPosX(), sender.getPosY(), sender.getPosZ(), SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((sender.getRNG().nextFloat() - sender.getRNG().nextFloat()) * 0.7F + 1.0F) * 2.0F);
 			sender.container.detectAndSendChanges();
 			notifyGive(sender, itemStackCopy);
 		} else {
@@ -157,7 +157,7 @@ public final class CommandUtilServer {
 				entityitem.makeFakeItem();
 			}
 
-			entityplayermp.world.playSound(null, entityplayermp.func_226277_ct_(), entityplayermp.func_226278_cu_(), entityplayermp.func_226281_cx_(), SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((entityplayermp.getRNG().nextFloat() - entityplayermp.getRNG().nextFloat()) * 0.7F + 1.0F) * 2.0F);
+			entityplayermp.world.playSound(null, entityplayermp.getPosX(), entityplayermp.getPosY(), entityplayermp.getPosZ(), SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((entityplayermp.getRNG().nextFloat() - entityplayermp.getRNG().nextFloat()) * 0.7F + 1.0F) * 2.0F);
 			entityplayermp.container.detectAndSendChanges();
 		} else {
 			ItemEntity entityitem = entityplayermp.dropItem(itemStack, false);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -7,7 +7,7 @@
 modLoader="javafml" #mandatory
 
 # A version range to match for said mod loader - for regular FML @Mod it will be the minecraft version (without the 1.)
-loaderVersion="[14,)" #mandatory
+loaderVersion="[31,)" #mandatory
 
 # A URL to query for updates for this mod. See the JSON update specification <here>
 #updateJSONURL="" #optional
@@ -48,7 +48,7 @@ JEI is an item and recipe viewing mod for Minecraft, built from the ground up fo
 [[dependencies.jei]]
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[28.1.0,)" #mandatory
+    versionRange="[31.0.0,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER


### PR DESCRIPTION
Changes:
- Updated JEI to 1.15.2
- Updated mappings to 1.15.1 from 1.14.3
- Fix compile issue with maven central now requiring https and JEI referencing it via http
- Comment out a couple config references that are unused currently, and the classes they referenced no longer exist in forge, due to cleanup done in https://github.com/MinecraftForge/MinecraftForge/pull/6437
- Switch reference of now removed `ConfigChangedEvent.OnConfigChangedEvent` to `ModConfig.Reloading`. I am not 100% positive this is the proper replacement and it shouldn't just be commented out for now, but I believe the idea is the same.