### PR TITLE
Add Cosmetic Error Type for RecipeTransferHandler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ curse_project_id=238222
 
 version_major=6
 version_minor=0
-version_patch=0
+version_patch=2

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,3 @@ curse_project_id=238222
 version_major=6
 version_minor=0
 version_patch=2
-

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -26,9 +26,9 @@ public interface IRecipeTransferError {
 		USER_FACING,
 
 		/**
-		 * @since JEI version 6.0.2
 		 * Errors that still allow the usage of the recipe transfer button.
 		 * Hovering over the button will display the error, however the button is active and can be used.
+		 * @since JEI version 6.0.2
 		 */
 		COSMETIC
 

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -26,6 +26,7 @@ public interface IRecipeTransferError {
 		USER_FACING,
 
 		/**
+		 * @since JEI version 6.0.2
 		 * Errors that still allow the usage of the recipe transfer button.
 		 * Hovering over the button will display the error, however the button is active and can be used.
 		 */

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -23,7 +23,14 @@ public interface IRecipeTransferError {
 		 * Errors that the player can fix. Missing items, inventory full, etc.
 		 * Something informative will be shown to the player.
 		 */
-		USER_FACING
+		USER_FACING,
+
+		/**
+		 * Errors that still allow the usage of the recipe transfer button.
+		 * Hovering over the button will display the error, however the button is active and can be used.
+		 */
+		COSMETIC
+
 	}
 
 	Type getType();

--- a/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
@@ -33,7 +33,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 			this.recipeTransferError = RecipeTransferErrorInternal.INSTANCE;
 		}
 
-		if (this.recipeTransferError == null) {
+		if (this.recipeTransferError == null || this.recipeTransferError.getType().equals(IRecipeTransferError.Type.COSMETIC)) {
 			this.active = true;
 			this.visible = true;
 		} else {
@@ -45,11 +45,11 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 
 	public void drawToolTip(int mouseX, int mouseY) {
 		if (isMouseOver(mouseX, mouseY)) {
-			if (recipeTransferError != null) {
-				recipeTransferError.showError(mouseX, mouseY, recipeLayout, recipeLayout.getPosX(), recipeLayout.getPosY());
-			} else {
+			if (recipeTransferError == null || !recipeTransferError.getType().equals(IRecipeTransferError.Type.COSMETIC)) {
 				String tooltipTransfer = Translator.translateToLocal("jei.tooltip.transfer");
 				TooltipRenderer.drawHoveringText(tooltipTransfer, mouseX, mouseY);
+			} else {
+				recipeTransferError.showError(mouseX, mouseY, recipeLayout, recipeLayout.getPosX(), recipeLayout.getPosY());
 			}
 		}
 	}

--- a/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
@@ -33,7 +33,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 			this.recipeTransferError = RecipeTransferErrorInternal.INSTANCE;
 		}
 
-		if (RecipeTransferUtil.allowTransfer(recipeTransferError)) {
+		if (RecipeTransferUtil.allowsTransfer(recipeTransferError)) {
 			this.active = true;
 			this.visible = true;
 		} else {
@@ -45,7 +45,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 
 	public void drawToolTip(int mouseX, int mouseY) {
 		if (isMouseOver(mouseX, mouseY)) {
-			if (RecipeTransferUtil.allowTransfer(recipeTransferError)) {
+			if (RecipeTransferUtil.allowsTransfer(recipeTransferError)) {
 				String tooltipTransfer = Translator.translateToLocal("jei.tooltip.transfer");
 				TooltipRenderer.drawHoveringText(tooltipTransfer, mouseX, mouseY);
 			} else {

--- a/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeTransferButton.java
@@ -33,7 +33,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 			this.recipeTransferError = RecipeTransferErrorInternal.INSTANCE;
 		}
 
-		if (this.recipeTransferError == null || this.recipeTransferError.getType().equals(IRecipeTransferError.Type.COSMETIC)) {
+		if (RecipeTransferUtil.allowTransfer(recipeTransferError)) {
 			this.active = true;
 			this.visible = true;
 		} else {
@@ -45,7 +45,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 
 	public void drawToolTip(int mouseX, int mouseY) {
 		if (isMouseOver(mouseX, mouseY)) {
-			if (recipeTransferError == null || !recipeTransferError.getType().equals(IRecipeTransferError.Type.COSMETIC)) {
+			if (RecipeTransferUtil.allowTransfer(recipeTransferError)) {
 				String tooltipTransfer = Translator.translateToLocal("jei.tooltip.transfer");
 				TooltipRenderer.drawHoveringText(tooltipTransfer, mouseX, mouseY);
 			} else {

--- a/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
+++ b/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
@@ -39,7 +39,7 @@ public final class RecipeTransferUtil {
 
 	public static boolean transferRecipe(RecipeTransferManager recipeTransferManager, Container container, RecipeLayout recipeLayout, PlayerEntity player, boolean maxTransfer) {
 		IRecipeTransferError error = transferRecipe(recipeTransferManager, container, recipeLayout, player, maxTransfer, true);
-		return allowTransfer(error);
+		return allowsTransfer(error);
 	}
 
 	@Nullable
@@ -61,10 +61,10 @@ public final class RecipeTransferUtil {
 		return transferHandler.transferRecipe(container, recipeLayout, player, maxTransfer, doTransfer);
 	}
 
-	public static boolean allowTransfer(@Nullable IRecipeTransferError error){
-		if(error == null){
+	public static boolean allowsTransfer(@Nullable IRecipeTransferError error) {
+		if (error == null) {
 			return true;
-		} else if(error.getType() == IRecipeTransferError.Type.COSMETIC){
+		} else if (error.getType() == IRecipeTransferError.Type.COSMETIC) {
 			return true;
 		}
 		return false;

--- a/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
+++ b/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
@@ -39,7 +39,7 @@ public final class RecipeTransferUtil {
 
 	public static boolean transferRecipe(RecipeTransferManager recipeTransferManager, Container container, RecipeLayout recipeLayout, PlayerEntity player, boolean maxTransfer) {
 		IRecipeTransferError error = transferRecipe(recipeTransferManager, container, recipeLayout, player, maxTransfer, true);
-		return error == null;
+		return error == null || error.getType().equals(IRecipeTransferError.Type.COSMETIC);
 	}
 
 	@Nullable

--- a/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
+++ b/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
@@ -39,7 +39,7 @@ public final class RecipeTransferUtil {
 
 	public static boolean transferRecipe(RecipeTransferManager recipeTransferManager, Container container, RecipeLayout recipeLayout, PlayerEntity player, boolean maxTransfer) {
 		IRecipeTransferError error = transferRecipe(recipeTransferManager, container, recipeLayout, player, maxTransfer, true);
-		return error == null || error.getType().equals(IRecipeTransferError.Type.COSMETIC);
+		return allowTransfer(error);
 	}
 
 	@Nullable
@@ -59,6 +59,15 @@ public final class RecipeTransferUtil {
 
 		//noinspection unchecked
 		return transferHandler.transferRecipe(container, recipeLayout, player, maxTransfer, doTransfer);
+	}
+
+	public static boolean allowTransfer(@Nullable IRecipeTransferError error){
+		if(error == null){
+			return true;
+		} else if(error.getType() == IRecipeTransferError.Type.COSMETIC){
+			return true;
+		}
+		return false;
 	}
 
 	public static class MatchingItemsResult {


### PR DESCRIPTION
This adds an option for custom recipe transfer handler to display an error while keeping the recipe transfer button enabled and usable. 

Example usage: https://gfycat.com/UnpleasantSomeDutchshepherddog