### PR TITLE
Add mouse-aware getGuiClickableAreas to the API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ curse_project_id=238222
 
 version_major=6
 version_minor=0
-version_patch=0
+version_patch=1

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -15,8 +15,20 @@ public interface IGuiClickableArea {
 	 * The hover/click area for this {@link IGuiClickableArea}.
 	 * When hovered, the message from {@link #getTooltipStrings()} will be displayed.
 	 * When clicked, {@link #onClick(IFocusFactory, IRecipesGui)} will be called.
+	 * @deprecated Prefer and implement {@link #isMouseOver(double, double)} instead.
 	 */
+	@Deprecated//TODO 1.16: Remove this and make isMouseOver no longer defaulted
 	Rectangle2d getArea();
+
+	/**
+	 * Used to check if the mouse is currently over the hover/click area for this {@link IGuiClickableArea}.
+	 * When hovered, the message from {@link #getTooltipStrings()} will be displayed.
+	 * When clicked, {@link #onClick(IFocusFactory, IRecipesGui)} will be called.
+	 */
+	default boolean isMouseOver(double mouseX, double mouseY) {
+		Rectangle2d area = getArea();
+		return mouseX >= area.getX() && mouseY >= area.getY() && mouseX < area.getX() + area.getWidth() && mouseY < area.getY() + area.getHeight();
+	}
 
 	/**
 	 * Returns the strings to be shown on the tooltip when this area is hovered over.
@@ -43,8 +55,14 @@ public interface IGuiClickableArea {
 		Collections.addAll(recipeCategoryUidList, recipeCategoryUids);
 		return new IGuiClickableArea() {
 			@Override
+			@Deprecated
 			public Rectangle2d getArea() {
 				return area;
+			}
+
+			@Override
+			public boolean isMouseOver(double mouseX, double mouseY) {
+				return mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height;
 			}
 
 			@Override

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -19,18 +19,6 @@ public interface IGuiClickableArea {
 	Rectangle2d getArea();
 
 	/**
-	 * Used to check if the mouse is currently over the hover/click area for this {@link IGuiClickableArea}.
-	 * When hovered, the message from {@link #getTooltipStrings()} will be displayed.
-	 * When clicked, {@link #onClick(IFocusFactory, IRecipesGui)} will be called.
-	 *
-	 * @since JEI version 6.0.1
-	 */
-	default boolean isMouseOver(double mouseX, double mouseY) {
-		Rectangle2d area = getArea();
-		return mouseX >= area.getX() && mouseY >= area.getY() && mouseX < area.getX() + area.getWidth() && mouseY < area.getY() + area.getHeight();
-	}
-
-	/**
 	 * Returns the strings to be shown on the tooltip when this area is hovered over.
 	 * Return an empty list to display the default "Show Recipes" message.
 	 */

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -22,6 +22,8 @@ public interface IGuiClickableArea {
 	 * Used to check if the mouse is currently over the hover/click area for this {@link IGuiClickableArea}.
 	 * When hovered, the message from {@link #getTooltipStrings()} will be displayed.
 	 * When clicked, {@link #onClick(IFocusFactory, IRecipesGui)} will be called.
+	 *
+	 * @since JEI version 6.0.1
 	 */
 	default boolean isMouseOver(double mouseX, double mouseY) {
 		Rectangle2d area = getArea();

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -15,9 +15,7 @@ public interface IGuiClickableArea {
 	 * The hover/click area for this {@link IGuiClickableArea}.
 	 * When hovered, the message from {@link #getTooltipStrings()} will be displayed.
 	 * When clicked, {@link #onClick(IFocusFactory, IRecipesGui)} will be called.
-	 * @deprecated Prefer and implement {@link #isMouseOver(double, double)} instead.
 	 */
-	@Deprecated//TODO 1.16: Remove this and make isMouseOver no longer defaulted
 	Rectangle2d getArea();
 
 	/**
@@ -55,14 +53,8 @@ public interface IGuiClickableArea {
 		Collections.addAll(recipeCategoryUidList, recipeCategoryUids);
 		return new IGuiClickableArea() {
 			@Override
-			@Deprecated
 			public Rectangle2d getArea() {
 				return area;
-			}
-
-			@Override
-			public boolean isMouseOver(double mouseX, double mouseY) {
-				return mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height;
 			}
 
 			@Override

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
@@ -45,8 +45,23 @@ public interface IGuiContainerHandler<T extends ContainerScreen> {
 	/**
 	 * Return the JEI-controlled clickable areas for this GUI.
 	 * This is useful when you want to add a spot on your GUI that opens JEI and shows recipes.
+	 *
+	 * @deprecated Prefer and implement {@link #getGuiClickableArea(ContainerScreen, double, double)} instead.
 	 */
+	@Deprecated//TODO 1.16: Remove this in favor of getGuiClickableArea, changing that to default to returning null
 	default Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen) {
 		return Collections.emptyList();
+	}
+
+	/**
+	 * Return the JEI-controlled clickable area currently under the mouse for this GUI.
+	 * This is useful when you want to add a spot on your GUI that opens JEI and shows recipes.
+	 *
+	 * @param mouseX the current X position of the mouse in screen coordinates.
+	 * @param mouseY the current Y position of the mouse in screen coordinates.
+	 */
+	@Nullable
+	default IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
+		return getGuiClickableAreas(containerScreen).stream().filter(guiClickableArea -> guiClickableArea.isMouseOver(mouseX, mouseY)).findFirst().orElse(null);
 	}
 }

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
@@ -46,7 +46,7 @@ public interface IGuiContainerHandler<T extends ContainerScreen> {
 	 * Return the JEI-controlled clickable areas for this GUI.
 	 * This is useful when you want to add a spot on your GUI that opens JEI and shows recipes.
 	 *
-	 * @deprecated Prefer and implement {@link #getGuiClickableArea(ContainerScreen, double, double)} instead.
+	 * @deprecated since JEI version 6.0.1. Prefer and implement {@link #getGuiClickableArea(ContainerScreen, double, double)} instead.
 	 */
 	@Deprecated
 	default Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen) {

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
@@ -62,6 +62,13 @@ public interface IGuiContainerHandler<T extends ContainerScreen> {
 	 */
 	@Nullable
 	default IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
-		return getGuiClickableAreas(containerScreen).stream().filter(guiClickableArea -> guiClickableArea.isMouseOver(mouseX, mouseY)).findFirst().orElse(null);
+		Collection<IGuiClickableArea> guiClickableAreas = getGuiClickableAreas(containerScreen);
+		for (IGuiClickableArea guiClickableArea : guiClickableAreas) {
+			Rectangle2d area = guiClickableArea.getArea();
+			if (mouseX >= area.getX() && mouseY >= area.getY() && mouseX < area.getX() + area.getWidth() && mouseY < area.getY() + area.getHeight()) {
+				return guiClickableArea;
+			}
+		}
+		return null;
 	}
 }

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
@@ -46,7 +46,7 @@ public interface IGuiContainerHandler<T extends ContainerScreen> {
 	 * Return the JEI-controlled clickable areas for this GUI.
 	 * This is useful when you want to add a spot on your GUI that opens JEI and shows recipes.
 	 *
-	 * @deprecated since JEI version 6.0.1. Prefer and implement {@link #getGuiClickableArea(ContainerScreen, double, double)} instead.
+	 * @deprecated since JEI version 6.0.1. Prefer and implement {@link #getGuiClickableAreas(ContainerScreen, double, double)} instead.
 	 */
 	@Deprecated
 	default Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen) {
@@ -54,21 +54,13 @@ public interface IGuiContainerHandler<T extends ContainerScreen> {
 	}
 
 	/**
-	 * Return the JEI-controlled clickable area currently under the mouse for this GUI.
+	 * Return the JEI-controlled clickable areas for this GUI.
 	 * This is useful when you want to add a spot on your GUI that opens JEI and shows recipes.
 	 *
-	 * @param mouseX the current X position of the mouse in screen coordinates.
-	 * @param mouseY the current Y position of the mouse in screen coordinates.
+	 * Optionally, you can restrict what you return here based on the current mouse position.
+	 * @since JEI version 6.0.1
 	 */
-	@Nullable
-	default IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
-		Collection<IGuiClickableArea> guiClickableAreas = getGuiClickableAreas(containerScreen);
-		for (IGuiClickableArea guiClickableArea : guiClickableAreas) {
-			Rectangle2d area = guiClickableArea.getArea();
-			if (mouseX >= area.getX() && mouseY >= area.getY() && mouseX < area.getX() + area.getWidth() && mouseY < area.getY() + area.getHeight()) {
-				return guiClickableArea;
-			}
-		}
-		return null;
+	default Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen, double mouseX, double mouseY) {
+		return getGuiClickableAreas(containerScreen);
 	}
 }

--- a/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
+++ b/src/api/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java
@@ -48,7 +48,7 @@ public interface IGuiContainerHandler<T extends ContainerScreen> {
 	 *
 	 * @deprecated Prefer and implement {@link #getGuiClickableArea(ContainerScreen, double, double)} instead.
 	 */
-	@Deprecated//TODO 1.16: Remove this in favor of getGuiClickableArea, changing that to default to returning null
+	@Deprecated
 	default Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen) {
 		return Collections.emptyList();
 	}

--- a/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
@@ -1,8 +1,6 @@
 package mezz.jei.api.registration;
 
-import java.util.Collection;
-import java.util.Collections;
-
+import javax.annotation.Nullable;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.inventory.ContainerScreen;
 import net.minecraft.util.ResourceLocation;
@@ -44,10 +42,13 @@ public interface IGuiHandlerRegistration {
 	 */
 	default <T extends ContainerScreen<?>> void addRecipeClickArea(Class<? extends T> guiContainerClass, int xPos, int yPos, int width, int height, ResourceLocation... recipeCategoryUids) {
 		this.addGuiContainerHandler(guiContainerClass, new IGuiContainerHandler<T>() {
+			@Nullable
 			@Override
-			public Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen) {
-				IGuiClickableArea clickableArea = IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
-				return Collections.singleton(clickableArea);
+			public IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
+				if (mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height) {
+					return IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
+				}
+				return null;
 			}
 		});
 	}

--- a/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
@@ -45,8 +45,9 @@ public interface IGuiHandlerRegistration {
 			@Nullable
 			@Override
 			public IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
-				if (mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height) {
-					return IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
+				IGuiClickableArea clickableArea = IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
+				if (clickableArea.isMouseOver(mouseX, mouseY)) {
+					return clickableArea;
 				}
 				return null;
 			}

--- a/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
@@ -1,6 +1,8 @@
 package mezz.jei.api.registration;
 
-import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.inventory.ContainerScreen;
 import net.minecraft.util.ResourceLocation;
@@ -42,13 +44,10 @@ public interface IGuiHandlerRegistration {
 	 */
 	default <T extends ContainerScreen<?>> void addRecipeClickArea(Class<? extends T> guiContainerClass, int xPos, int yPos, int width, int height, ResourceLocation... recipeCategoryUids) {
 		this.addGuiContainerHandler(guiContainerClass, new IGuiContainerHandler<T>() {
-			@Nullable
 			@Override
-			public IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
-				if (mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height) {
-					return IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
-				}
-				return null;
+			public Collection<IGuiClickableArea> getGuiClickableAreas(T containerScreen, double mouseX, double mouseY) {
+				IGuiClickableArea clickableArea = IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
+				return Collections.singleton(clickableArea);
 			}
 		});
 	}

--- a/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IGuiHandlerRegistration.java
@@ -45,9 +45,8 @@ public interface IGuiHandlerRegistration {
 			@Nullable
 			@Override
 			public IGuiClickableArea getGuiClickableArea(T containerScreen, double mouseX, double mouseY) {
-				IGuiClickableArea clickableArea = IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
-				if (clickableArea.isMouseOver(mouseX, mouseY)) {
-					return clickableArea;
+				if (mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height) {
+					return IGuiClickableArea.createBasic(xPos, yPos, width, height, recipeCategoryUids);
 				}
 				return null;
 			}

--- a/src/main/java/mezz/jei/gui/GuiScreenHelper.java
+++ b/src/main/java/mezz/jei/gui/GuiScreenHelper.java
@@ -208,13 +208,7 @@ public class GuiScreenHelper {
 	@Nullable
 	private static <T extends ContainerScreen> IGuiClickableArea getGuiClickableArea(Class<? extends T> handlerClass, IGuiContainerHandler<T> handler, ContainerScreen containerScreen, double mouseX, double mouseY) {
 		if (handlerClass.isInstance(containerScreen)) {
-			T castContainer = handlerClass.cast(containerScreen);
-			Collection<IGuiClickableArea> guiClickableAreas = handler.getGuiClickableAreas(castContainer);
-			for (IGuiClickableArea guiClickableArea : guiClickableAreas) {
-				if (MathUtil.contains(guiClickableArea.getArea(), mouseX, mouseY)) {
-					return guiClickableArea;
-				}
-			}
+			return handler.getGuiClickableArea(handlerClass.cast(containerScreen), mouseX, mouseY);
 		}
 		return null;
 	}

--- a/src/main/java/mezz/jei/gui/GuiScreenHelper.java
+++ b/src/main/java/mezz/jei/gui/GuiScreenHelper.java
@@ -209,7 +209,12 @@ public class GuiScreenHelper {
 	private static <T extends ContainerScreen> IGuiClickableArea getGuiClickableArea(Class<? extends T> handlerClass, IGuiContainerHandler<T> handler, ContainerScreen containerScreen, double mouseX, double mouseY) {
 		if (handlerClass.isInstance(containerScreen)) {
 			T castContainer = handlerClass.cast(containerScreen);
-			return handler.getGuiClickableArea(castContainer, mouseX, mouseY);
+			Collection<IGuiClickableArea> guiClickableAreas = handler.getGuiClickableAreas(castContainer, mouseX, mouseY);
+			for (IGuiClickableArea guiClickableArea : guiClickableAreas) {
+				if (MathUtil.contains(guiClickableArea.getArea(), mouseX, mouseY)) {
+					return guiClickableArea;
+				}
+			}
 		}
 		return null;
 	}

--- a/src/main/java/mezz/jei/gui/GuiScreenHelper.java
+++ b/src/main/java/mezz/jei/gui/GuiScreenHelper.java
@@ -208,7 +208,8 @@ public class GuiScreenHelper {
 	@Nullable
 	private static <T extends ContainerScreen> IGuiClickableArea getGuiClickableArea(Class<? extends T> handlerClass, IGuiContainerHandler<T> handler, ContainerScreen containerScreen, double mouseX, double mouseY) {
 		if (handlerClass.isInstance(containerScreen)) {
-			return handler.getGuiClickableArea(handlerClass.cast(containerScreen), mouseX, mouseY);
+			T castContainer = handlerClass.cast(containerScreen);
+			return handler.getGuiClickableArea(castContainer, mouseX, mouseY);
 		}
 		return null;
 	}


### PR DESCRIPTION
Modify the API around `IGuiClickableArea` to allow for custom GUI container handlers to have clickable areas that are only sometimes accessible. The use case I have in mind if for Mekanism V10, where our GUI's have the ability to create "popup windows" on top of them, ideally I would like to be able to have the recipe clickable areas not display or be interacted with when the "popup window" is over the area.

This PR modifies the way that `IGuiClickableArea` is interacted with in a backwards compatible way (with TODOs to remove the old methods in the port to 1.16).