### PR TITLE
Fix ghost ingredient target and hover highlighting

### DIFF
--- a/src/main/java/mezz/jei/gui/ghost/GhostIngredientDrag.java
+++ b/src/main/java/mezz/jei/gui/ghost/GhostIngredientDrag.java
@@ -16,8 +16,8 @@ import mezz.jei.util.MathUtil;
 import org.lwjgl.opengl.GL11;
 
 public class GhostIngredientDrag<T> {
-	private static final int targetColor = 0x13C90A;
-	private static final int hoverColor = 0x4CC919;
+	private static final int targetColor = 0x4013C90A;
+	private static final int hoverColor = 0x804CC919;
 
 	private final IGhostIngredientHandler<?> handler;
 	private final List<Target<T>> targets;


### PR DESCRIPTION
I started work on implementing ghost slots and was wondering why the highlighting wasn't working and managed to track it down to the lack of an alpha value in the target and hover colors. The values I set it to mirror the alpha values that JEI for 1.12 uses.