### PR TITLE
Update Polish translation

### DIFF
--- a/src/main/resources/assets/jei/lang/pl_pl.lang
+++ b/src/main/resources/assets/jei/lang/pl_pl.lang
@@ -101,8 +101,8 @@ config.jei.advanced.maxRecipeGuiHeight=Maksymalna wysokość interfejsu
 config.jei.advanced.maxRecipeGuiHeight.comment=Maksymalna wysokość interfejsu z recepturami.
 config.jei.advanced.giveMode=Tryb dawania
 config.jei.advanced.giveMode.comment=Zdecyduj, czy JEI ma dawać składniki bezpośrednio do ekwipunku (inventory), czy chcesz zabierać i przenosić je samemu (mouse_pickup).
-config.jei.advanced.optimizeMemoryUsage=Optymalizacja zużycia pamięci
-config.jei.advanced.optimizeMemoryUsage.comment=Włącz optymalizacje zużycia pamięci przez JEI.
+config.jei.advanced.optimizeMemoryUsage=Optymalizacja użycia pamięci
+config.jei.advanced.optimizeMemoryUsage.comment=Włącz optymalizacje użycia pamięci przez JEI.
 
 # Hide Ingredients Mode
 gui.jei.editMode.description=Tryb ukrywania składników JEI:


### PR DESCRIPTION
In this commit I updated the Polish translation in the 1.12 branch. If you still support it, here is a comment about the changes.

Since word "zużycie" can also mean destroying something via using it, I don't like it in this case, so I changed it. Word "wykorzystanie" (like in the Windows Task Manager) would also suit here, but it is unnecessarily longer.