### PR TITLE
Allow anvil recipes with no item in the right input slot

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaRecipeFactory.java
@@ -26,7 +26,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 	@Override
 	public AnvilRecipe createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		ErrorUtil.checkNotEmpty(leftInput, "leftInput");
-		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
+		ErrorUtil.checkNotNull(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 
 		return new AnvilRecipe(Collections.singletonList(leftInput), rightInputs, outputs);
@@ -35,7 +35,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 	@Override
 	public AnvilRecipe createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs) {
 		ErrorUtil.checkNotEmpty(leftInputs, "leftInput");
-		ErrorUtil.checkNotEmpty(rightInputs, "rightInputs");
+		ErrorUtil.checkNotNull(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 
 		return new AnvilRecipe(leftInputs, rightInputs, outputs);

--- a/src/main/java/mezz/jei/util/ErrorUtil.java
+++ b/src/main/java/mezz/jei/util/ErrorUtil.java
@@ -226,6 +226,18 @@ public final class ErrorUtil {
 		}
 	}
 
+	public static void checkNotNull(@Nullable Collection<?> values, String name) {
+		if (values == null) {
+			throw new NullPointerException(name + " must not be null.");
+		} else if (!(values instanceof NonNullList)) {
+			for (Object value : values) {
+				if (value == null) {
+					throw new NullPointerException(name + " must not contain null values.");
+				}
+			}
+		}
+	}
+
 	public static <T> void checkIsValidIngredient(@Nullable T ingredient, String name) {
 		checkNotNull(ingredient, name);
 		IngredientManager ingredientManager = Internal.getIngredientManager();


### PR DESCRIPTION
Talked to you, mezz, about this a week or so ago.
If the new collection null check in ErrorUtil is unnecessary for some reason I'll get rid of it, I figured that we still wanted to make sure that no null snuck in.

![image](https://user-images.githubusercontent.com/20242421/89734041-d218b300-da59-11ea-911d-31035e824e49.png)
