### PR TITLE
Fix fractional text rendering

### DIFF
--- a/src/main/java/mezz/jei/gui/recipes/RecipeCategoryTab.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeCategoryTab.java
@@ -62,10 +62,10 @@ public class RecipeCategoryTab extends RecipeGuiTab {
 				String text = category.getTitle().substring(0, 2);
 				Minecraft minecraft = Minecraft.getInstance();
 				FontRenderer fontRenderer = minecraft.fontRenderer;
-				float textCenterX = x + (TAB_WIDTH / 2f);
-				float textCenterY = y + (TAB_HEIGHT / 2f) - 3;
+				int textCenterX = x + (TAB_WIDTH / 2);
+				int textCenterY = y + (TAB_HEIGHT / 2) - 3;
 				int color = isMouseOver(mouseX, mouseY) ? 0xFFFFA0 : 0xE0E0E0;
-				fontRenderer.func_238405_a_(matrixStack, text, textCenterX - fontRenderer.getStringWidth(text) / 2f, textCenterY, color);
+				fontRenderer.func_238405_a_(matrixStack, text, textCenterX - fontRenderer.getStringWidth(text) / 2, textCenterY, color);
 				RenderSystem.color4f(1, 1, 1, 1);
 			}
 		}

--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -105,7 +105,7 @@ public class RecipesGui extends Screen implements IRecipesGui, IShowsRecipeFocus
 	}
 
 	private static void drawCenteredStringWithShadow(MatrixStack matrixStack, FontRenderer font, String string, int guiWidth, int xOffset, int yPos, int color) {
-		font.func_238405_a_(matrixStack, string, (guiWidth - font.getStringWidth(string)) / 2.0f + xOffset, yPos, color);
+		font.func_238405_a_(matrixStack, string, (guiWidth - font.getStringWidth(string)) / 2 + xOffset, yPos, color);
 	}
 
 	public int getGuiLeft() {


### PR DESCRIPTION
This PR corrects the fractional positions passed into the font renderer resulting in raster artifacts:

**Before**:

![image](https://user-images.githubusercontent.com/5201207/90838896-f18dc680-e30a-11ea-833c-9c3be1649fc9.png)

**After**:

![image](https://user-images.githubusercontent.com/5201207/90838903-f6527a80-e30a-11ea-8fa4-b8d6ed803be7.png)
