### PR TITLE
[1.16] fix shading bug of ItemMultiLayerBakedModel

### DIFF
--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -22,7 +22,6 @@ import mezz.jei.config.IWorldConfig;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.input.ClickedIngredient;
 import mezz.jei.util.ErrorUtil;
-import net.minecraftforge.client.model.ItemMultiLayerBakedModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.GL11;

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -111,7 +111,7 @@ public class IngredientListBatchRenderer {
 			if (!bakedModel.isBuiltInRenderer() && !(itemStack.getItem() instanceof ISlowRenderItem)) {
 				ItemStackFastRenderer renderer = new ItemStackFastRenderer(itemStackElement);
 				ingredientListSlot.setIngredientRenderer(renderer);
-				if (bakedModel.func_230044_c_()) {
+				if (bakedModel.func_230044_c_()) { //isSideLit
 					renderItems3d.add(renderer);
 				} else {
 					renderItems2d.add(renderer);

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -112,7 +112,7 @@ public class IngredientListBatchRenderer {
 			if (!bakedModel.isBuiltInRenderer() && !(itemStack.getItem() instanceof ISlowRenderItem)) {
 				ItemStackFastRenderer renderer = new ItemStackFastRenderer(itemStackElement);
 				ingredientListSlot.setIngredientRenderer(renderer);
-				if (bakedModel.isGui3d() && !(bakedModel instanceof ItemMultiLayerBakedModel)) {
+				if (bakedModel.func_230044_c_()) {
 					renderItems3d.add(renderer);
 				} else {
 					renderItems2d.add(renderer);

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -22,6 +22,7 @@ import mezz.jei.config.IWorldConfig;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.input.ClickedIngredient;
 import mezz.jei.util.ErrorUtil;
+import net.minecraftforge.client.model.ItemMultiLayerBakedModel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.GL11;
@@ -111,7 +112,7 @@ public class IngredientListBatchRenderer {
 			if (!bakedModel.isBuiltInRenderer() && !(itemStack.getItem() instanceof ISlowRenderItem)) {
 				ItemStackFastRenderer renderer = new ItemStackFastRenderer(itemStackElement);
 				ingredientListSlot.setIngredientRenderer(renderer);
-				if (bakedModel.isGui3d()) {
+				if (bakedModel.isGui3d() && !(bakedModel instanceof ItemMultiLayerBakedModel)) {
 					renderItems3d.add(renderer);
 				} else {
 					renderItems2d.add(renderer);


### PR DESCRIPTION
Bugfix for the issue https://github.com/mezz/JustEnoughItems/issues/2087
It is a bit hacky but it works for all classes that use the `ItemMultiLayerBakedModel`. It can be undone when Forge fixed the wrong return value of the `isGui3d()` method.