### PR TITLE
Add 1.16.3 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,18 @@ dependencies {
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 
+processResources {
+	from(sourceSets.main.resources.srcDirs) {
+		include 'META-INF/mods.toml'
+
+		expand 'version': version, 'forgeversion_min': forgeversion_min, 'forgeversion_max': forgeversion_max, 'mcversion_min': mcversion_min, 'mcversion_max': mcversion_max
+	}
+
+	from(sourceSets.main.resources.srcDirs) {
+		exclude 'META-INF/mods.toml'
+	}
+}
+
 minecraft {
 	mappings channel: "snapshot", version: project.mcp_mappings
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,11 @@
 org.gradle.daemon=false
 
-mcversion=1.16.2
-forgeversion=33.0.19
+mcversion_min=1.16.2
+mcversion=1.16.3
+mcversion_max=1.17
+forgeversion_min=33.0.19
+forgeversion=34.0.7
+forgeversion_max=35.0.0
 forgegroup=net.minecraftforge
 mcp_mappings=20200723-1.16.1
 curse_project_id=238222

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -37,7 +37,7 @@ authors="mezz" #optional
 modId="jei" #mandatory
 
 # The version number of the mod
-version="${file.jarVersion}" #mandatory
+version="${version}" #mandatory
 
 # A display name for the mod
 displayName="Just Enough Items" #mandatory
@@ -51,7 +51,16 @@ JEI is an item and recipe viewing mod for Minecraft, built from the ground up fo
 [[dependencies.jei]]
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[33.0.0,)" #mandatory
+    versionRange="[${forgeversion_min},${forgeversion_max})" #mandatory
+    # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
+    ordering="NONE"
+    # Side this dependency is applied on - BOTH, CLIENT or SERVER
+    side="BOTH"
+
+[[dependencies.jei]]
+    modId="minecraft" #mandatory
+    mandatory=true #mandatory
+    versionRange="[${mcversion_min},${mcversion_max})" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER


### PR DESCRIPTION
mods.toml's version field was not being updated.
Mod loads on both 1.16.2 (forge 33.0.19) and 1.16.3 (forge 34.0.7).

Upper bound on minecraft version set to any 1.16.x version greater than
or equal to 1.16.2, may need finer tuning if a 1.16.4 version comes out
that breaks it.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>