### PR TITLE
[1.16] Optimize item stack rendering

### DIFF
--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.ItemModelMesher;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.RenderHelper;
@@ -156,6 +157,8 @@ public class IngredientListBatchRenderer {
 		TextureManager textureManager = minecraft.getTextureManager();
 		itemRenderer.zLevel += 50.0F;
 
+		IRenderTypeBuffer.Impl buffer = Minecraft.getInstance().getRenderTypeBuffers().getBufferSource();
+
 		textureManager.bindTexture(PlayerContainer.LOCATION_BLOCKS_TEXTURE);
 		textureManager.getTexture(PlayerContainer.LOCATION_BLOCKS_TEXTURE).setBlurMipmapDirect(false, false);
 		RenderSystem.enableRescaleNormal();
@@ -167,15 +170,17 @@ public class IngredientListBatchRenderer {
 		// 3d Items
 		RenderSystem.enableLighting();
 		for (ItemStackFastRenderer slot : renderItems3d) {
-			slot.renderItemAndEffectIntoGUI(matrixStack, editModeConfig, worldConfig);
+			slot.renderItemAndEffectIntoGUI(buffer, matrixStack, editModeConfig, worldConfig);
 		}
+		buffer.finish();
 
 		// 2d Items
 		RenderSystem.disableLighting();
 		RenderHelper.setupGuiFlatDiffuseLighting();
 		for (ItemStackFastRenderer slot : renderItems2d) {
-			slot.renderItemAndEffectIntoGUI(matrixStack, editModeConfig, worldConfig);
+			slot.renderItemAndEffectIntoGUI(buffer, matrixStack, editModeConfig, worldConfig);
 		}
+		buffer.finish();
 		RenderHelper.setupGui3DDiffuseLighting();
 
 		RenderSystem.disableAlphaTest();

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -157,7 +157,7 @@ public class IngredientListBatchRenderer {
 		TextureManager textureManager = minecraft.getTextureManager();
 		itemRenderer.zLevel += 50.0F;
 
-		IRenderTypeBuffer.Impl buffer = Minecraft.getInstance().getRenderTypeBuffers().getBufferSource();
+		IRenderTypeBuffer.Impl buffer = minecraft.getRenderTypeBuffers().getBufferSource();
 
 		textureManager.bindTexture(PlayerContainer.LOCATION_BLOCKS_TEXTURE);
 		textureManager.getTexture(PlayerContainer.LOCATION_BLOCKS_TEXTURE).setBlurMipmapDirect(false, false);

--- a/src/main/java/mezz/jei/render/ItemStackFastRenderer.java
+++ b/src/main/java/mezz/jei/render/ItemStackFastRenderer.java
@@ -24,9 +24,9 @@ public class ItemStackFastRenderer extends IngredientListElementRenderer<ItemSta
 		super(itemStackElement);
 	}
 
-	public void renderItemAndEffectIntoGUI(MatrixStack matrixStack, IEditModeConfig editModeConfig, IWorldConfig worldConfig) {
+	public void renderItemAndEffectIntoGUI(IRenderTypeBuffer buffer, MatrixStack matrixStack, IEditModeConfig editModeConfig, IWorldConfig worldConfig) {
 		try {
-			uncheckedRenderItemAndEffectIntoGUI(matrixStack, editModeConfig, worldConfig);
+			uncheckedRenderItemAndEffectIntoGUI(buffer, matrixStack, editModeConfig, worldConfig);
 		} catch (RuntimeException | LinkageError e) {
 			throw ErrorUtil.createRenderIngredientException(e, element.getIngredient());
 		}
@@ -40,7 +40,7 @@ public class ItemStackFastRenderer extends IngredientListElementRenderer<ItemSta
 		return bakedModel.getOverrides().func_239290_a_(bakedModel, itemStack, null, null);
 	}
 
-	private void uncheckedRenderItemAndEffectIntoGUI(MatrixStack matrixStack, IEditModeConfig editModeConfig, IWorldConfig worldConfig) {
+	private void uncheckedRenderItemAndEffectIntoGUI(IRenderTypeBuffer buffer, MatrixStack matrixStack, IEditModeConfig editModeConfig, IWorldConfig worldConfig) {
 		if (worldConfig.isEditModeEnabled()) {
 			renderEditMode(matrixStack, area, padding, editModeConfig);
 			RenderSystem.enableBlend();
@@ -58,11 +58,8 @@ public class ItemStackFastRenderer extends IngredientListElementRenderer<ItemSta
 		matrixStack.translate(-0.5, -0.5, -0.5);
 		Minecraft minecraft = Minecraft.getInstance();
 		ItemRenderer itemRenderer = minecraft.getItemRenderer();
-		IRenderTypeBuffer.Impl iRenderTypeBuffer = minecraft.getRenderTypeBuffers().getBufferSource();
-		itemRenderer.renderItem(itemStack, ItemCameraTransforms.TransformType.GUI, false, matrixStack, iRenderTypeBuffer, 15728880, OverlayTexture.NO_OVERLAY, bakedModel);
-		iRenderTypeBuffer.finish();
+		itemRenderer.renderItem(itemStack, ItemCameraTransforms.TransformType.GUI, false, matrixStack, buffer, 15728880, OverlayTexture.NO_OVERLAY, bakedModel);
 		matrixStack.pop();
-
 	}
 
 	public void renderOverlay() {


### PR DESCRIPTION
**This PR adds:**
- Batch rendering of item stacks using `IRenderTypeBuffer`

This change halves the time it takes to render item stacks in the overlay. Data is based on Minecraft's in-game frame time graph.

**Before:**
![image](https://user-images.githubusercontent.com/19599406/97068928-be70e900-1580-11eb-9763-1e9977ed017c.png)

**After:**
![image](https://user-images.githubusercontent.com/19599406/97068930-c3ce3380-1580-11eb-81cc-bdcb2a4607f7.png)
