### PR TITLE
Implement event system ownership tracking (fix memory leak on reload)

### DIFF
--- a/src/main/java/mezz/jei/JustEnoughItems.java
+++ b/src/main/java/mezz/jei/JustEnoughItems.java
@@ -33,7 +33,7 @@ public class JustEnoughItems {
 	private static void clientStart(IEventBus modEventBus, NetworkHandler networkHandler) {
 		JEIClientConfig.register();
 
-		EventBusHelper.addListener(modEventBus, ColorHandlerEvent.Block.class, setupEvent -> {
+		EventBusHelper.addListener(JustEnoughItems.class, modEventBus, ColorHandlerEvent.Block.class, setupEvent -> {
 			Minecraft minecraft = Minecraft.getInstance();
 			JeiSpriteUploader spriteUploader = new JeiSpriteUploader(minecraft.textureManager);
 			Textures textures = new Textures(spriteUploader);
@@ -42,17 +42,17 @@ public class JustEnoughItems {
 				IReloadableResourceManager reloadableResourceManager = (IReloadableResourceManager) resourceManager;
 				reloadableResourceManager.addReloadListener(spriteUploader);
 			}
-			EventBusHelper.addLifecycleListener(modEventBus, FMLLoadCompleteEvent.class, loadCompleteEvent ->
+			EventBusHelper.addLifecycleListener(JustEnoughItems.class, modEventBus, FMLLoadCompleteEvent.class, loadCompleteEvent ->
 				new ClientLifecycleHandler(networkHandler, textures)
 			);
-			EventBusHelper.addLifecycleListener(modEventBus, FMLClientSetupEvent.class, event ->
+			EventBusHelper.addLifecycleListener(JustEnoughItems.class, modEventBus, FMLClientSetupEvent.class, event ->
 				GoVoteHandler.init()
 			);
 		});
 	}
 
 	private static void commonStart(IEventBus modEventBus, NetworkHandler networkHandler) {
-		EventBusHelper.addLifecycleListener(modEventBus, FMLCommonSetupEvent.class, event ->
+		EventBusHelper.addLifecycleListener(JustEnoughItems.class, modEventBus, FMLCommonSetupEvent.class, event ->
 			networkHandler.createServerPacketHandler()
 		);
 	}

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -90,12 +90,12 @@ public class IngredientFilter implements IIngredientGridSource {
 			this.elementSearch.registerPrefix(prefixInfo);
 		}
 
-		EventBusHelper.addListener(EditModeToggleEvent.class, editModeToggleEvent -> {
+		EventBusHelper.addListener(this, EditModeToggleEvent.class, editModeToggleEvent -> {
 			this.filterCached = null;
 			updateHidden();
 		});
 
-		EventBusHelper.addListener(PlayerJoinedWorldEvent.class, playerJoinedWorldEvent -> {
+		EventBusHelper.addListener(this, PlayerJoinedWorldEvent.class, playerJoinedWorldEvent -> {
 			this.filterCached = null;
 			updateHidden();
 		});

--- a/src/main/java/mezz/jei/ingredients/IngredientFilterBackgroundBuilder.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilterBackgroundBuilder.java
@@ -32,7 +32,7 @@ public class IngredientFilterBackgroundBuilder {
 	public void start() {
 		boolean finished = run(10000);
 		if (!finished) {
-			EventBusHelper.addListener(TickEvent.ClientTickEvent.class, this.onTickHandler);
+			EventBusHelper.addListener(this, TickEvent.ClientTickEvent.class, this.onTickHandler);
 		}
 	}
 
@@ -43,7 +43,7 @@ public class IngredientFilterBackgroundBuilder {
 				return;
 			}
 		}
-		EventBusHelper.removeListener(this.onTickHandler);
+		EventBusHelper.removeListener(this, this.onTickHandler);
 	}
 
 	private boolean run(final int timeoutMs) {

--- a/src/main/java/mezz/jei/startup/ClientLifecycleHandler.java
+++ b/src/main/java/mezz/jei/startup/ClientLifecycleHandler.java
@@ -87,8 +87,8 @@ public class ClientLifecycleHandler {
 
 		KeyBindings.init();
 
-		EventBusHelper.addListener(WorldEvent.Save.class, event -> worldConfig.onWorldSave());
-		EventBusHelper.addListener(RecipesUpdatedEvent.class, event -> {
+		EventBusHelper.addListener(this, WorldEvent.Save.class, event -> worldConfig.onWorldSave());
+		EventBusHelper.addListener(this, RecipesUpdatedEvent.class, event -> {
 			ClientPlayNetHandler connection = Minecraft.getInstance().getConnection();
 			if (connection != null) {
 				NetworkManager networkManager = connection.getNetworkManager();


### PR DESCRIPTION
This PR reworks the JEI event system so that each event listener must have an associated owner. The ownership concept gives scope to the listeners, such that when an owner is unregistered, all listeners associated with it are also unregistered. This prevents all memory leaks caused by dangling (not unregistered) event listener subscriptions.

Practically, this change fixes at least #2148. With this PR applied, there is no longer a memory leak.