### PR TITLE
Reduce memory used after exiting and loading a world

### DIFF
--- a/src/main/java/mezz/jei/Internal.java
+++ b/src/main/java/mezz/jei/Internal.java
@@ -12,6 +12,7 @@ import mezz.jei.ingredients.IngredientManager;
 import mezz.jei.input.InputHandler;
 import mezz.jei.runtime.JeiHelpers;
 import mezz.jei.runtime.JeiRuntime;
+import mezz.jei.startup.JeiReloadListener;
 
 /**
  * For JEI internal use only, these are normally accessed from the API.
@@ -33,6 +34,8 @@ public final class Internal {
 	private static InputHandler inputHandler;
 	@Nullable
 	private static Textures textures;
+	@Nullable
+	private static JeiReloadListener reloadListener;
 
 	private Internal() {
 
@@ -116,5 +119,15 @@ public final class Internal {
 
 		Internal.inputHandler = inputHandler;
 		EventBusHelper.register(inputHandler);
+	}
+
+	@Nullable
+	public static JeiReloadListener getReloadListener() {
+		return reloadListener;
+	}
+
+	public static void setReloadListener(JeiReloadListener listener) {
+		Preconditions.checkState(reloadListener == null, "Reload Listener has already been assigned.");
+		reloadListener = listener;
 	}
 }

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -2,6 +2,7 @@ package mezz.jei.gui.overlay;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import javax.annotation.Nullable;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -46,7 +47,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 	private final IFilterTextSource filterTextSource;
 	private final IWorldConfig worldConfig;
 	private final IngredientGrid ingredientGrid;
-	private final IIngredientGridSource ingredientSource;
+	private final WeakReference<IIngredientGridSource> ingredientSource;
 	private Rectangle2d area = new Rectangle2d(0, 0, 0, 0);
 
 	public IngredientGridWithNavigation(
@@ -59,7 +60,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 		this.filterTextSource = filterTextSource;
 		this.worldConfig = worldConfig;
 		this.ingredientGrid = ingredientGrid;
-		this.ingredientSource = ingredientSource;
+		this.ingredientSource = new WeakReference<>(ingredientSource);
 		this.guiScreenHelper = guiScreenHelper;
 		this.pageDelegate = new IngredientGridPaged();
 		this.navigation = new PageNavigation(this.pageDelegate, false);
@@ -70,7 +71,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 			firstItemIndex = 0;
 		}
 		String filterText = filterTextSource.getFilterText();
-		List<IIngredientListElement<?>> ingredientList = ingredientSource.getIngredientList(filterText);
+		List<IIngredientListElement<?>> ingredientList = ingredientSource.get().getIngredientList(filterText);
 		if (firstItemIndex >= ingredientList.size()) {
 			firstItemIndex = 0;
 		}
@@ -211,7 +212,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 		@Override
 		public boolean nextPage() {
 			String filterText = filterTextSource.getFilterText();
-			final int itemsCount = ingredientSource.getIngredientList(filterText).size();
+			final int itemsCount = ingredientSource.get().getIngredientList(filterText).size();
 			if (itemsCount > 0) {
 				firstItemIndex += ingredientGrid.size();
 				if (firstItemIndex >= itemsCount) {
@@ -235,7 +236,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 				return false;
 			}
 			String filterText = filterTextSource.getFilterText();
-			final int itemsCount = ingredientSource.getIngredientList(filterText).size();
+			final int itemsCount = ingredientSource.get().getIngredientList(filterText).size();
 
 			int pageNum = firstItemIndex / itemsPerPage;
 			if (pageNum == 0) {
@@ -258,7 +259,7 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 			String filterText = filterTextSource.getFilterText();
 			// true if there is more than one page because this wraps around
 			int itemsPerPage = ingredientGrid.size();
-			return itemsPerPage > 0 && ingredientSource.getIngredientList(filterText).size() > itemsPerPage;
+			return itemsPerPage > 0 && ingredientSource.get().getIngredientList(filterText).size() > itemsPerPage;
 		}
 
 		@Override
@@ -266,13 +267,13 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 			String filterText = filterTextSource.getFilterText();
 			// true if there is more than one page because this wraps around
 			int itemsPerPage = ingredientGrid.size();
-			return itemsPerPage > 0 && ingredientSource.getIngredientList(filterText).size() > itemsPerPage;
+			return itemsPerPage > 0 && ingredientSource.get().getIngredientList(filterText).size() > itemsPerPage;
 		}
 
 		@Override
 		public int getPageCount() {
 			String filterText = filterTextSource.getFilterText();
-			final int itemCount = ingredientSource.getIngredientList(filterText).size();
+			final int itemCount = ingredientSource.get().getIngredientList(filterText).size();
 			final int stacksPerPage = ingredientGrid.size();
 			if (stacksPerPage == 0) {
 				return 1;

--- a/src/main/java/mezz/jei/input/GuiTextFieldFilter.java
+++ b/src/main/java/mezz/jei/input/GuiTextFieldFilter.java
@@ -1,6 +1,8 @@
 package mezz.jei.input;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
+
+import java.lang.ref.WeakReference;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -25,7 +27,7 @@ public class GuiTextFieldFilter extends TextFieldWidget {
 	private static final List<String> history = new LinkedList<>();
 
 	private final HoverChecker hoverChecker;
-	private final IIngredientGridSource ingredientSource;
+	private final WeakReference<IIngredientGridSource> ingredientSource;
 	private final IWorldConfig worldConfig;
 	private boolean previousKeyboardRepeatEnabled;
 
@@ -38,7 +40,7 @@ public class GuiTextFieldFilter extends TextFieldWidget {
 
 		setMaxStringLength(maxSearchLength);
 		this.hoverChecker = new HoverChecker();
-		this.ingredientSource = ingredientSource;
+		this.ingredientSource = new WeakReference<>(ingredientSource);
 
 		this.background = Internal.getTextures().getSearchBackground();
 	}
@@ -57,7 +59,7 @@ public class GuiTextFieldFilter extends TextFieldWidget {
 		if (!filterText.equals(getText())) {
 			setText(filterText);
 		}
-		List<IIngredientListElement<?>> ingredientList = ingredientSource.getIngredientList(filterText);
+		List<IIngredientListElement<?>> ingredientList = ingredientSource.get().getIngredientList(filterText);
 		if (ingredientList.size() == 0) {
 			setTextColor(0xFFFF0000);
 		} else {

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -1,6 +1,7 @@
 package mezz.jei.input;
 
 import javax.annotation.Nullable;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +35,7 @@ import mezz.jei.util.ReflectionUtil;
 
 public class InputHandler {
 	private final IIngredientManager ingredientManager;
-	private final IngredientFilter ingredientFilter;
+	private final WeakReference<IngredientFilter> ingredientFilter;
 	private final RecipesGui recipesGui;
 	private final IngredientListOverlay ingredientListOverlay;
 	private final IEditModeConfig editModeConfig;
@@ -57,7 +58,7 @@ public class InputHandler {
 		BookmarkList bookmarkList
 	) {
 		this.ingredientManager = ingredientManager;
-		this.ingredientFilter = ingredientFilter;
+		this.ingredientFilter = new WeakReference<>(ingredientFilter);
 		this.recipesGui = recipesGui;
 		this.ingredientListOverlay = ingredientListOverlay;
 		this.editModeConfig = editModeConfig;
@@ -233,9 +234,9 @@ public class InputHandler {
 		IIngredientHelper<V> ingredientHelper = ingredientManager.getIngredientHelper(ingredient);
 
 		if (editModeConfig.isIngredientOnConfigBlacklist(ingredient, ingredientHelper)) {
-			editModeConfig.removeIngredientFromConfigBlacklist(ingredientFilter, ingredientManager, ingredient, blacklistType, ingredientHelper);
+			editModeConfig.removeIngredientFromConfigBlacklist(ingredientFilter.get(), ingredientManager, ingredient, blacklistType, ingredientHelper);
 		} else {
-			editModeConfig.addIngredientToConfigBlacklist(ingredientFilter, ingredientManager, ingredient, blacklistType, ingredientHelper);
+			editModeConfig.addIngredientToConfigBlacklist(ingredientFilter.get(), ingredientManager, ingredient, blacklistType, ingredientHelper);
 		}
 		clicked.onClickHandled();
 		return true;

--- a/src/main/java/mezz/jei/startup/JeiReloadListener.java
+++ b/src/main/java/mezz/jei/startup/JeiReloadListener.java
@@ -1,0 +1,47 @@
+package mezz.jei.startup;
+
+import com.google.common.base.Preconditions;
+import mezz.jei.api.IModPlugin;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.IResourceManager;
+import net.minecraftforge.resource.IResourceType;
+import net.minecraftforge.resource.ISelectiveResourceReloadListener;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public final class JeiReloadListener implements ISelectiveResourceReloadListener {
+    private ClientLifecycleHandler handler;
+    private List<IModPlugin> plugins;
+
+    JeiReloadListener(ClientLifecycleHandler handler, List<IModPlugin> plugins) {
+        this.handler = handler;
+        this.plugins = plugins;
+    }
+
+    void update(ClientLifecycleHandler handler, List<IModPlugin> plugins) {
+        this.handler = handler;
+        this.plugins = plugins;
+    }
+
+    @Override
+    public void onResourceManagerReload(IResourceManager resourceManager, Predicate<IResourceType> resourcePredicate) {
+        // check that JEI has been started before. if not, do nothing
+        if (handler.starter.hasStarted() && Minecraft.getInstance().world != null) {
+            handler.LOGGER.info("Restarting JEI.");
+            Preconditions.checkNotNull(handler.textures);
+            handler.starter.start(
+                    plugins,
+                    handler.textures,
+                    handler.clientConfig,
+                    handler.editModeConfig,
+                    handler.ingredientFilterConfig,
+                    handler.worldConfig,
+                    handler.bookmarkConfig,
+                    handler.modIdHelper,
+                    handler.recipeCategorySortingConfig,
+                    handler.ingredientSorter
+            );
+        }
+    }
+}

--- a/src/main/java/mezz/jei/startup/JeiReloadListener.java
+++ b/src/main/java/mezz/jei/startup/JeiReloadListener.java
@@ -7,40 +7,42 @@ import net.minecraft.resources.IResourceManager;
 import net.minecraftforge.resource.IResourceType;
 import net.minecraftforge.resource.ISelectiveResourceReloadListener;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.function.Predicate;
 
 public final class JeiReloadListener implements ISelectiveResourceReloadListener {
-    private ClientLifecycleHandler handler;
+    private WeakReference<ClientLifecycleHandler> handler;
     private List<IModPlugin> plugins;
 
     JeiReloadListener(ClientLifecycleHandler handler, List<IModPlugin> plugins) {
-        this.handler = handler;
+        this.handler = new WeakReference<>(handler);
         this.plugins = plugins;
     }
 
     void update(ClientLifecycleHandler handler, List<IModPlugin> plugins) {
-        this.handler = handler;
+        this.handler = new WeakReference<>(handler);
         this.plugins = plugins;
     }
 
     @Override
     public void onResourceManagerReload(IResourceManager resourceManager, Predicate<IResourceType> resourcePredicate) {
+        ClientLifecycleHandler handlerRef = handler.get();
         // check that JEI has been started before. if not, do nothing
-        if (handler.starter.hasStarted() && Minecraft.getInstance().world != null) {
-            handler.LOGGER.info("Restarting JEI.");
-            Preconditions.checkNotNull(handler.textures);
-            handler.starter.start(
+        if (handlerRef.starter.hasStarted() && Minecraft.getInstance().world != null) {
+            handlerRef.LOGGER.info("Restarting JEI.");
+            Preconditions.checkNotNull(handlerRef.textures);
+            handlerRef.starter.start(
                     plugins,
-                    handler.textures,
-                    handler.clientConfig,
-                    handler.editModeConfig,
-                    handler.ingredientFilterConfig,
-                    handler.worldConfig,
-                    handler.bookmarkConfig,
-                    handler.modIdHelper,
-                    handler.recipeCategorySortingConfig,
-                    handler.ingredientSorter
+                    handlerRef.textures,
+                    handlerRef.clientConfig,
+                    handlerRef.editModeConfig,
+                    handlerRef.ingredientFilterConfig,
+                    handlerRef.worldConfig,
+                    handlerRef.bookmarkConfig,
+                    handlerRef.modIdHelper,
+                    handlerRef.recipeCategorySortingConfig,
+                    handlerRef.ingredientSorter
             );
         }
     }


### PR DESCRIPTION
`JeiReloadListener` is re-created and re-subscribed on each server join, causing a significant memory leak. It is not possible to unsubscribe it due to vanilla Minecraft limitations, but this PR works around the problem by keeping one reload listener and updating the state within it every time it is necessary.

Large objects such as `IngredientFilter` already occupy about 200MB of RAM in an average modpack. Due to the way Forge's event bus handles listener removal, 2 instances of these objects remain at all times, even though only one is used. This PR works around that, effectively saving half of that RAM space.

Reference: https://github.com/MinecraftForge/EventBus/issues/39