### PR TITLE
Fix erroneous event listener removal

### DIFF
--- a/src/main/java/mezz/jei/events/EventBusHelper.java
+++ b/src/main/java/mezz/jei/events/EventBusHelper.java
@@ -22,6 +22,10 @@ public class EventBusHelper {
             this.eventBus = eventBus;
             this.listener = listener;
         }
+
+        private void unregister() {
+            eventBus.unregister(listener);
+        }
     }
 
     private static final Map<Object, List<Subscription>> subscriptions = new HashMap<>();
@@ -57,15 +61,16 @@ public class EventBusHelper {
      * See {@link EventBusHelper#addListener(Object, IEventBus, Class, Consumer)}
      */
     public static <T extends Event> void removeListener(Object owner, Consumer<T> listener) {
-        removeListener(owner, getInstance(), listener);
-    }
-
-    /**
-     * See {@link EventBusHelper#addListener(Object, IEventBus, Class, Consumer)}
-     */
-    public static <T extends Event> void removeListener(Object owner, IEventBus eventBus, Consumer<T> listener) {
-        subscriptions.get(owner).removeIf(sub -> Objects.equals(sub.listener, listener));
-        eventBus.unregister(listener);
+        List<Subscription> subs = subscriptions.get(owner);
+        if (subs != null) {
+            subs.removeIf(sub -> {
+                if (Objects.equals(sub.listener, listener)) {
+                    sub.unregister();
+                    return true;
+                }
+                return false;
+            });
+        }
     }
 
     public static void register(Object owner) {
@@ -81,11 +86,13 @@ public class EventBusHelper {
      */
     public static void unregister(Object owner) {
         IEventBus eventBus = getInstance();
-        for (Subscription sub : subscriptions.get(owner)) {
-            removeListener(owner, sub.eventBus, sub.listener);
+        List<Subscription> subs = subscriptions.remove(owner);
+        if (subs != null) {
+            for (Subscription sub : subs) {
+                sub.unregister();
+            }
         }
         eventBus.unregister(owner);
-        subscriptions.remove(owner);
     }
 
     public static void post(Event event) {

--- a/src/main/java/mezz/jei/events/EventBusHelper.java
+++ b/src/main/java/mezz/jei/events/EventBusHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import net.minecraftforge.fml.event.lifecycle.ModLifecycleEvent;
@@ -63,7 +64,7 @@ public class EventBusHelper {
      * See {@link EventBusHelper#addListener(Object, IEventBus, Class, Consumer)}
      */
     public static <T extends Event> void removeListener(Object owner, IEventBus eventBus, Consumer<T> listener) {
-        subscriptions.get(owner).remove(listener);
+        subscriptions.get(owner).removeIf(sub -> Objects.equals(sub.listener, listener));
         eventBus.unregister(listener);
     }
 


### PR DESCRIPTION
This PR addresses the following:
1. Listener removal erroneously attempts to remove a `Consumer<T>` from a list of type `Subscription`
2. Owner removal depends on failed listener removal as otherwise a concurrent modification exception would be raised
3. A removal for an owner which is not registered results in a null deference
4. Listeners are only removed from the "FORGE" event bus regardless of what they are actually registered to