### PR TITLE
Expose getUniqueIdentifierForStack in the IStackHelper API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ curse_project_id=238222
 
 version_major=7
 version_minor=6
-version_patch=0
+version_patch=1

--- a/src/api/java/mezz/jei/api/helpers/IStackHelper.java
+++ b/src/api/java/mezz/jei/api/helpers/IStackHelper.java
@@ -26,4 +26,11 @@ public interface IStackHelper {
 	default boolean isEquivalent(@Nullable ItemStack lhs, @Nullable ItemStack rhs) {
 		return isEquivalent(lhs, rhs, UidContext.Ingredient);
 	}
+
+	/**
+	 * Gets the unique identifier for a stack, ignoring NBT on items without subtypes, and uses the {@link ISubtypeManager}.
+	 * If two unique identifiers are equal, then the items can be considered equivalent.
+	 * @since JEI 7.6.1
+	 */
+	String getUniqueIdentifierForStack(ItemStack stack, UidContext context);
 }

--- a/src/main/java/mezz/jei/util/StackHelper.java
+++ b/src/main/java/mezz/jei/util/StackHelper.java
@@ -37,6 +37,7 @@ public class StackHelper implements IStackHelper {
 		return keyLhs.equals(keyRhs);
 	}
 
+	@Override
 	public String getUniqueIdentifierForStack(ItemStack stack, UidContext context) {
 		String result = getRegistryNameForStack(stack);
 		String subtypeInfo = subtypeManager.getSubtypeInfo(stack, context);


### PR DESCRIPTION
Exposes `StackHelper#getUniqueIdentifierForStack` to the API via `IStackHelper#getUniqueIdentifierForStack` to allow for mods to do some more extensive caching while comparing two sets of items rather than recalculating the Unique ID for each pair of items.