### PR TITLE
Fix SelectAll text selection getting reset

### DIFF
--- a/src/main/java/mezz/jei/input/GuiTextFieldFilter.java
+++ b/src/main/java/mezz/jei/input/GuiTextFieldFilter.java
@@ -51,7 +51,6 @@ public class GuiTextFieldFilter extends TextFieldWidget {
 		this.width = area.getWidth();
 		this.height = area.getHeight();
 		this.hoverChecker.updateBounds(area.getY(), area.getY() + area.getHeight(), area.getX(), area.getX() + area.getWidth());
-		setSelectionPos(getCursorPosition());
 	}
 
 	public void update() {


### PR DESCRIPTION
When in the Survival Gamemode doing Select All (Ctrl + A) in the search field doesn't work as `setSelectionPos` is being called every draw background event, This results in the text selection being reset within a couple frames.

This PR simply removes the `setSelectionPos` call as from testing it does not appear to be required when updating the bounds of the search field.