### PR TITLE
Deduplicate JEI plugins loaded from Jars containing multiple mods

### DIFF
--- a/src/main/java/mezz/jei/util/AnnotatedInstanceUtil.java
+++ b/src/main/java/mezz/jei/util/AnnotatedInstanceUtil.java
@@ -1,8 +1,10 @@
 package mezz.jei.util;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.forgespi.language.ModFileScanData;
@@ -28,7 +30,7 @@ public final class AnnotatedInstanceUtil {
 	private static <T> List<T> getInstances(Class<?> annotationClass, Class<T> instanceClass) {
 		Type annotationType = Type.getType(annotationClass);
 		List<ModFileScanData> allScanData = ModList.get().getAllScanData();
-		List<String> pluginClassNames = new ArrayList<>();
+		Set<String> pluginClassNames = new HashSet<>();
 		for (ModFileScanData scanData : allScanData) {
 			Iterable<ModFileScanData.AnnotationData> annotations = scanData.getAnnotations();
 			for (ModFileScanData.AnnotationData a : annotations) {

--- a/src/main/java/mezz/jei/util/AnnotatedInstanceUtil.java
+++ b/src/main/java/mezz/jei/util/AnnotatedInstanceUtil.java
@@ -1,7 +1,7 @@
 package mezz.jei.util;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -30,7 +30,7 @@ public final class AnnotatedInstanceUtil {
 	private static <T> List<T> getInstances(Class<?> annotationClass, Class<T> instanceClass) {
 		Type annotationType = Type.getType(annotationClass);
 		List<ModFileScanData> allScanData = ModList.get().getAllScanData();
-		Set<String> pluginClassNames = new HashSet<>();
+		Set<String> pluginClassNames = new LinkedHashSet<>();
 		for (ModFileScanData scanData : allScanData) {
 			Iterable<ModFileScanData.AnnotationData> annotations = scanData.getAnnotations();
 			for (ModFileScanData.AnnotationData a : annotations) {


### PR DESCRIPTION
Fairly simple. When there are multiple mods contained in a single Jar file, JEI will instantiate plugins contained within the jar multiple times.
Here we just collect to a Set in order to have a de-duplicated collection of plugins to load.