### PR TITLE
Fix the "give command" item argument for vanilla servers

### DIFF
--- a/src/main/java/mezz/jei/util/CommandUtil.java
+++ b/src/main/java/mezz/jei/util/CommandUtil.java
@@ -28,7 +28,7 @@ public final class CommandUtil {
 	}
 
 	/**
-	 * /give <player> <item> [amount] [data] [dataTag]
+	 * /give &lt;player&gt; &lt;item&gt; [amount]
 	 *
 	 * {@link CreativeScreen} has special client-side handling for itemStacks, just give the item on the client
 	 */

--- a/src/main/java/mezz/jei/util/CommandUtilServer.java
+++ b/src/main/java/mezz/jei/util/CommandUtilServer.java
@@ -54,11 +54,12 @@ public final class CommandUtilServer {
 
 		List<String> commandStrings = new ArrayList<>();
 		commandStrings.add(senderName.getString());
-		commandStrings.add(itemResourceLocation.toString());
+		String itemArgument = itemResourceLocation.toString();
 		CompoundNBT tagCompound = itemStack.getTag();
 		if (tagCompound != null) {
-			commandStrings.add(tagCompound.toString());
+			itemArgument += tagCompound;
 		}
+		commandStrings.add(itemArgument);
 		commandStrings.add(String.valueOf(amount));
 		return commandStrings.toArray(new String[0]);
 	}


### PR DESCRIPTION
Brigadier was introduced in Minecraft 1.13 and changed the syntax for some commands.
Apparently there was a long standing (since the initial port to 1.13) bug in `CommandUtilServer` that lead to an invalid `give`
 command being generated.
This closes #2228.

If you want I can also backport this fix to older versions of JEI.