### PR TITLE
Add in support for showing shulker box coloring recipes

### DIFF
--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
@@ -39,6 +39,7 @@ import mezz.jei.plugins.vanilla.cooking.fuel.FuelRecipeMaker;
 import mezz.jei.plugins.vanilla.cooking.fuel.FurnaceFuelCategory;
 import mezz.jei.plugins.vanilla.crafting.CraftingCategoryExtension;
 import mezz.jei.plugins.vanilla.crafting.CraftingRecipeCategory;
+import mezz.jei.plugins.vanilla.crafting.ShulkerBoxColoringRecipeMaker;
 import mezz.jei.plugins.vanilla.crafting.TippedArrowRecipeMaker;
 import mezz.jei.plugins.vanilla.crafting.VanillaRecipes;
 import mezz.jei.plugins.vanilla.ingredients.fluid.FluidStackHelper;
@@ -200,6 +201,7 @@ public class VanillaPlugin implements IModPlugin {
 		registration.addRecipes(FuelRecipeMaker.getFuelRecipes(ingredientManager, jeiHelpers), VanillaRecipeCategoryUid.FUEL);
 		registration.addRecipes(BrewingRecipeMaker.getBrewingRecipes(ingredientManager, vanillaRecipeFactory), VanillaRecipeCategoryUid.BREWING);
 		registration.addRecipes(TippedArrowRecipeMaker.createTippedArrowRecipes(), VanillaRecipeCategoryUid.CRAFTING);
+		registration.addRecipes(ShulkerBoxColoringRecipeMaker.createShulkerBoxColoringRecipes(), VanillaRecipeCategoryUid.CRAFTING);
 		registration.addRecipes(AnvilRecipeMaker.getAnvilRecipes(vanillaRecipeFactory, ingredientManager), VanillaRecipeCategoryUid.ANVIL);
 		registration.addRecipes(vanillaRecipes.getSmithingRecipes(smithingCategory), VanillaRecipeCategoryUid.SMITHING);
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/crafting/ShulkerBoxColoringRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/crafting/ShulkerBoxColoringRecipeMaker.java
@@ -33,8 +33,8 @@ public final class ShulkerBoxColoringRecipeMaker {
             Ingredient.IItemList colorList = new Ingredient.TagList(colorTag);
             Stream<Ingredient.IItemList> colorIngredientStream = Stream.of(dyeList, colorList);
             //Shulker box special recipe allows the matching dye item or any item in the tag.
-			// we need to specify both in case someone removes the dye item from the dye tag
-			// as the item will still be valid for this recipe
+            // we need to specify both in case someone removes the dye item from the dye tag
+            // as the item will still be valid for this recipe
             Ingredient colorIngredient = Ingredient.fromItemListStream(colorIngredientStream);
             NonNullList<Ingredient> inputs = NonNullList.from(Ingredient.EMPTY, baseShulkerIngredient, colorIngredient);
             Block coloredShulkerBox = ShulkerBoxBlock.getBlockByColor(color);

--- a/src/main/java/mezz/jei/plugins/vanilla/crafting/ShulkerBoxColoringRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/crafting/ShulkerBoxColoringRecipeMaker.java
@@ -1,0 +1,52 @@
+package mezz.jei.plugins.vanilla.crafting;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import mezz.jei.api.constants.ModIds;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.ShulkerBoxBlock;
+import net.minecraft.item.DyeColor;
+import net.minecraft.item.DyeItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.item.crafting.ShapelessRecipe;
+import net.minecraft.tags.ITag;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+
+public final class ShulkerBoxColoringRecipeMaker {
+
+    public static List<IRecipe<?>> createShulkerBoxColoringRecipes() {
+        List<IRecipe<?>> recipes = new ArrayList<>();
+        String group = "jei.shulker.color";
+        ItemStack baseShulkerStack = new ItemStack(Blocks.SHULKER_BOX);
+        Ingredient baseShulkerIngredient = Ingredient.fromStacks(baseShulkerStack);
+        for (DyeColor color : DyeColor.values()) {
+            DyeItem dye = DyeItem.getItem(color);
+            ItemStack dyeStack = new ItemStack(dye);
+            ITag<Item> colorTag = color.getTag();
+            Ingredient.IItemList dyeList = new Ingredient.SingleItemList(dyeStack);
+            Ingredient.IItemList colorList = new Ingredient.TagList(colorTag);
+            Stream<Ingredient.IItemList> colorIngredientStream = Stream.of(dyeList, colorList);
+            //Shulker box special recipe allows the matching dye item or any item in the tag.
+			// we need to specify both in case someone removes the dye item from the dye tag
+			// as the item will still be valid for this recipe
+            Ingredient colorIngredient = Ingredient.fromItemListStream(colorIngredientStream);
+            NonNullList<Ingredient> inputs = NonNullList.from(Ingredient.EMPTY, baseShulkerIngredient, colorIngredient);
+            Block coloredShulkerBox = ShulkerBoxBlock.getBlockByColor(color);
+            ItemStack output = new ItemStack(coloredShulkerBox);
+            ResourceLocation id = new ResourceLocation(ModIds.MINECRAFT_ID, "jei.shulker.color." + output.getTranslationKey());
+            ShapelessRecipe recipe = new ShapelessRecipe(id, group, output, inputs);
+            recipes.add(recipe);
+        }
+        return recipes;
+    }
+
+    private ShulkerBoxColoringRecipeMaker() {
+
+    }
+}


### PR DESCRIPTION
One thing to note, is that similar to how the existing tipped arrow recipe compat is, the shulker box recipe adder makes no attempt to validate that the special recipe is in fact registered as I couldn't really come up with a good/clean way to do so