### PR TITLE
Expose ColorGetter#getColors to the API via an IColorHelper

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ curse_project_id=238222
 
 version_major=7
 version_minor=6
-version_patch=2
+version_patch=3

--- a/src/api/java/mezz/jei/api/helpers/IColorHelper.java
+++ b/src/api/java/mezz/jei/api/helpers/IColorHelper.java
@@ -1,0 +1,22 @@
+package mezz.jei.api.helpers;
+
+import java.util.List;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+/**
+ * Helper class for getting colors for sprites for purposes of implementing {@link mezz.jei.api.ingredients.IIngredientHelper#getColors(Object)}.
+ * Get an instance from {@link mezz.jei.api.registration.IModIngredientRegistration#getColorHelper()}
+ *
+ * @since JEI 7.6.3
+ */
+public interface IColorHelper {
+
+    /**
+     * Gets the "main" colors of a given sprite when overlayed with a specific tint color.
+     * @param textureAtlasSprite Sprite to extract main colors from.
+     * @param renderColor        Overlay/tint color that is applied to the sprite.
+     * @param colorCount         Number of "main" colors to get.
+     * @return A list of the main colors for the given sprite when overlayed with a specific tint color.
+     */
+    List<Integer> getColors(TextureAtlasSprite textureAtlasSprite, int renderColor, int colorCount);
+}

--- a/src/api/java/mezz/jei/api/helpers/IColorHelper.java
+++ b/src/api/java/mezz/jei/api/helpers/IColorHelper.java
@@ -17,6 +17,8 @@ public interface IColorHelper {
      * @param renderColor        Overlay/tint color that is applied to the sprite.
      * @param colorCount         Number of "main" colors to get.
      * @return A list of the main colors for the given sprite when overlayed with a specific tint color.
+     *
+     * @apiNote Get the instance from {@link mezz.jei.api.registration.IModIngredientRegistration#getColorHelper()}.
      */
     List<Integer> getColors(TextureAtlasSprite textureAtlasSprite, int renderColor, int colorCount);
 }

--- a/src/api/java/mezz/jei/api/helpers/IColorHelper.java
+++ b/src/api/java/mezz/jei/api/helpers/IColorHelper.java
@@ -17,8 +17,6 @@ public interface IColorHelper {
      * @param renderColor        Overlay/tint color that is applied to the sprite.
      * @param colorCount         Number of "main" colors to get.
      * @return A list of the main colors for the given sprite when overlayed with a specific tint color.
-     *
-     * @apiNote Get the instance from {@link mezz.jei.api.registration.IModIngredientRegistration#getColorHelper()}.
      */
     List<Integer> getColors(TextureAtlasSprite textureAtlasSprite, int renderColor, int colorCount);
 }

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -97,6 +97,7 @@ public interface IIngredientHelper<V> {
 	/**
 	 * Get the main colors of this ingredient. Used for the color search.
 	 * If this is too difficult to implement for your ingredient, just return an empty collection.
+	 * @see mezz.jei.api.helpers.IColorHelper
 	 */
 	default Iterable<Integer> getColors(V ingredient) {
 		return Collections.emptyList();

--- a/src/api/java/mezz/jei/api/registration/IModIngredientRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IModIngredientRegistration.java
@@ -3,6 +3,7 @@ package mezz.jei.api.registration;
 import java.util.Collection;
 
 import mezz.jei.api.IModPlugin;
+import mezz.jei.api.helpers.IColorHelper;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRenderer;
 import mezz.jei.api.ingredients.IIngredientType;
@@ -17,6 +18,13 @@ import mezz.jei.api.runtime.IIngredientManager;
  */
 public interface IModIngredientRegistration {
 	ISubtypeManager getSubtypeManager();
+
+	/**
+	 * Gets an {@link IColorHelper} to help in implementing {@link IIngredientHelper#getColors(Object)} for {@link IIngredientHelper}s that are being registered.
+	 *
+	 * @since JEI 7.6.3
+	 */
+	IColorHelper getColorHelper();
 
 	/**
 	 * Register a new type of ingredient.

--- a/src/main/java/mezz/jei/color/ColorGetter.java
+++ b/src/main/java/mezz/jei/color/ColorGetter.java
@@ -21,13 +21,17 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.MathHelper;
 
+import mezz.jei.api.helpers.IColorHelper;
 import mezz.jei.util.ErrorUtil;
-import mezz.jei.util.MathUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public final class ColorGetter {
+public final class ColorGetter implements IColorHelper {
+
+	public static final ColorGetter INSTANCE = new ColorGetter();
+
 	private static final Logger LOGGER = LogManager.getLogger();
 	private static final String[] defaultColors = new String[]{
 		"White:EEEEEE",
@@ -110,7 +114,7 @@ public final class ColorGetter {
 		if (textureAtlasSprite == null) {
 			return Collections.emptyList();
 		}
-		return getColors(textureAtlasSprite, renderColor, colorCount);
+		return INSTANCE.getColors(textureAtlasSprite, renderColor, colorCount);
 	}
 
 	private static List<Integer> getBlockColors(Block block, int colorCount) {
@@ -121,10 +125,14 @@ public final class ColorGetter {
 		if (textureAtlasSprite == null) {
 			return Collections.emptyList();
 		}
-		return getColors(textureAtlasSprite, renderColor, colorCount);
+		return INSTANCE.getColors(textureAtlasSprite, renderColor, colorCount);
 	}
 
-	public static List<Integer> getColors(TextureAtlasSprite textureAtlasSprite, int renderColor, int colorCount) {
+	@Override
+	public List<Integer> getColors(TextureAtlasSprite textureAtlasSprite, int renderColor, int colorCount) {
+		if (colorCount <= 0) {
+			return Collections.emptyList();
+		}
 		final NativeImage bufferedImage = getNativeImage(textureAtlasSprite);
 		if (bufferedImage == null) {
 			return Collections.emptyList();
@@ -136,9 +144,9 @@ public final class ColorGetter {
 				int red = (int) ((colorInt[0] - 1) * (float) (renderColor >> 16 & 255) / 255.0F);
 				int green = (int) ((colorInt[1] - 1) * (float) (renderColor >> 8 & 255) / 255.0F);
 				int blue = (int) ((colorInt[2] - 1) * (float) (renderColor & 255) / 255.0F);
-				red = MathUtil.clamp(red, 0, 255);
-				green = MathUtil.clamp(green, 0, 255);
-				blue = MathUtil.clamp(blue, 0, 255);
+				red = MathHelper.clamp(red, 0, 255);
+				green = MathHelper.clamp(green, 0, 255);
+				blue = MathHelper.clamp(blue, 0, 255);
 				int color = ((0xFF) << 24) |
 					((red & 0xFF) << 16) |
 					((green & 0xFF) << 8) |

--- a/src/main/java/mezz/jei/ingredients/ModIngredientRegistration.java
+++ b/src/main/java/mezz/jei/ingredients/ModIngredientRegistration.java
@@ -7,11 +7,13 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
+import mezz.jei.api.helpers.IColorHelper;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRenderer;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.ISubtypeManager;
 import mezz.jei.api.registration.IModIngredientRegistration;
+import mezz.jei.color.ColorGetter;
 import mezz.jei.util.ErrorUtil;
 
 public class ModIngredientRegistration implements IModIngredientRegistration {
@@ -40,6 +42,11 @@ public class ModIngredientRegistration implements IModIngredientRegistration {
 	@Override
 	public ISubtypeManager getSubtypeManager() {
 		return subtypeManager;
+	}
+
+	@Override
+	public IColorHelper getColorHelper() {
+		return ColorGetter.INSTANCE;
 	}
 
 	public List<RegisteredIngredient<?>> getRegisteredIngredients() {

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
@@ -149,7 +149,7 @@ public class VanillaPlugin implements IModPlugin {
 		registration.register(VanillaTypes.ITEM, itemStacks, itemStackHelper, itemStackRenderer);
 
 		List<FluidStack> fluidStacks = FluidStackListFactory.create();
-		FluidStackHelper fluidStackHelper = new FluidStackHelper(subtypeManager, FluidStackRenderer);
+		FluidStackHelper fluidStackHelper = new FluidStackHelper(subtypeManager, colorHelper);
 		FluidStackRenderer fluidStackRenderer = new FluidStackRenderer();
 		registration.register(VanillaTypes.FLUID, fluidStacks, fluidStackHelper, fluidStackRenderer);
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/VanillaPlugin.java
@@ -6,6 +6,7 @@ import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.ModIds;
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.helpers.IColorHelper;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.helpers.IStackHelper;
@@ -140,6 +141,7 @@ public class VanillaPlugin implements IModPlugin {
 		ISubtypeManager subtypeManager = registration.getSubtypeManager();
 		StackHelper stackHelper = new StackHelper(subtypeManager);
 		ItemStackListFactory itemStackListFactory = new ItemStackListFactory();
+		IColorHelper colorHelper = registration.getColorHelper();
 
 		List<ItemStack> itemStacks = itemStackListFactory.create(stackHelper);
 		ItemStackHelper itemStackHelper = new ItemStackHelper(stackHelper);
@@ -147,7 +149,7 @@ public class VanillaPlugin implements IModPlugin {
 		registration.register(VanillaTypes.ITEM, itemStacks, itemStackHelper, itemStackRenderer);
 
 		List<FluidStack> fluidStacks = FluidStackListFactory.create();
-		FluidStackHelper fluidStackHelper = new FluidStackHelper(subtypeManager);
+		FluidStackHelper fluidStackHelper = new FluidStackHelper(subtypeManager, FluidStackRenderer);
 		FluidStackRenderer fluidStackRenderer = new FluidStackRenderer();
 		registration.register(VanillaTypes.FLUID, fluidStacks, fluidStackHelper, fluidStackRenderer);
 	}

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -19,14 +19,16 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 
 import com.google.common.base.MoreObjects;
+import mezz.jei.api.helpers.IColorHelper;
 import mezz.jei.api.ingredients.IIngredientHelper;
-import mezz.jei.color.ColorGetter;
 
 public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 	private final ISubtypeManager subtypeManager;
+	private final IColorHelper colorHelper;
 
-	public FluidStackHelper(ISubtypeManager subtypeManager) {
+	public FluidStackHelper(ISubtypeManager subtypeManager, IColorHelper colorHelper) {
 		this.subtypeManager = subtypeManager;
+		this.colorHelper = colorHelper;
 	}
 
 
@@ -88,7 +90,7 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 			Minecraft minecraft = Minecraft.getInstance();
 			TextureAtlasSprite fluidStillSprite = minecraft.getAtlasSpriteGetter(PlayerContainer.LOCATION_BLOCKS_TEXTURE).apply(fluidStill);
 			int renderColor = attributes.getColor(ingredient);
-			return ColorGetter.getColors(fluidStillSprite, renderColor, 1);
+			return colorHelper.getColors(fluidStillSprite, renderColor, 1);
 		}
 		return Collections.emptyList();
 	}

--- a/src/main/java/mezz/jei/util/MathUtil.java
+++ b/src/main/java/mezz/jei/util/MathUtil.java
@@ -17,13 +17,6 @@ public final class MathUtil {
 		return (int) Math.ceil((float) numerator / denominator);
 	}
 
-	public static int clamp(int value, int min, int max) {
-		if (value < min) {
-			return min;
-		}
-		return Math.min(value, max);
-	}
-
 	public static boolean intersects(Collection<Rectangle2d> areas, Rectangle2d comparisonArea) {
 		for (Rectangle2d area : areas) {
 			if (intersects(area, comparisonArea)) {


### PR DESCRIPTION
Similar to previous commits that adjust the registration/helper interfaces I did not default `IModIngredientRegistration#getColorHelper`, if I should instead make it nullable for now with a TODO to remove the default and nullable for 1.17 I can do so. Closes #1886

I also removed `MathUtil#clamp` from the `ColorGetter#getColors` in favor of just calling vanilla's existing `MathHelper#clamp` method.