### PR TITLE
Close the recipe screen even if parent screen is null

### DIFF
--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -396,10 +396,8 @@ public class RecipesGui extends Screen implements IRecipesGui, IShowsRecipeFocus
 	@Override
 	public void closeScreen() {
 		if (isOpen() && minecraft != null) {
-			if (parentScreen != null) {
-				minecraft.displayGuiScreen(parentScreen);
-				parentScreen = null;
-			}
+			minecraft.displayGuiScreen(parentScreen);
+			parentScreen = null;
 			logic.clearHistory();
 			return;
 		}


### PR DESCRIPTION
When you open the recipe screen when still in world, `this.parentScreen` is null, making you stuck on the recipe screen with no way out.