### PR TITLE
Fix some minor Deprecation issues

### DIFF
--- a/src/api/java/mezz/jei/api/constants/VanillaRecipeCategoryUid.java
+++ b/src/api/java/mezz/jei/api/constants/VanillaRecipeCategoryUid.java
@@ -2,7 +2,10 @@ package mezz.jei.api.constants;
 
 import java.util.List;
 
+import net.minecraft.item.crafting.BlastingRecipe;
+import net.minecraft.item.crafting.CampfireCookingRecipe;
 import net.minecraft.item.crafting.SmithingRecipe;
+import net.minecraft.item.crafting.SmokingRecipe;
 import net.minecraft.item.crafting.StonecuttingRecipe;
 import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
 import net.minecraft.item.ItemStack;
@@ -47,21 +50,21 @@ public final class VanillaRecipeCategoryUid {
 	/**
 	 * The smoking recipe category.
 	 *
-	 * Automatically includes every {@link FurnaceRecipe}
+	 * Automatically includes every {@link SmokingRecipe}
 	 */
 	public static final ResourceLocation SMOKING = new ResourceLocation(ModIds.MINECRAFT_ID, "smoking");
 
 	/**
 	 * The blasting recipe category.
 	 *
-	 * Automatically includes every {@link FurnaceRecipe}
+	 * Automatically includes every {@link BlastingRecipe}
 	 */
 	public static final ResourceLocation BLASTING = new ResourceLocation(ModIds.MINECRAFT_ID, "blasting");
 
 	/**
 	 * The campfire furnace recipe category.
 	 *
-	 * Automatically includes every {@link FurnaceRecipe}
+	 * Automatically includes every {@link CampfireCookingRecipe}
 	 */
 	public static final ResourceLocation CAMPFIRE = new ResourceLocation(ModIds.MINECRAFT_ID, "campfire");
 

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -76,7 +76,7 @@ public interface IIngredientHelper<V> {
 	/**
 	 * Wildcard ID for use in comparing, blacklisting, and looking up ingredients.
 	 * For an example, ItemStack's wildcardId does not include NBT.
-	 * For ingredients like FluidStacks which do not have a wildcardId, just return the uniqueId here.
+	 * For ingredients which do not have a wildcardId, just return the uniqueId here.
 	 */
 	default String getWildcardId(V ingredient) {
 		return getUniqueId(ingredient);

--- a/src/api/java/mezz/jei/api/recipe/IRecipeManager.java
+++ b/src/api/java/mezz/jei/api/recipe/IRecipeManager.java
@@ -165,6 +165,7 @@ public interface IRecipeManager {
 	 * Returns a list of recipes in recipeCategory.
 	 * @deprecated since JEI 7.7.1. Use {@link #getRecipes(IRecipeCategory, IFocus, boolean)}
 	 */
+	@Deprecated
 	default <T> List<T> getRecipes(IRecipeCategory<T> recipeCategory) {
 		return getRecipes(recipeCategory, null, false);
 	}
@@ -174,6 +175,7 @@ public interface IRecipeManager {
 	 *
 	 * @deprecated since JEI 7.7.1. Use {@link #getRecipes(IRecipeCategory, IFocus, boolean)}
 	 */
+	@Deprecated
 	default <T, V> List<T> getRecipes(IRecipeCategory<T> recipeCategory, IFocus<V> focus) {
 		return getRecipes(recipeCategory, focus, false);
 	}

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -10,7 +10,7 @@ import mezz.jei.api.gui.IRecipeLayout;
  * A reason that a recipe transfer couldn't happen.
  *
  * Recipe transfer errors can be created with {@link IRecipeTransferHandlerHelper} or you can implement your own.
- * These errors are returned from {@link IRecipeTransferHandler#transferRecipe(Container, IRecipeLayout, PlayerEntity, boolean, boolean)}.
+ * These errors are returned from {@link IRecipeTransferHandler#transferRecipe(Container, Object, IRecipeLayout, PlayerEntity, boolean, boolean)}.
  */
 public interface IRecipeTransferError {
 	enum Type {

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -2,6 +2,7 @@ package mezz.jei.plugins.jei.ingredients;
 
 import javax.annotation.Nullable;
 
+import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -12,12 +13,23 @@ import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.util.CommandUtilServer;
 
 public class DebugIngredientHelper implements IIngredientHelper<DebugIngredient> {
+	@Override
+	@Nullable
+	@Deprecated
+	public DebugIngredient getMatch(Iterable<DebugIngredient> ingredients, DebugIngredient toMatch) {
+		return getMatch(ingredients, toMatch, UidContext.Ingredient);
+	}
+
 	@Nullable
 	@Override
-	public DebugIngredient getMatch(Iterable<DebugIngredient> ingredients, DebugIngredient ingredientToMatch) {
+	public DebugIngredient getMatch(Iterable<DebugIngredient> ingredients, DebugIngredient ingredientToMatch, UidContext context) {
 		for (DebugIngredient debugIngredient : ingredients) {
 			if (debugIngredient.getNumber() == ingredientToMatch.getNumber()) {
-				return debugIngredient;
+				String keyLhs = getUniqueId(ingredientToMatch, context);
+				String keyRhs = getUniqueId(debugIngredient, context);
+				if (keyLhs.equals(keyRhs)) {
+					return debugIngredient;
+				}
 			}
 		}
 		return null;

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 
 import mezz.jei.api.ingredients.subtypes.ISubtypeManager;
 import mezz.jei.api.ingredients.subtypes.UidContext;
+import mezz.jei.util.ErrorUtil;
 import net.minecraft.inventory.container.PlayerContainer;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
@@ -31,13 +32,23 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 		this.colorHelper = colorHelper;
 	}
 
+	@Override
+	@Nullable
+	@Deprecated
+	public FluidStack getMatch(Iterable<FluidStack> ingredients, FluidStack toMatch) {
+		return getMatch(ingredients, toMatch, UidContext.Ingredient);
+	}
 
 	@Override
 	@Nullable
-	public FluidStack getMatch(Iterable<FluidStack> ingredients, FluidStack toMatch) {
+	public FluidStack getMatch(Iterable<FluidStack> ingredients, FluidStack toMatch, UidContext context) {
 		for (FluidStack fluidStack : ingredients) {
 			if (toMatch.getFluid() == fluidStack.getFluid()) {
-				return fluidStack;
+				String keyLhs = getUniqueId(toMatch, context);
+				String keyRhs = getUniqueId(fluidStack, context);
+				if (keyLhs.equals(keyRhs)) {
+					return fluidStack;
+				}
 			}
 		}
 		return null;
@@ -67,6 +78,14 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 			result.append(subtypeInfo);
 		}
 		return result.toString();
+	}
+
+	@Override
+	public String getWildcardId(FluidStack ingredient) {
+		ErrorUtil.checkNotEmpty(ingredient);
+		Fluid fluid = ingredient.getFluid();
+		ResourceLocation registryName = fluid.getRegistryName();
+		return "fluid:" + registryName;
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -54,6 +54,7 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 
 	@Override
 	@Nullable
+	@Deprecated
 	public ItemStack getMatch(Iterable<ItemStack> ingredients, ItemStack toMatch) {
 		return getMatch(ingredients, toMatch, UidContext.Ingredient);
 	}

--- a/src/main/java/mezz/jei/transfer/PlayerRecipeTransferHandler.java
+++ b/src/main/java/mezz/jei/transfer/PlayerRecipeTransferHandler.java
@@ -52,7 +52,7 @@ public class PlayerRecipeTransferHandler implements IRecipeTransferHandler<Playe
 
 	@Nullable
 	@Override
-	public IRecipeTransferError transferRecipe(PlayerContainer container, IRecipeLayout recipeLayout, PlayerEntity player, boolean maxTransfer, boolean doTransfer) {
+	public IRecipeTransferError transferRecipe(PlayerContainer container, Object recipe, IRecipeLayout recipeLayout, PlayerEntity player, boolean maxTransfer, boolean doTransfer) {
 		if (!ServerInfo.isJeiOnServer()) {
 			ITextComponent tooltipMessage = new TranslationTextComponent("jei.tooltip.error.recipe.transfer.no.server");
 			return handlerHelper.createUserErrorWithTooltip(tooltipMessage);

--- a/src/main/java/mezz/jei/util/ErrorUtil.java
+++ b/src/main/java/mezz/jei/util/ErrorUtil.java
@@ -8,6 +8,8 @@ import java.util.List;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.config.ClientConfig;
 import mezz.jei.ingredients.IngredientsForType;
+import net.minecraft.fluid.Fluid;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -176,6 +178,26 @@ public final class ErrorUtil {
 		return itemStack + " " + itemName;
 	}
 
+	public static String getFluidStackInfo(@Nullable FluidStack fluidStack) {
+		if (fluidStack == null) {
+			return "null";
+		}
+		Fluid fluid = fluidStack.getFluid();
+		final String fluidName;
+		ResourceLocation registryName = fluid.getRegistryName();
+		if (registryName != null) {
+			fluidName = registryName.toString();
+		} else {
+			fluidName = fluid.getClass().getName();
+		}
+
+		CompoundNBT nbt = fluidStack.getTag();
+		if (nbt != null) {
+			return fluidStack + " " + fluidName + " nbt:" + nbt;
+		}
+		return fluidStack + " " + fluidName;
+	}
+
 	public static void checkNotEmpty(@Nullable ItemStack itemStack) {
 		if (itemStack == null) {
 			throw new NullPointerException("ItemStack must not be null.");
@@ -191,6 +213,15 @@ public final class ErrorUtil {
 		} else if (itemStack.isEmpty()) {
 			String info = getItemStackInfo(itemStack);
 			throw new IllegalArgumentException("ItemStack " + name + " must not be empty. " + info);
+		}
+	}
+
+	public static void checkNotEmpty(@Nullable FluidStack fluidStack) {
+		if (fluidStack == null) {
+			throw new NullPointerException("FluidStack must not be null.");
+		} else if (fluidStack.isEmpty()) {
+			String info = getFluidStackInfo(fluidStack);
+			throw new IllegalArgumentException("FluidStack value must not be empty. " + info);
 		}
 	}
 

--- a/src/test/java/mezz/jei/test/lib/TestIngredientHelper.java
+++ b/src/test/java/mezz/jei/test/lib/TestIngredientHelper.java
@@ -4,14 +4,26 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 
 import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.subtypes.UidContext;
 
 public class TestIngredientHelper implements IIngredientHelper<TestIngredient> {
+	@Override
+	@Nullable
+	@Deprecated
+	public TestIngredient getMatch(Iterable<TestIngredient> ingredients, TestIngredient toMatch) {
+		return getMatch(ingredients, toMatch, UidContext.Ingredient);
+	}
+
 	@Nullable
 	@Override
-	public TestIngredient getMatch(Iterable<TestIngredient> ingredients, TestIngredient ingredientToMatch) {
+	public TestIngredient getMatch(Iterable<TestIngredient> ingredients, TestIngredient ingredientToMatch, UidContext context) {
 		for (TestIngredient ingredient : ingredients) {
 			if (ingredient.getNumber() == ingredientToMatch.getNumber()) {
-				return ingredient;
+				String keyLhs = getUniqueId(ingredientToMatch, context);
+				String keyRhs = getUniqueId(ingredient, context);
+				if (keyLhs.equals(keyRhs)) {
+					return ingredient;
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
This PR fixes a couple minor things I came across and fixed in the port to 1.17 (#2426) when removing deprecated methods of doing things.
- Two `IRecipeManager#getRecipes` methods that were deprecated in 7.7.1 based on the JavaDoc were missing the deprecated annotation
- A references to and one implementation of `IRecipeTransferHandler#transferRecipe` were still referencing the deprecated version
- `IIngredientHelper#getMatch` for `FluidStackHelper`, `TestIngredientHelper`, and `DebugIngredientHelper` were all ignoring the `UidContext`. This strictly speaking only matters for the `FluidStackHelper` due to it actually supporting setting that type of data/NBT as of #2263, though I added the same fix to the other two types as well for consistency.
- `FluidStackHelper#getWildCard` did not get overrode in #2263 to be similar to how `ItemStackHelper` is in that the wild card does not give NBT. I overrode it to return functionality/behavior to that and updated the JavaDoc to properly not reference fluid stacks as a type that has no nbt so can just fallback to the default implementation of the unique id.
- VanillaRecipeCategoryUid referencing the wrong classes for some recipes