### PR TITLE
Perform code cleanup and make use of modern Java features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,15 +40,17 @@ version = "${semver}.${build_number}"
 group = 'mezz.jei' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 
 sourceSets {
-	api
+	api {
+		//The API has no resources
+		resources.srcDirs = []
+	}
 	main {
 		compileClasspath += sourceSets.api.output
 		runtimeClasspath += sourceSets.api.output
-		resources {
-			srcDir 'src/generated/resources'
-		}
 	}
 	test {
+		//The test module has no resources
+		resources.srcDirs = []
 		compileClasspath += sourceSets.api.output
 		runtimeClasspath += sourceSets.api.output
 	}
@@ -94,14 +96,6 @@ minecraft {
 		server {
 			property 'forge.logging.console.level', 'debug'
 			workingDirectory file('run')
-			mods {
-				jei.sources((SourceSet[]) [sourceSets.main, sourceSets.api])
-			}
-		}
-		data {
-			property 'forge.logging.console.level', 'debug'
-			workingDirectory file('run')
-			args '--mod', 'jei', '--all', '--output', file('src/generated/resources/')
 			mods {
 				jei.sources((SourceSet[]) [sourceSets.main, sourceSets.api])
 			}

--- a/src/api/java/mezz/jei/api/recipe/category/IRecipeCategory.java
+++ b/src/api/java/mezz/jei/api/recipe/category/IRecipeCategory.java
@@ -117,8 +117,7 @@ public interface IRecipeCategory<T> {
 	 * @since JEI 7.2.0
 	 */
 	default boolean isHandled(T recipe) {
-		if (recipe instanceof Recipe) {
-			Recipe<?> iRecipe = (Recipe<?>) recipe;
+		if (recipe instanceof Recipe<?> iRecipe) {
 			return !iRecipe.isSpecial();
 		}
 		return true;

--- a/src/main/java/mezz/jei/color/ColorGetter.java
+++ b/src/main/java/mezz/jei/color/ColorGetter.java
@@ -94,8 +94,7 @@ public final class ColorGetter implements IColorHelper {
 		final Item item = itemStack.getItem();
 		if (itemStack.isEmpty()) {
 			return Collections.emptyList();
-		} else if (item instanceof BlockItem) {
-			final BlockItem itemBlock = (BlockItem) item;
+		} else if (item instanceof final BlockItem itemBlock) {
 			final Block block = itemBlock.getBlock();
 			//noinspection ConstantConditions
 			if (block == null) {

--- a/src/main/java/mezz/jei/config/BookmarkConfig.java
+++ b/src/main/java/mezz/jei/config/BookmarkConfig.java
@@ -41,7 +41,7 @@ public class BookmarkConfig {
 		for (IIngredientListElement<?> element : ingredientListElements) {
 			Object object = element.getIngredient();
 			if (object instanceof ItemStack) {
-				strings.add(MARKER_STACK + ((ItemStack) object).save(new CompoundTag()).toString());
+				strings.add(MARKER_STACK + ((ItemStack) object).save(new CompoundTag()));
 			} else {
 				strings.add(MARKER_OTHER + getUid(ingredientManager, element));
 			}

--- a/src/main/java/mezz/jei/config/BookmarkConfig.java
+++ b/src/main/java/mezz/jei/config/BookmarkConfig.java
@@ -40,8 +40,8 @@ public class BookmarkConfig {
 		List<String> strings = new ArrayList<>();
 		for (IIngredientListElement<?> element : ingredientListElements) {
 			Object object = element.getIngredient();
-			if (object instanceof ItemStack) {
-				strings.add(MARKER_STACK + ((ItemStack) object).save(new CompoundTag()));
+			if (object instanceof ItemStack stack) {
+				strings.add(MARKER_STACK + stack.save(new CompoundTag()));
 			} else {
 				strings.add(MARKER_OTHER + getUid(ingredientManager, element));
 			}

--- a/src/main/java/mezz/jei/config/ClientConfig.java
+++ b/src/main/java/mezz/jei/config/ClientConfig.java
@@ -88,8 +88,7 @@ public final class ClientConfig implements IJEIConfig, IClientConfig {
 		{
 			builder.comment("Color values to search for");
 			searchColorsCfg = builder.defineList("SearchColors", Lists.newArrayList(ColorGetter.getColorDefaults()), obj -> {
-				if (obj instanceof String) {
-					String entry = (String) obj;
+				if (obj instanceof String entry) {
 					String[] values = entry.split(":");
 					if (values.length == 2) {
 						try {
@@ -234,8 +233,7 @@ public final class ClientConfig implements IJEIConfig, IClientConfig {
 			validEntries.add(name);
 		}
 		return obj -> {
-			if (obj instanceof String) {
-				String name = (String) obj;
+			if (obj instanceof String name) {
 				return validEntries.contains(name);
 			}
 			return false;

--- a/src/main/java/mezz/jei/config/EditModeConfig.java
+++ b/src/main/java/mezz/jei/config/EditModeConfig.java
@@ -175,7 +175,6 @@ public class EditModeConfig implements IEditModeConfig {
 		return switch (blacklistType) {
 			case ITEM -> ingredientHelper.getUniqueId(ingredient, UidContext.Ingredient);
 			case WILDCARD -> ingredientHelper.getWildcardId(ingredient);
-			default -> throw new IllegalStateException("Unknown blacklist type: " + blacklistType);
 		};
 	}
 }

--- a/src/main/java/mezz/jei/config/EditModeConfig.java
+++ b/src/main/java/mezz/jei/config/EditModeConfig.java
@@ -172,13 +172,10 @@ public class EditModeConfig implements IEditModeConfig {
 	}
 
 	private static <V> String getIngredientUid(V ingredient, IngredientBlacklistType blacklistType, IIngredientHelper<V> ingredientHelper) {
-		switch (blacklistType) {
-			case ITEM:
-				return ingredientHelper.getUniqueId(ingredient, UidContext.Ingredient);
-			case WILDCARD:
-				return ingredientHelper.getWildcardId(ingredient);
-			default:
-				throw new IllegalStateException("Unknown blacklist type: " + blacklistType);
-		}
+		return switch (blacklistType) {
+			case ITEM -> ingredientHelper.getUniqueId(ingredient, UidContext.Ingredient);
+			case WILDCARD -> ingredientHelper.getWildcardId(ingredient);
+			default -> throw new IllegalStateException("Unknown blacklist type: " + blacklistType);
+		};
 	}
 }

--- a/src/main/java/mezz/jei/config/ModIdFormattingConfig.java
+++ b/src/main/java/mezz/jei/config/ModIdFormattingConfig.java
@@ -110,7 +110,7 @@ public class ModIdFormattingConfig implements IJEIConfig {
 		for (String string : strings) {
 			ChatFormatting valueByName = ChatFormatting.getByName(string);
 			if (valueByName != null) {
-				format.append(valueByName.toString());
+				format.append(valueByName);
 			} else {
 				LOGGER.error("Invalid format: {}", string);
 			}

--- a/src/main/java/mezz/jei/config/forge/Config.java
+++ b/src/main/java/mezz/jei/config/forge/Config.java
@@ -51,7 +51,7 @@ public @interface Config
      */
     String category() default "general";
 
-    public static enum Type
+    enum Type
     {
         /**
         * Loaded once, directly after mod construction. Before pre-init.
@@ -61,7 +61,7 @@ public @interface Config
 
 
         private boolean isStatic = true;
-        private Type(boolean isStatic) { this.isStatic = isStatic; }
+        Type(boolean isStatic) { this.isStatic = isStatic; }
         public boolean isStatic(){ return this.isStatic; }
     }
 

--- a/src/main/java/mezz/jei/config/forge/Config.java
+++ b/src/main/java/mezz/jei/config/forge/Config.java
@@ -60,7 +60,7 @@ public @interface Config
         INSTANCE(true);
 
 
-        private boolean isStatic = true;
+        private boolean isStatic;
         Type(boolean isStatic) { this.isStatic = isStatic; }
         public boolean isStatic(){ return this.isStatic; }
     }

--- a/src/main/java/mezz/jei/config/forge/ConfigCategory.java
+++ b/src/main/java/mezz/jei/config/forge/ConfigCategory.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -75,9 +76,8 @@ public class ConfigCategory implements Map<String, Property>
     @Override
     public boolean equals(Object obj)
     {
-        if (obj instanceof ConfigCategory)
+        if (obj instanceof ConfigCategory cat)
         {
-            ConfigCategory cat = (ConfigCategory)obj;
             return name.equals(cat.name) && children.equals(cat.children);
         }
 
@@ -224,10 +224,7 @@ public class ConfigCategory implements Map<String, Property>
 
     public List<String> getPropertyOrder()
     {
-        if (this.propertyOrder != null)
-            return ImmutableList.copyOf(this.propertyOrder);
-        else
-            return ImmutableList.copyOf(properties.keySet());
+        return ImmutableList.copyOf(Objects.requireNonNullElseGet(this.propertyOrder, () -> properties.keySet()));
     }
 
     public boolean containsKey(String key)
@@ -247,9 +244,9 @@ public class ConfigCategory implements Map<String, Property>
 
     private void write(BufferedWriter out, boolean new_line, String... data) throws IOException
     {
-        for (int x = 0; x < data.length; x++)
+        for (String datum : data)
         {
-            out.write(data[x]);
+            out.write(datum);
         }
         if (new_line) out.newLine();
     }
@@ -350,12 +347,7 @@ public class ConfigCategory implements Map<String, Property>
 
     private String getIndent(int indent)
     {
-        StringBuilder buf = new StringBuilder("");
-        for (int x = 0; x < indent; x++)
-        {
-            buf.append("    ");
-        }
-        return buf.toString();
+        return "    ".repeat(Math.max(0, indent));
     }
 
     public boolean hasChanged()

--- a/src/main/java/mezz/jei/config/forge/ConfigElement.java
+++ b/src/main/java/mezz/jei/config/forge/ConfigElement.java
@@ -219,14 +219,14 @@ public class ConfigElement implements IConfigElement
             {
                 Double[] da = new Double[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    da[i] = Double.valueOf(aVal[i].toString());
+                    da[i] = Double.valueOf(aVal[i]);
                 return da;
             }
             else if (type == Property.Type.INTEGER)
             {
                 Integer[] ia = new Integer[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    ia[i] = Integer.valueOf(aVal[i].toString());
+                    ia[i] = Integer.valueOf(aVal[i]);
                 return ia;
             }
             else
@@ -269,14 +269,14 @@ public class ConfigElement implements IConfigElement
             {
                 Double[] da = new Double[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    da[i] = Double.valueOf(aVal[i].toString());
+                    da[i] = Double.valueOf(aVal[i]);
                 return da;
             }
             else if (type == Property.Type.INTEGER)
             {
                 Integer[] ia = new Integer[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    ia[i] = Integer.valueOf(aVal[i].toString());
+                    ia[i] = Integer.valueOf(aVal[i]);
                 return ia;
             }
             else

--- a/src/main/java/mezz/jei/config/forge/ConfigElement.java
+++ b/src/main/java/mezz/jei/config/forge/ConfigElement.java
@@ -310,21 +310,21 @@ public class ConfigElement implements IConfigElement
             {
                 boolean[] ba = new boolean[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    ba[i] = Boolean.valueOf(aVal[i].toString());
+                    ba[i] = Boolean.parseBoolean(aVal[i].toString());
                 prop.set(ba);
             }
             else if (type == Property.Type.DOUBLE)
             {
                 double[] da = new double[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    da[i] = Double.valueOf(aVal[i].toString());
+                    da[i] = Double.parseDouble(aVal[i].toString());
                 prop.set(da);
             }
             else if (type == Property.Type.INTEGER)
             {
                 int[] ia = new int[aVal.length];
                 for(int i = 0; i < aVal.length; i++)
-                    ia[i] = Integer.valueOf(aVal[i].toString());
+                    ia[i] = Integer.parseInt(aVal[i].toString());
                 prop.set(ia);
             }
             else

--- a/src/main/java/mezz/jei/config/forge/ConfigGuiType.java
+++ b/src/main/java/mezz/jei/config/forge/ConfigGuiType.java
@@ -27,5 +27,5 @@ public enum ConfigGuiType
 	DOUBLE,
 	COLOR,
 	MOD_ID,
-	CONFIG_CATEGORY;
+	CONFIG_CATEGORY
 }

--- a/src/main/java/mezz/jei/config/forge/Configuration.java
+++ b/src/main/java/mezz/jei/config/forge/Configuration.java
@@ -66,8 +66,8 @@ public class Configuration
     public static final String NEW_LINE;
     public static final String COMMENT_SEPARATOR = "##########################################################################################################";
     private static final String CONFIG_VERSION_MARKER = "~CONFIG_VERSION";
-    private static final Pattern CONFIG_START = Pattern.compile("START: \"([^\\\"]+)\"");
-    private static final Pattern CONFIG_END = Pattern.compile("END: \"([^\\\"]+)\"");
+    private static final Pattern CONFIG_START = Pattern.compile("START: \"([^\"]+)\"");
+    private static final Pattern CONFIG_END = Pattern.compile("END: \"([^\"]+)\"");
     public static final CharMatcher allowedProperties = CharMatcher.javaLetterOrDigit().or(CharMatcher.anyOf(ALLOWED_CHARS));
     private static Configuration PARENT = null;
 

--- a/src/main/java/mezz/jei/config/forge/Configuration.java
+++ b/src/main/java/mezz/jei/config/forge/Configuration.java
@@ -1666,7 +1666,7 @@ public class Configuration
         prop.setComment(comment + " [range: " + minValue + " ~ " + maxValue + ", default: " + defaultValue + "]");
         prop.setMinValue(minValue);
         prop.setMaxValue(maxValue);
-        return prop.getInt(defaultValue) < minValue ? minValue : (prop.getInt(defaultValue) > maxValue ? maxValue : prop.getInt(defaultValue));
+        return prop.getInt(defaultValue) < minValue ? minValue : Math.min(prop.getInt(defaultValue), maxValue);
     }
 
     /**

--- a/src/main/java/mezz/jei/config/forge/Property.java
+++ b/src/main/java/mezz/jei/config/forge/Property.java
@@ -813,7 +813,7 @@ public class Property
      */
     public boolean isBooleanValue()
     {
-        return ("true".equals(value.toLowerCase()) || "false".equals(value.toLowerCase()));
+        return ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value));
     }
 
     /**

--- a/src/main/java/mezz/jei/config/forge/Property.java
+++ b/src/main/java/mezz/jei/config/forge/Property.java
@@ -891,7 +891,7 @@ public class Property
             {
                 nums.add(Integer.parseInt(value));
             }
-            catch (NumberFormatException e){}
+            catch (NumberFormatException ignored){}
         }
 
         int[] primitives = new int[nums.size()];
@@ -940,7 +940,7 @@ public class Property
             {
                 tmp.add(Boolean.parseBoolean(value));
             }
-            catch (NumberFormatException e){}
+            catch (NumberFormatException ignored){}
         }
 
         boolean[] primitives = new boolean[tmp.size()];
@@ -986,7 +986,7 @@ public class Property
             {
                 tmp.add(Double.parseDouble(value));
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException ignored) {}
         }
 
         double[] primitives = new double[tmp.size()];

--- a/src/main/java/mezz/jei/config/forge/Property.java
+++ b/src/main/java/mezz/jei/config/forge/Property.java
@@ -84,8 +84,8 @@ public class Property
     private Pattern validationPattern;
     private final boolean wasRead;
     private final boolean isList;
-    private boolean isListLengthFixed = false;
-    private int maxListLength = -1;
+    private boolean isListLengthFixed;
+    private int maxListLength;
     private final Type type;
     private boolean changed = false;
 

--- a/src/main/java/mezz/jei/config/sorting/serializers/SortingSerializers.java
+++ b/src/main/java/mezz/jei/config/sorting/serializers/SortingSerializers.java
@@ -8,7 +8,7 @@ import java.io.Reader;
 import java.util.List;
 
 public final class SortingSerializers {
-	public static final ISortingSerializer<String> STRING = new ISortingSerializer<String>() {
+	public static final ISortingSerializer<String> STRING = new ISortingSerializer<>() {
 		@Override
 		public List<String> read(Reader reader) throws IOException {
 			return IOUtils.readLines(reader);

--- a/src/main/java/mezz/jei/gui/GuiEventHandler.java
+++ b/src/main/java/mezz/jei/gui/GuiEventHandler.java
@@ -128,8 +128,7 @@ public class GuiEventHandler {
 		}
 		drawnOnBackground = false;
 
-		if (gui instanceof AbstractContainerScreen) {
-			AbstractContainerScreen<?> guiContainer = (AbstractContainerScreen<?>) gui;
+		if (gui instanceof AbstractContainerScreen<?> guiContainer) {
 			IGuiClickableArea guiClickableArea = guiScreenHelper.getGuiClickableArea(guiContainer, event.getMouseX() - guiContainer.getGuiLeft(), event.getMouseY() - guiContainer.getGuiTop());
 			if (guiClickableArea != null) {
 				List<Component> tooltipStrings = guiClickableArea.getTooltipStrings();

--- a/src/main/java/mezz/jei/gui/GuiScreenHelper.java
+++ b/src/main/java/mezz/jei/gui/GuiScreenHelper.java
@@ -101,8 +101,7 @@ public class GuiScreenHelper {
 			return Collections.emptySet();
 		}
 		Set<Rect2i> allGuiExtraAreas = new HashSet<>();
-		if (screen instanceof AbstractContainerScreen) {
-			AbstractContainerScreen<?> guiContainer = (AbstractContainerScreen<?>) screen;
+		if (screen instanceof AbstractContainerScreen<?> guiContainer) {
 			Collection<Rect2i> guiExtraAreas = this.guiContainerHandlers.getGuiExtraAreas(guiContainer);
 			allGuiExtraAreas.addAll(guiExtraAreas);
 		}

--- a/src/main/java/mezz/jei/gui/elements/DrawableAnimated.java
+++ b/src/main/java/mezz/jei/gui/elements/DrawableAnimated.java
@@ -64,20 +64,11 @@ public class DrawableAnimated implements IDrawableAnimated {
 		int animationValue = tickTimer.getValue();
 
 		switch (startDirection) {
-			case TOP:
-				maskBottom = animationValue;
-				break;
-			case BOTTOM:
-				maskTop = animationValue;
-				break;
-			case LEFT:
-				maskRight = animationValue;
-				break;
-			case RIGHT:
-				maskLeft = animationValue;
-				break;
-			default:
-				throw new IllegalStateException("Unknown startDirection " + startDirection);
+			case TOP -> maskBottom = animationValue;
+			case BOTTOM -> maskTop = animationValue;
+			case LEFT -> maskRight = animationValue;
+			case RIGHT -> maskLeft = animationValue;
+			default -> throw new IllegalStateException("Unknown startDirection " + startDirection);
 		}
 
 		drawable.draw(poseStack, xOffset, yOffset, maskTop, maskBottom, maskLeft, maskRight);

--- a/src/main/java/mezz/jei/gui/elements/GuiIconButton.java
+++ b/src/main/java/mezz/jei/gui/elements/GuiIconButton.java
@@ -63,10 +63,10 @@ public class GuiIconButton extends Button {
 				color |= -16777216;
 			}
 
-			float red = (float) (color >> 16 & 255) / 255.0F;
-			float blue = (float) (color >> 8 & 255) / 255.0F;
-			float green = (float) (color & 255) / 255.0F;
-			float alpha = (float) (color >> 24 & 255) / 255.0F;
+			float red = (color >> 16 & 255) / 255.0F;
+			float blue = (color >> 8 & 255) / 255.0F;
+			float green = (color & 255) / 255.0F;
+			float alpha = (color >> 24 & 255) / 255.0F;
 			RenderSystem.setShaderColor(red, blue, green, alpha);
 
 			double xOffset = x + (width - icon.getWidth()) / 2.0;

--- a/src/main/java/mezz/jei/gui/elements/GuiIconButtonSmall.java
+++ b/src/main/java/mezz/jei/gui/elements/GuiIconButtonSmall.java
@@ -49,10 +49,10 @@ public class GuiIconButtonSmall extends Button {
 				color |= -16777216;
 			}
 
-			float red = (float) (color >> 16 & 255) / 255.0F;
-			float blue = (float) (color >> 8 & 255) / 255.0F;
-			float green = (float) (color & 255) / 255.0F;
-			float alpha = (float) (color >> 24 & 255) / 255.0F;
+			float red = (color >> 16 & 255) / 255.0F;
+			float blue = (color >> 8 & 255) / 255.0F;
+			float green = (color & 255) / 255.0F;
+			float alpha = (color >> 24 & 255) / 255.0F;
 			RenderSystem.setShaderColor(red, blue, green, alpha);
 
 			double xOffset = x + (width - this.icon.getWidth()) / 2.0;

--- a/src/main/java/mezz/jei/gui/ghost/GhostIngredientDrag.java
+++ b/src/main/java/mezz/jei/gui/ghost/GhostIngredientDrag.java
@@ -81,10 +81,10 @@ public class GhostIngredientDrag<T> {
 			GL11.glEnable(GL11.GL_LINE_SMOOTH);
 			GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_NICEST);
 			GL11.glBegin(GL11.GL_LINES);
-			float red = (float) (targetColor >> 24 & 255) / 255.0F;
-			float green = (float) (targetColor >> 16 & 255) / 255.0F;
-			float blue = (float) (targetColor >> 8 & 255) / 255.0F;
-			float alpha = (float) (targetColor & 255) / 255.0F;
+			float red = (targetColor >> 24 & 255) / 255.0F;
+			float green = (targetColor >> 16 & 255) / 255.0F;
+			float blue = (targetColor >> 8 & 255) / 255.0F;
+			float alpha = (targetColor & 255) / 255.0F;
 			RenderSystem.setShaderColor(red, green, blue, alpha);
 			GL11.glVertex3f(mouseX, mouseY, 150);
 			GL11.glVertex3f(originX, originY, 150);

--- a/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
+++ b/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
@@ -108,12 +108,7 @@ public class GuiIngredient<T> extends GuiComponent implements IGuiIngredient<T> 
 	public void set(@Nullable List<T> ingredients, @Nullable Focus<T> focus) {
 		this.displayIngredients.clear();
 		this.allIngredients.clear();
-		List<T> displayIngredients;
-		if (ingredients == null) {
-			displayIngredients = Collections.emptyList();
-		} else {
-			displayIngredients = ingredients;
-		}
+		List<T> displayIngredients = Objects.requireNonNullElse(ingredients, Collections.emptyList());
 
 		T match = getMatch(displayIngredients, focus);
 		if (match != null) {

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -175,8 +175,7 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 		GiveMode giveMode = this.clientConfig.getGiveMode();
 		if (giveMode == GiveMode.MOUSE_PICKUP) {
 			IClickedIngredient<?> ingredientUnderMouse = getIngredientUnderMouse(mouseX, mouseY);
-			if (ingredientUnderMouse != null && ingredientUnderMouse.getValue() instanceof ItemStack) {
-				ItemStack value = (ItemStack) ingredientUnderMouse.getValue();
+			if (ingredientUnderMouse != null && ingredientUnderMouse.getValue() instanceof ItemStack value) {
 				return !ItemHandlerHelper.canItemStacksStack(itemStack, value);
 			}
 		}

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
@@ -119,7 +119,7 @@ public class BookmarkOverlay implements IShowsRecipeFocuses, ILeftAreaContent, I
 
 		this.bookmarkButton.updateBounds(new Rect2i(
 			displayArea.getX(),
-			(int) Math.floor(displayArea.getY() + displayArea.getHeight()) - BUTTON_SIZE - 2,
+			displayArea.getY() + displayArea.getHeight() - BUTTON_SIZE - 2,
 			BUTTON_SIZE,
 			BUTTON_SIZE
 		));

--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -532,8 +532,8 @@ public class RecipesGui extends Screen implements IRecipesGui, IShowsRecipeFocus
 
 	@Nullable
 	private AbstractContainerMenu getParentContainer() {
-		if (parentScreen instanceof AbstractContainerScreen) {
-			return ((AbstractContainerScreen<?>) parentScreen).getMenu();
+		if (parentScreen instanceof AbstractContainerScreen<?> screen) {
+			return screen.getMenu();
 		}
 		return null;
 	}

--- a/src/main/java/mezz/jei/ingredients/IngredientSorter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientSorter.java
@@ -216,7 +216,7 @@ public final class IngredientSorter implements IIngredientSorter {
 	};
 
 	private static Double getAttackDamage(ItemStack itemStack) {
-		Double attackDamage = Double.MIN_VALUE;
+		double attackDamage = Double.MIN_VALUE;
 		if (!isTool(itemStack) && !isArmor(itemStack)) {
 			Multimap<Attribute, AttributeModifier> multimap = itemStack.getAttributeModifiers(EquipmentSlot.MAINHAND);
 			boolean hasDamage = multimap.containsKey(Attributes.ATTACK_DAMAGE);
@@ -229,8 +229,8 @@ public final class IngredientSorter implements IIngredientSorter {
 	};
 
 	private static Double getAttackSpeed(ItemStack itemStack) {
-		Double attackDamage = Double.MIN_VALUE;
-		Double attackSpeed = Double.MIN_VALUE;
+		double attackDamage = Double.MIN_VALUE;
+		double attackSpeed = Double.MIN_VALUE;
 		//This is the isWeapon test so we don't order by these properties for non-weapons.
 		if (!isTool(itemStack) && !isArmor(itemStack)) {
 			Multimap<Attribute, AttributeModifier> multimap = itemStack.getAttributeModifiers(EquipmentSlot.MAINHAND);

--- a/src/main/java/mezz/jei/ingredients/IngredientSorter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientSorter.java
@@ -338,7 +338,7 @@ public final class IngredientSorter implements IIngredientSorter {
 					nullToolClassWarned = true;
 					LogManager.getLogger().warn("Item '" + item.getRegistryName() + "' has a null tool class entry.");
 				}
-			} else if (toolClass.getName() != "sword") {
+			} else if (!toolClass.getName().equals("sword")) {
 				//Swords are not "tools".
 				toolClassSet.add(toolClass.getName());
 			}

--- a/src/main/java/mezz/jei/ingredients/IngredientSorter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientSorter.java
@@ -139,9 +139,9 @@ public final class IngredientSorter implements IIngredientSorter {
 
 	private Comparator<IIngredientListElementInfo<?>> createTagComparator() {
 		Comparator<IIngredientListElementInfo<?>> isTagged = 
-			Comparator.comparing(o -> hasTag(o));
+			Comparator.comparing(IngredientSorter::hasTag);
 		Comparator<IIngredientListElementInfo<?>> tag = 
-			Comparator.comparing(o -> getTagForSorting(o));
+			Comparator.comparing(IngredientSorter::getTagForSorting);
 		return isTagged.reversed().thenComparing(tag);
 	}
 
@@ -263,8 +263,7 @@ public final class IngredientSorter implements IIngredientSorter {
 
 	private static int getArmorSlotIndex(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
-		if (item instanceof ArmorItem) {
-			ArmorItem armorItem = (ArmorItem) item;				
+		if (item instanceof ArmorItem armorItem) {
 			return armorItem.getSlot().getFilterFlag();
 		}
 		return 0;
@@ -272,8 +271,7 @@ public final class IngredientSorter implements IIngredientSorter {
 
 	private static int getArmorDamageReduce(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
-		if (item instanceof ArmorItem) {
-			ArmorItem armorItem = (ArmorItem) item;				
+		if (item instanceof ArmorItem armorItem) {
 			return armorItem.getDefense();
 		}
 		return Integer.MIN_VALUE;
@@ -281,8 +279,7 @@ public final class IngredientSorter implements IIngredientSorter {
 
 	private static float getArmorToughness(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
-		if (item instanceof ArmorItem) {
-			ArmorItem armorItem = (ArmorItem) item;				
+		if (item instanceof ArmorItem armorItem) {
 			return armorItem.getToughness();
 		}
 		return Float.MIN_VALUE;
@@ -332,7 +329,7 @@ public final class IngredientSorter implements IIngredientSorter {
 		Item item = itemStack.getItem();
 		Set<ToolType> toolTypeSet = item.getToolTypes(itemStack);
 		
-		Set<String> toolClassSet = new HashSet<String>();
+		Set<String> toolClassSet = new HashSet<>();
 
 		for (ToolType toolClass: toolTypeSet) {
 			if (toolClass == null) {
@@ -362,9 +359,9 @@ public final class IngredientSorter implements IIngredientSorter {
 		
 		//We have a preferred type to list tools under, primarily the pickaxe for harvest level.
 		String[] prefOrder = {"pickaxe", "axe", "shovel", "hoe", "shears", "wrench"};
-		for (int i = 0; i < prefOrder.length; i++) {
-			if (toolClassSet.contains(prefOrder[i])) {
-				return prefOrder[i];
+		for (String type : prefOrder) {
+			if (toolClassSet.contains(type)) {
+				return type;
 			}
 		}
 		

--- a/src/main/java/mezz/jei/ingredients/IngredientSorter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientSorter.java
@@ -229,7 +229,6 @@ public final class IngredientSorter implements IIngredientSorter {
 	}
 
 	private static Double getAttackSpeed(ItemStack itemStack) {
-		double attackDamage = Double.MIN_VALUE;
 		double attackSpeed = Double.MIN_VALUE;
 		//This is the isWeapon test so we don't order by these properties for non-weapons.
 		if (!isTool(itemStack) && !isArmor(itemStack)) {
@@ -238,7 +237,7 @@ public final class IngredientSorter implements IIngredientSorter {
 			boolean hasSpeed = multimap.containsKey(Attributes.ATTACK_SPEED);			
 			if (hasDamage) {
 				Collection<AttributeModifier> damageMap = multimap.get(Attributes.ATTACK_DAMAGE);
-				attackDamage = ((AttributeModifier) damageMap.toArray()[0]).getAmount();
+				double attackDamage = ((AttributeModifier) damageMap.toArray()[0]).getAmount();
 				//Apply the isWeapon final test here.
 				if (attackDamage > notQuiteZero && hasSpeed) {
 					Collection<AttributeModifier> speedMap = multimap.get(Attributes.ATTACK_SPEED);

--- a/src/main/java/mezz/jei/ingredients/IngredientSorter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientSorter.java
@@ -189,19 +189,19 @@ public final class IngredientSorter implements IIngredientSorter {
 			maxDamage = itemStack.getMaxDamage();	
 		}
 		return maxDamage;
-	};
+	}
 
 	private static int getHarvestLevel(ItemStack itemStack) {		
 		if (itemStack != ItemStack.EMPTY) {
 			return (itemStack.getToolTypes().size() > 0 ? itemStack.getHarvestLevel(itemStack.getToolTypes().iterator().next(), null, null) : -1);
 		}
 		return -1;
-	};
+	}
 
 	private static boolean isTool(ItemStack itemStack){
 		//Sort non-tools after the tools.
 		return !getToolClass(itemStack).isEmpty();
-	};
+	}
 
 	private static int getToolDurability(ItemStack itemStack) {
 		if (isTool(itemStack))
@@ -213,7 +213,7 @@ public final class IngredientSorter implements IIngredientSorter {
 		//Sort Weapons apart from tools, armor, and other random things..		
 		//AttackDamage also filters out Tools and Armor.  Anything that deals extra damage is a weapon.
 		return getAttackDamage(itemStack) > notQuiteZero;
-	};
+	}
 
 	private static Double getAttackDamage(ItemStack itemStack) {
 		double attackDamage = Double.MIN_VALUE;
@@ -226,7 +226,7 @@ public final class IngredientSorter implements IIngredientSorter {
 			}
 		}
 		return attackDamage;
-	};
+	}
 
 	private static Double getAttackSpeed(ItemStack itemStack) {
 		double attackDamage = Double.MIN_VALUE;
@@ -247,7 +247,7 @@ public final class IngredientSorter implements IIngredientSorter {
 			}
 		}
 		return attackSpeed;
-	};
+	}
 
 	private static int getWeaponDurability(ItemStack itemStack) {
 		if (isWeapon(itemStack)) {
@@ -259,7 +259,7 @@ public final class IngredientSorter implements IIngredientSorter {
 	private static boolean isArmor(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
 		return item instanceof ArmorItem;
-	};
+	}
 
 	private static int getArmorSlotIndex(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
@@ -267,7 +267,7 @@ public final class IngredientSorter implements IIngredientSorter {
 			return armorItem.getSlot().getFilterFlag();
 		}
 		return 0;
-	};
+	}
 
 	private static int getArmorDamageReduce(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
@@ -275,7 +275,7 @@ public final class IngredientSorter implements IIngredientSorter {
 			return armorItem.getDefense();
 		}
 		return Integer.MIN_VALUE;
-	};
+	}
 
 	private static float getArmorToughness(ItemStack itemStack) {
 		Item item = itemStack.getItem();	
@@ -283,7 +283,7 @@ public final class IngredientSorter implements IIngredientSorter {
 			return armorItem.getToughness();
 		}
 		return Float.MIN_VALUE;
-	};
+	}
 
 	private static int getArmorDurability(ItemStack itemStack) {
 		if (isArmor(itemStack))
@@ -310,12 +310,12 @@ public final class IngredientSorter implements IIngredientSorter {
 			}
 		}
 		return bestTag;
-	};
+	}
 
 	private static boolean hasTag(IIngredientListElementInfo<?> elementInfo){
 		//Sort non-tools after the tools.
 		return !getTagForSorting(elementInfo).isEmpty();
-	};
+	}
 
 
 	private static Boolean nullToolClassWarned = false;

--- a/src/main/java/mezz/jei/input/GuiContainerWrapper.java
+++ b/src/main/java/mezz/jei/input/GuiContainerWrapper.java
@@ -22,10 +22,9 @@ public class GuiContainerWrapper implements IShowsRecipeFocuses {
 	@Override
 	public IClickedIngredient<?> getIngredientUnderMouse(double mouseX, double mouseY) {
 		Screen guiScreen = Minecraft.getInstance().screen;
-		if (!(guiScreen instanceof AbstractContainerScreen)) {
+		if (!(guiScreen instanceof AbstractContainerScreen<?> guiContainer)) {
 			return null;
 		}
-		AbstractContainerScreen<?> guiContainer = (AbstractContainerScreen<?>) guiScreen;
 		Slot slotUnderMouse = guiContainer.getSlotUnderMouse();
 		if (slotUnderMouse != null) {
 			ItemStack stack = slotUnderMouse.getItem();

--- a/src/main/java/mezz/jei/input/InputHandler.java
+++ b/src/main/java/mezz/jei/input/InputHandler.java
@@ -242,8 +242,7 @@ public class InputHandler {
 		@Nullable
 		@Override
 		public IMouseHandler handleClick(Screen screen, double mouseX, double mouseY, int mouseButton, MouseClickState clickState) {
-			if (screen instanceof AbstractContainerScreen) {
-				AbstractContainerScreen<?> guiContainer = (AbstractContainerScreen<?>) screen;
+			if (screen instanceof AbstractContainerScreen<?> guiContainer) {
 				IGuiClickableArea clickableArea = guiScreenHelper.getGuiClickableArea(guiContainer, mouseX - guiContainer.getGuiLeft(), mouseY - guiContainer.getGuiTop());
 				if (clickableArea != null) {
 					return new GuiAreaClickHandler(recipesGui, clickableArea, guiContainer);

--- a/src/main/java/mezz/jei/network/packets/PacketGiveItemStack.java
+++ b/src/main/java/mezz/jei/network/packets/PacketGiveItemStack.java
@@ -31,8 +31,7 @@ public class PacketGiveItemStack extends PacketJei {
 	}
 
 	public static void readPacketData(FriendlyByteBuf buf, Player player) {
-		if (player instanceof ServerPlayer) {
-			ServerPlayer sender = (ServerPlayer) player;
+		if (player instanceof ServerPlayer sender) {
 
 			ItemStack itemStack = buf.readItem();
 			if (!itemStack.isEmpty()) {

--- a/src/main/java/mezz/jei/network/packets/PacketRequestCheatPermission.java
+++ b/src/main/java/mezz/jei/network/packets/PacketRequestCheatPermission.java
@@ -21,8 +21,7 @@ public class PacketRequestCheatPermission extends PacketJei {
 	}
 
 	public static void readPacketData(FriendlyByteBuf buf, Player player) {
-		if (player instanceof ServerPlayer) {
-			ServerPlayer sender = (ServerPlayer) player;
+		if (player instanceof ServerPlayer sender) {
 			boolean hasPermission = CommandUtilServer.hasPermission(sender);
 			PacketCheatPermission packetCheatPermission = new PacketCheatPermission(hasPermission);
 

--- a/src/main/java/mezz/jei/network/packets/PacketSetHotbarItemStack.java
+++ b/src/main/java/mezz/jei/network/packets/PacketSetHotbarItemStack.java
@@ -35,8 +35,7 @@ public class PacketSetHotbarItemStack extends PacketJei {
 	}
 
 	public static void readPacketData(FriendlyByteBuf buf, Player player) {
-		if (player instanceof ServerPlayer) {
-			ServerPlayer sender = (ServerPlayer) player;
+		if (player instanceof ServerPlayer sender) {
 
 			ItemStack itemStack = buf.readItem();
 			if (!itemStack.isEmpty()) {

--- a/src/main/java/mezz/jei/plugins/debug/JeiDebugPlugin.java
+++ b/src/main/java/mezz/jei/plugins/debug/JeiDebugPlugin.java
@@ -133,7 +133,7 @@ public class JeiDebugPlugin implements IModPlugin {
 	@Override
 	public void registerGuiHandlers(IGuiHandlerRegistration registration) {
 		if (ClientConfig.getInstance().isDebugModeEnabled()) {
-			registration.addGuiContainerHandler(BrewingStandScreen.class, new IGuiContainerHandler<BrewingStandScreen>() {
+			registration.addGuiContainerHandler(BrewingStandScreen.class, new IGuiContainerHandler<>() {
 				@Override
 				public List<Rect2i> getGuiExtraAreas(BrewingStandScreen containerScreen) {
 					int widthMovement = (int) ((System.currentTimeMillis() / 100) % 100);

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipeCategory.java
@@ -39,7 +39,7 @@ public class AnvilRecipeCategory implements IRecipeCategory<AnvilRecipe> {
 		icon = guiHelper.createDrawableIngredient(new ItemStack(Blocks.ANVIL));
 		cachedDisplayData = CacheBuilder.newBuilder()
 			.maximumSize(25)
-			.build(new CacheLoader<AnvilRecipe, AnvilRecipeDisplayData>() {
+			.build(new CacheLoader<>() {
 				@Override
 				public AnvilRecipeDisplayData load(AnvilRecipe key) {
 					return new AnvilRecipeDisplayData();

--- a/src/main/java/mezz/jei/plugins/vanilla/brewing/BrewingRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/brewing/BrewingRecipeMaker.java
@@ -150,8 +150,7 @@ public class BrewingRecipeMaker {
 
 	private void addModdedBrewingRecipes(Collection<IBrewingRecipe> brewingRecipes, Collection<IJeiBrewingRecipe> recipes) {
 		for (IBrewingRecipe iBrewingRecipe : brewingRecipes) {
-			if (iBrewingRecipe instanceof BrewingRecipe) {
-				BrewingRecipe brewingRecipe = (BrewingRecipe) iBrewingRecipe;
+			if (iBrewingRecipe instanceof BrewingRecipe brewingRecipe) {
 				ItemStack[] ingredients = brewingRecipe.getIngredient().getItems();
 				if (ingredients.length > 0) {
 					Ingredient inputIngredient = brewingRecipe.getInput();

--- a/src/main/java/mezz/jei/plugins/vanilla/brewing/JeiBrewingRecipe.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/brewing/JeiBrewingRecipe.java
@@ -54,10 +54,9 @@ public class JeiBrewingRecipe implements IJeiBrewingRecipe {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof JeiBrewingRecipe)) {
+		if (!(obj instanceof JeiBrewingRecipe other)) {
 			return false;
 		}
-		JeiBrewingRecipe other = (JeiBrewingRecipe) obj;
 
 		for (int i = 0; i < potionInputs.size(); i++) {
 			ItemStack potionInput = potionInputs.get(i);

--- a/src/main/java/mezz/jei/plugins/vanilla/cooking/AbstractCookingCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/cooking/AbstractCookingCategory.java
@@ -35,7 +35,7 @@ public abstract class AbstractCookingCategory<T extends AbstractCookingRecipe> e
 		this.localizedName = new TranslatableComponent(translationKey);
 		this.cachedArrows = CacheBuilder.newBuilder()
 			.maximumSize(25)
-			.build(new CacheLoader<Integer, IDrawableAnimated>() {
+			.build(new CacheLoader<>() {
 				@Override
 				public IDrawableAnimated load(Integer cookTime) {
 					return guiHelper.drawableBuilder(Constants.RECIPE_GUI_VANILLA, 82, 128, 24, 17)

--- a/src/main/java/mezz/jei/plugins/vanilla/crafting/CraftingCategoryExtension.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/crafting/CraftingCategoryExtension.java
@@ -33,8 +33,7 @@ public class CraftingCategoryExtension<T extends CraftingRecipe> implements ICra
 	@Nullable
 	@Override
 	public Size2i getSize() {
-		if (recipe instanceof IShapedRecipe) {
-			IShapedRecipe<?> shapedRecipe = (IShapedRecipe<?>) this.recipe;
+		if (recipe instanceof IShapedRecipe<?> shapedRecipe) {
 			return new Size2i(shapedRecipe.getRecipeWidth(), shapedRecipe.getRecipeHeight());
 		}
 		return null;

--- a/src/main/java/mezz/jei/plugins/vanilla/crafting/CraftingRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/crafting/CraftingRecipeCategory.java
@@ -90,8 +90,7 @@ public class CraftingRecipeCategory implements IExtendableRecipeCategory<Craftin
 
 		ICraftingCategoryExtension recipeExtension = this.extendableHelper.getRecipeExtension(recipe);
 
-		if (recipeExtension instanceof ICustomCraftingCategoryExtension) {
-			ICustomCraftingCategoryExtension customExtension = (ICustomCraftingCategoryExtension) recipeExtension;
+		if (recipeExtension instanceof ICustomCraftingCategoryExtension customExtension) {
 			customExtension.setRecipe(recipeLayout, ingredients);
 			return;
 		}

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -40,8 +40,7 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 		// Nothing crafts those, the player probably wants to look up fluids.
 		if (item instanceof BlockItem) {
 			Block block = ((BlockItem) item).getBlock();
-			if (block instanceof IFluidBlock) {
-				IFluidBlock fluidBlock = (IFluidBlock) block;
+			if (block instanceof IFluidBlock fluidBlock) {
 				Fluid fluid = fluidBlock.getFluid();
 				if (fluid != null) {
 					FluidStack fluidStack = new FluidStack(fluid, FluidAttributes.BUCKET_VOLUME);

--- a/src/main/java/mezz/jei/recipes/InternalRecipeManagerPlugin.java
+++ b/src/main/java/mezz/jei/recipes/InternalRecipeManagerPlugin.java
@@ -47,14 +47,11 @@ public class InternalRecipeManagerPlugin implements IRecipeManagerPlugin {
 		focus = Focus.check(focus);
 		V ingredient = focus.getValue();
 
-		switch (focus.getMode()) {
-			case INPUT:
-				return recipeInputMap.getRecipeCategories(ingredient);
-			case OUTPUT:
-				return recipeOutputMap.getRecipeCategories(ingredient);
-			default:
-				return getRecipeCategories();
-		}
+		return switch (focus.getMode()) {
+			case INPUT -> recipeInputMap.getRecipeCategories(ingredient);
+			case OUTPUT -> recipeOutputMap.getRecipeCategories(ingredient);
+			default -> getRecipeCategories();
+		};
 	}
 
 	private ImmutableList<ResourceLocation> getRecipeCategories() {

--- a/src/main/java/mezz/jei/recipes/InternalRecipeManagerPlugin.java
+++ b/src/main/java/mezz/jei/recipes/InternalRecipeManagerPlugin.java
@@ -50,7 +50,6 @@ public class InternalRecipeManagerPlugin implements IRecipeManagerPlugin {
 		return switch (focus.getMode()) {
 			case INPUT -> recipeInputMap.getRecipeCategories(ingredient);
 			case OUTPUT -> recipeOutputMap.getRecipeCategories(ingredient);
-			default -> getRecipeCategories();
 		};
 	}
 

--- a/src/main/java/mezz/jei/recipes/RecipeManagerInternal.java
+++ b/src/main/java/mezz/jei/recipes/RecipeManagerInternal.java
@@ -151,7 +151,7 @@ public class RecipeManagerInternal {
 
 		// hide the category if it has no recipes, or if the recipes have all been hidden
 		Stream<?> visibleRecipes = getRecipesStream(recipeCategory, focus, false);
-		return !visibleRecipes.findAny().isPresent();
+		return visibleRecipes.findAny().isEmpty();
 	}
 
 	public <V> Stream<IRecipeCategory<?>> getRecipeCategoriesStream(@Nullable Collection<ResourceLocation> recipeCategoryUids, @Nullable Focus<V> focus, boolean includeHidden) {

--- a/src/main/java/mezz/jei/search/suffixtree/Node.java
+++ b/src/main/java/mezz/jei/search/suffixtree/Node.java
@@ -136,6 +136,6 @@ class Node {
 
 	@Override
 	public String toString() {
-		return "Node: size:" + data.size() + " Edges: " + edges.toString();
+		return "Node: size:" + data.size() + " Edges: " + edges;
 	}
 }

--- a/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
+++ b/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
@@ -148,11 +148,11 @@ public final class RecipeTransferUtil {
 
 		@Override
 		public Iterator<ItemStackMatchable<Integer>> iterator() {
-			return new MatchingIterable.DelegateIterator<Map.Entry<Integer, ItemStack>, ItemStackMatchable<Integer>>(map.entrySet().iterator()) {
+			return new MatchingIterable.DelegateIterator<>(map.entrySet().iterator()) {
 				@Override
 				public ItemStackMatchable<Integer> next() {
 					final Map.Entry<Integer, ItemStack> entry = delegate.next();
-					return new ItemStackMatchable<Integer>() {
+					return new ItemStackMatchable<>() {
 						@Override
 						public ItemStack getStack() {
 							return entry.getValue();

--- a/src/main/java/mezz/jei/util/CommandUtilServer.java
+++ b/src/main/java/mezz/jei/util/CommandUtilServer.java
@@ -135,8 +135,7 @@ public final class CommandUtilServer {
 			giveCount = itemStack.getCount();
 		}
 
-		if (sender instanceof ServerPlayer) {
-			ServerPlayer serverPlayerEntity = (ServerPlayer) sender;
+		if (sender instanceof ServerPlayer serverPlayerEntity) {
 			itemStackCopy.setCount(giveCount);
 			notifyGive(serverPlayerEntity, itemStackCopy);
 			serverPlayerEntity.containerMenu.setRemoteCarried(serverPlayerEntity.containerMenu.getCarried());

--- a/src/main/java/mezz/jei/util/ErrorUtil.java
+++ b/src/main/java/mezz/jei/util/ErrorUtil.java
@@ -102,8 +102,7 @@ public final class ErrorUtil {
 		ResourceLocation registryName = null;
 		if (recipe instanceof Recipe) {
 			registryName = ((Recipe<?>) recipe).getId();
-		} else if (recipe instanceof IForgeRegistryEntry) {
-			IForgeRegistryEntry<?> registryEntry = (IForgeRegistryEntry<?>) recipe;
+		} else if (recipe instanceof IForgeRegistryEntry<?> registryEntry) {
 			registryName = registryEntry.getRegistryName();
 		}
 		if (registryName != null) {

--- a/src/main/java/mezz/jei/util/GiveMode.java
+++ b/src/main/java/mezz/jei/util/GiveMode.java
@@ -13,18 +13,17 @@ public enum GiveMode {
 	@OnlyIn(Dist.CLIENT)
 	public static int getStackSize(GiveMode giveMode, ItemStack itemStack, InputConstants.Key input) {
 		switch (giveMode) {
-			case INVENTORY: {
+			case INVENTORY -> {
 				if (input.getType() == InputConstants.Type.MOUSE && input.getValue() == 0) {
 					return itemStack.getMaxStackSize();
 				}
 				return 1;
 			}
-			case MOUSE_PICKUP: {
+			case MOUSE_PICKUP -> {
 				boolean modifierActive = Screen.hasShiftDown() || Minecraft.getInstance().options.keyPickItem.isActiveAndMatches(input);
 				return modifierActive ? itemStack.getMaxStackSize() : 1;
 			}
-			default:
-				throw new IllegalArgumentException("Unknown give mode: " + giveMode);
+			default -> throw new IllegalArgumentException("Unknown give mode: " + giveMode);
 		}
 	}
 }

--- a/src/main/java/mezz/jei/util/MatchingIterable.java
+++ b/src/main/java/mezz/jei/util/MatchingIterable.java
@@ -15,11 +15,11 @@ public class MatchingIterable implements Iterable<ItemStackMatchable<ItemStack>>
 	@Override
 	public Iterator<ItemStackMatchable<ItemStack>> iterator() {
 		Iterator<ItemStack> stacks = list.iterator();
-		return new DelegateIterator<ItemStack, ItemStackMatchable<ItemStack>>(stacks) {
+		return new DelegateIterator<>(stacks) {
 			@Override
 			public ItemStackMatchable<ItemStack> next() {
 				final ItemStack stack = delegate.next();
-				return new ItemStackMatchable<ItemStack>() {
+				return new ItemStackMatchable<>() {
 					@Nullable
 					@Override
 					public ItemStack getStack() {


### PR DESCRIPTION
See commit messages for individual changes, things of note that potentially should be considered but I didn't do for now here:
- Java now has a Set#of, List#of, and Map#ofEntries for immutable sets, lists, and maps so it may make sense in places to switch from Guava's Immutable to java's ways
- Java also now has a Stream#toList which can be used instead of .collect(Collectors.toList()) though from a brief glance I think the stream method may be immutable and create a couple extra intermediary objects unlike the old collect way so I didn't change any of those
- I didn't convert any thing to using records as those need more thought and if any of the getters override vanilla things they wouldn't work as because of the contract with how records and how forge does remapping it doesn't currently support remapping them fully yet