### PR TITLE
Replace raw Object references in the API with types where possible (includes breaking changes to API)

### DIFF
--- a/src/api/java/mezz/jei/api/gui/IRecipeLayout.java
+++ b/src/api/java/mezz/jei/api/gui/IRecipeLayout.java
@@ -42,24 +42,13 @@ public interface IRecipeLayout {
 	<T> IGuiIngredientGroup<T> getIngredientsGroup(IIngredientType<T> ingredientType);
 
 	/**
-	 * The current search focus. Set by the player when they look up the recipe. The object being looked up is the focus.
-	 * @see #getFocus(IIngredientType) for when you only care about a specific type of focus.
-	 */
-	@Nullable
-	IFocus<?> getFocus();
-
-	/**
-	 * The current search focus. Set by the player when they look up the recipe. The object being looked up is the focus.
+	 * The current search focus. Set by the player when they look up the recipe.
+	 * The ingredient being looked up is the focus.
 	 * Returns null if there is no focus, or if the focus is a different type
 	 * @since JEI 7.0.1
 	 */
 	@Nullable
 	<V> IFocus<V> getFocus(IIngredientType<V> ingredientType);
-
-	/**
-	 * The current recipe category.
-	 */
-	IRecipeCategory<?> getRecipeCategory();
 
 	/**
 	 * Moves the recipe transfer button's position relative to the recipe layout.

--- a/src/api/java/mezz/jei/api/gui/IRecipeLayoutDrawable.java
+++ b/src/api/java/mezz/jei/api/gui/IRecipeLayoutDrawable.java
@@ -3,6 +3,7 @@ package mezz.jei.api.gui;
 import com.mojang.blaze3d.vertex.PoseStack;
 import javax.annotation.Nullable;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IRecipeManager;
 import mezz.jei.api.recipe.category.IRecipeCategory;
@@ -37,8 +38,8 @@ public interface IRecipeLayoutDrawable extends IRecipeLayout {
 
 	/**
 	 * Returns the ingredient currently under the mouse, if there is one.
-	 * Can be an ItemStack, FluidStack, or any other ingredient registered with JEI.
+	 * Can be an ItemStack, FluidStack, or any other ingredient type registered with JEI.
 	 */
 	@Nullable
-	Object getIngredientUnderMouse(int mouseX, int mouseY);
+	<T> T getIngredientUnderMouse(int mouseX, int mouseY, IIngredientType<T> ingredientType);
 }

--- a/src/api/java/mezz/jei/api/gui/ingredient/IGuiIngredient.java
+++ b/src/api/java/mezz/jei/api/gui/ingredient/IGuiIngredient.java
@@ -16,7 +16,7 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
  */
 public interface IGuiIngredient<T> {
 	/**
-	 * @return The ingredient type for this IGuiIngredient.
+	 * @return The ingredient type for this {@link IGuiIngredient}.
 	 */
 	IIngredientType<T> getIngredientType();
 

--- a/src/api/java/mezz/jei/api/gui/ingredient/IGuiIngredient.java
+++ b/src/api/java/mezz/jei/api/gui/ingredient/IGuiIngredient.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 
@@ -14,6 +15,11 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
  * Get these from {@link IGuiIngredientGroup#getGuiIngredients()}.
  */
 public interface IGuiIngredient<T> {
+	/**
+	 * @return The ingredient type for this IGuiIngredient.
+	 */
+	IIngredientType<T> getIngredientType();
+
 	/**
 	 * The ingredient variation that is shown at this moment.
 	 * For ingredients that rotate through several values, this will change over time.

--- a/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
+++ b/src/api/java/mezz/jei/api/ingredients/IIngredientHelper.java
@@ -21,6 +21,11 @@ import mezz.jei.api.registration.IModIngredientRegistration;
  */
 public interface IIngredientHelper<V> {
 	/**
+	 * @return The ingredient type for this {@link IIngredientHelper}.
+	 */
+	IIngredientType<V> getIngredientType();
+
+	/**
 	 * Change one focus into a different focus.
 	 * This can be used to treat lookups of one focus as if it were something else.
 	 *

--- a/src/api/java/mezz/jei/api/recipe/IFocus.java
+++ b/src/api/java/mezz/jei/api/recipe/IFocus.java
@@ -2,7 +2,7 @@ package mezz.jei.api.recipe;
 
 /**
  * The current search focus.
- * Set by the player when they look up the recipe. The object being looked up is the focus.
+ * Set by the player when they look up the recipe. The ingredient being looked up is the focus.
  * This class is immutable, the value and mode do not change.
  *
  * Create a focus with {@link IRecipeManager#createFocus(Mode, Object)}.
@@ -15,7 +15,7 @@ public interface IFocus<V> {
 	}
 
 	/**
-	 * The object being focused on.
+	 * The ingredient that is being focused on.
 	 */
 	V getValue();
 

--- a/src/api/java/mezz/jei/api/recipe/IRecipeManager.java
+++ b/src/api/java/mezz/jei/api/recipe/IRecipeManager.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import net.minecraft.resources.ResourceLocation;
 
 import mezz.jei.api.constants.VanillaRecipeCategoryUid;
@@ -59,7 +60,7 @@ public interface IRecipeManager {
 	/**
 	 * Returns an unmodifiable collection of ingredients that can craft the recipes from recipeCategory.
 	 * For instance, the crafting table ItemStack is returned here for Crafting recipe category.
-	 * These are registered with {@link IRecipeCatalystRegistration#addRecipeCatalyst(Object, ResourceLocation...)}.
+	 * These are registered with {@link IRecipeCatalystRegistration#addRecipeCatalyst(IIngredientType, Object, ResourceLocation...)}.
 	 * @since JEI 7.7.1
 	 */
 	List<Object> getRecipeCatalysts(IRecipeCategory<?> recipeCategory, boolean includeHidden);

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
@@ -19,11 +19,16 @@ import mezz.jei.api.registration.IRecipeTransferRegistration;
  *
  * To register your recipe transfer handler, use {@link IRecipeTransferRegistration#addRecipeTransferHandler(IRecipeTransferHandler, ResourceLocation)}
  */
-public interface IRecipeTransferHandler<C extends AbstractContainerMenu> {
+public interface IRecipeTransferHandler<C extends AbstractContainerMenu, R> {
 	/**
 	 * The container that this recipe transfer handler can use.
 	 */
 	Class<C> getContainerClass();
+
+	/**
+	 * The recipe that this recipe transfer handler can use.
+	 */
+	Class<R> getRecipeClass();
 
 	/**
 	 * @param container    the container to act on
@@ -37,7 +42,7 @@ public interface IRecipeTransferHandler<C extends AbstractContainerMenu> {
 	 * @since JEI 7.1.3
 	 */
 	@Nullable
-	default IRecipeTransferError transferRecipe(C container, Object recipe, IRecipeLayout recipeLayout, Player player, boolean maxTransfer, boolean doTransfer) {
+	default IRecipeTransferError transferRecipe(C container, R recipe, IRecipeLayout recipeLayout, Player player, boolean maxTransfer, boolean doTransfer) {
 		return null;
 	}
 }

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferInfo.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferInfo.java
@@ -11,15 +11,20 @@ import mezz.jei.api.registration.IRecipeTransferRegistration;
 /**
  * Gives JEI the information it needs to transfer recipes from a slotted inventory into the crafting area.
  *
- * Most plugins with normal inventories can use the simpler {@link IRecipeTransferRegistration#addRecipeTransferHandler(Class, ResourceLocation, int, int, int, int)}.
+ * Most plugins with normal inventories can use the simpler {@link IRecipeTransferRegistration#addRecipeTransferHandler(Class, Class, ResourceLocation, int, int, int, int)}.
  * Containers with slot ranges that contain gaps or other oddities can implement this interface directly.
  * Containers that need full control over the recipe transfer or do not use slots can implement {@link IRecipeTransferHandler}.
  */
-public interface IRecipeTransferInfo<C extends AbstractContainerMenu> {
+public interface IRecipeTransferInfo<C extends AbstractContainerMenu, R> {
 	/**
 	 * Return the container class that this recipe transfer helper supports.
 	 */
 	Class<C> getContainerClass();
+
+	/**
+	 * Return the recipe class that this recipe transfer helper supports.
+	 */
+	Class<R> getRecipeClass();
 
 	/**
 	 * Return the recipe category that this container can handle.
@@ -27,24 +32,24 @@ public interface IRecipeTransferInfo<C extends AbstractContainerMenu> {
 	ResourceLocation getRecipeCategoryUid();
 
 	/**
-	 * Return true if this recipe transfer info can handle the given container instance.
+	 * Return true if this recipe transfer info can handle the given container instance and recipe.
 	 */
-	boolean canHandle(C container);
+	boolean canHandle(C container, R recipe);
 
 	/**
 	 * Return a list of slots for the recipe area.
 	 */
-	List<Slot> getRecipeSlots(C container);
+	List<Slot> getRecipeSlots(C container, R recipe);
 
 	/**
 	 * Return a list of slots that the transfer can use to get items for crafting, or place leftover items.
 	 */
-	List<Slot> getInventorySlots(C container);
+	List<Slot> getInventorySlots(C container, R recipe);
 
 	/**
 	 * Return false if the recipe transfer should attempt to place as many items as possible for all slots, even if one slot has less.
 	 */
-	default boolean requireCompleteSets() {
+	default boolean requireCompleteSets(C container, R recipe) {
 		return true;
 	}
 }

--- a/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferInfo.java
+++ b/src/api/java/mezz/jei/api/recipe/transfer/IRecipeTransferInfo.java
@@ -11,7 +11,7 @@ import mezz.jei.api.registration.IRecipeTransferRegistration;
 /**
  * Gives JEI the information it needs to transfer recipes from a slotted inventory into the crafting area.
  *
- * Most plugins with normal inventories can use the simpler {@link IRecipeTransferRegistration#addRecipeTransferHandler(Class, Class, ResourceLocation, int, int, int, int)}.
+ * Most plugins with normal inventories can use the simpler {@link IRecipeTransferRegistration#addRecipeTransferHandler(Class, ResourceLocation, int, int, int, int)}.
  * Containers with slot ranges that contain gaps or other oddities can implement this interface directly.
  * Containers that need full control over the recipe transfer or do not use slots can implement {@link IRecipeTransferHandler}.
  */

--- a/src/api/java/mezz/jei/api/recipe/vanilla/IJeiAnvilRecipe.java
+++ b/src/api/java/mezz/jei/api/recipe/vanilla/IJeiAnvilRecipe.java
@@ -1,0 +1,4 @@
+package mezz.jei.api.recipe.vanilla;
+
+public interface IJeiAnvilRecipe {
+}

--- a/src/api/java/mezz/jei/api/recipe/vanilla/IVanillaRecipeFactory.java
+++ b/src/api/java/mezz/jei/api/recipe/vanilla/IVanillaRecipeFactory.java
@@ -22,7 +22,7 @@ public interface IVanillaRecipeFactory {
 	 * @param rightInputs The itemStack(s) placed on the right slot.
 	 * @param outputs     The resulting itemStack(s).
 	 */
-	Object createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs);
+	IJeiAnvilRecipe createAnvilRecipe(ItemStack leftInput, List<ItemStack> rightInputs, List<ItemStack> outputs);
 
 	/**
 	 * Create an anvil recipe for the given inputs and output.
@@ -32,7 +32,7 @@ public interface IVanillaRecipeFactory {
 	 * @param rightInputs The itemStack(s) placed on the right slot.
 	 * @param outputs     The resulting itemStack(s).
 	 */
-	Object createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs);
+	IJeiAnvilRecipe createAnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs);
 
 	/**
 	 * Create a new brewing recipe.

--- a/src/api/java/mezz/jei/api/registration/IRecipeCatalystRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IRecipeCatalystRegistration.java
@@ -1,6 +1,9 @@
 package mezz.jei.api.registration;
 
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 
 public interface IRecipeCatalystRegistration {
 	/**
@@ -10,5 +13,16 @@ public interface IRecipeCatalystRegistration {
 	 * @param catalystIngredient the ingredient that can craft recipes (like a furnace or crafting table)
 	 * @param recipeCategoryUids the recipe categories handled by the ingredient
 	 */
-	void addRecipeCatalyst(Object catalystIngredient, ResourceLocation... recipeCategoryUids);
+	default void addRecipeCatalyst(ItemStack catalystIngredient, ResourceLocation... recipeCategoryUids) {
+		addRecipeCatalyst(VanillaTypes.ITEM, catalystIngredient, recipeCategoryUids);
+	}
+
+	/**
+	 * Add an association between an ingredient and what it can craft. (i.e. Furnace ItemStack -> Smelting and Fuel Recipes)
+	 * Allows players to see what ingredient they need to craft in order to make recipes from a recipe category.
+	 *
+	 * @param catalystIngredient the ingredient that can craft recipes (like a furnace or crafting table)
+	 * @param recipeCategoryUids the recipe categories handled by the ingredient
+	 */
+	<T> void addRecipeCatalyst(IIngredientType<T> ingredientType, T catalystIngredient, ResourceLocation... recipeCategoryUids);
 }

--- a/src/api/java/mezz/jei/api/registration/IRecipeCatalystRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IRecipeCatalystRegistration.java
@@ -7,11 +7,13 @@ import net.minecraft.world.item.ItemStack;
 
 public interface IRecipeCatalystRegistration {
 	/**
-	 * Add an association between an ingredient and what it can craft. (i.e. Furnace ItemStack -> Smelting and Fuel Recipes)
+	 * Add an association between an {@link ItemStack} and what it can craft.
+	 * (i.e. Furnace ItemStack can craft Smelting and Fuel Recipes)
 	 * Allows players to see what ingredient they need to craft in order to make recipes from a recipe category.
 	 *
-	 * @param catalystIngredient the ingredient that can craft recipes (like a furnace or crafting table)
-	 * @param recipeCategoryUids the recipe categories handled by the ingredient
+	 * @param catalystIngredient the {@link ItemStack} that can craft recipes (like a furnace or crafting table)
+	 * @param recipeCategoryUids the recipe categories handled by the catalyst
+	 * @see #addRecipeCatalyst(IIngredientType, Object, ResourceLocation...) to add non-{@link ItemStack} catalysts.
 	 */
 	default void addRecipeCatalyst(ItemStack catalystIngredient, ResourceLocation... recipeCategoryUids) {
 		addRecipeCatalyst(VanillaTypes.ITEM, catalystIngredient, recipeCategoryUids);

--- a/src/api/java/mezz/jei/api/registration/IRecipeTransferRegistration.java
+++ b/src/api/java/mezz/jei/api/registration/IRecipeTransferRegistration.java
@@ -35,17 +35,17 @@ public interface IRecipeTransferRegistration {
 	 *
 	 * Use this when recipe slots or inventory slots are spread out in different number ranges.
 	 */
-	<C extends AbstractContainerMenu> void addRecipeTransferHandler(IRecipeTransferInfo<C> recipeTransferInfo);
+	<C extends AbstractContainerMenu, R> void addRecipeTransferHandler(IRecipeTransferInfo<C, R> recipeTransferInfo);
 
 	/**
 	 * Complete control over recipe transfer.
 	 * Use this when the container has a non-standard inventory or crafting area.
 	 */
-	void addRecipeTransferHandler(IRecipeTransferHandler<?> recipeTransferHandler, ResourceLocation recipeCategoryUid);
+	<C extends AbstractContainerMenu, R> void addRecipeTransferHandler(IRecipeTransferHandler<C, R> recipeTransferHandler, ResourceLocation recipeCategoryUid);
 
 	/**
 	 * Add a universal handler that can handle any category of recipe.
 	 * Useful for mods with recipe pattern encoding, for automated recipe systems.
 	 */
-	void addUniversalRecipeTransferHandler(IRecipeTransferHandler<?> recipeTransferHandler);
+	<C extends AbstractContainerMenu, R> void addUniversalRecipeTransferHandler(IRecipeTransferHandler<C, R> recipeTransferHandler);
 }

--- a/src/api/java/mezz/jei/api/runtime/IBookmarkOverlay.java
+++ b/src/api/java/mezz/jei/api/runtime/IBookmarkOverlay.java
@@ -1,5 +1,7 @@
 package mezz.jei.api.runtime;
 
+import mezz.jei.api.ingredients.IIngredientType;
+
 import javax.annotation.Nullable;
 
 /**
@@ -12,5 +14,5 @@ public interface IBookmarkOverlay {
 	 * @return the ingredient that's currently under the mouse, or null if there is none.
 	 */
 	@Nullable
-	Object getIngredientUnderMouse();
+	<T> T getIngredientUnderMouse(IIngredientType<T> ingredientType);
 }

--- a/src/api/java/mezz/jei/api/runtime/IIngredientFilter.java
+++ b/src/api/java/mezz/jei/api/runtime/IIngredientFilter.java
@@ -1,7 +1,8 @@
 package mezz.jei.api.runtime;
 
-import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredientType;
+
+import java.util.List;
 
 /**
  * The IIngredientFilter is JEI's filter that can be set by players or controlled by mods.
@@ -23,5 +24,5 @@ public interface IIngredientFilter {
 	 * @return a list containing all ingredients that match the current filter.
 	 * To get all the ingredients known to JEI, see {@link IIngredientManager#getAllIngredients(IIngredientType)}.
 	 */
-	ImmutableList<Object> getFilteredIngredients();
+	<T> List<T> getFilteredIngredients(IIngredientType<T> ingredientType);
 }

--- a/src/api/java/mezz/jei/api/runtime/IIngredientListOverlay.java
+++ b/src/api/java/mezz/jei/api/runtime/IIngredientListOverlay.java
@@ -2,8 +2,9 @@ package mezz.jei.api.runtime;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredientType;
+
+import java.util.List;
 
 /**
  * The IItemListOverlay is JEI's gui that displays all the ingredients next to an open container gui.
@@ -11,12 +12,6 @@ import mezz.jei.api.ingredients.IIngredientType;
  * Get the instance from {@link IJeiRuntime#getIngredientListOverlay()}.
  */
 public interface IIngredientListOverlay {
-	/**
-	 * @return the ingredient that's currently under the mouse, or null if there is none.
-	 */
-	@Nullable
-	Object getIngredientUnderMouse();
-
 	/**
 	 * @return the ingredient that's currently under the mouse if it matches the given type, or null if there is none.
 	 * @since JEI 7.0.1
@@ -32,5 +27,5 @@ public interface IIngredientListOverlay {
 	/**
 	 * @return a list containing all currently visible ingredients. If JEI is hidden, the list will be empty.
 	 */
-	ImmutableList<Object> getVisibleIngredients();
+	<T> List<T> getVisibleIngredients(IIngredientType<T> ingredientType);
 }

--- a/src/api/java/mezz/jei/api/runtime/IRecipesGui.java
+++ b/src/api/java/mezz/jei/api/runtime/IRecipesGui.java
@@ -3,6 +3,7 @@ package mezz.jei.api.runtime;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import net.minecraft.resources.ResourceLocation;
 
 import mezz.jei.api.recipe.IFocus;
@@ -32,5 +33,5 @@ public interface IRecipesGui {
 	 * @return the ingredient that's currently under the mouse in this gui, or null if there is none.
 	 */
 	@Nullable
-	Object getIngredientUnderMouse();
+	<T> T getIngredientUnderMouse(IIngredientType<T> ingredientType);
 }

--- a/src/main/java/mezz/jei/gui/Focus.java
+++ b/src/main/java/mezz/jei/gui/Focus.java
@@ -2,13 +2,10 @@ package mezz.jei.gui;
 
 import mezz.jei.Internal;
 import mezz.jei.api.ingredients.IIngredientHelper;
-import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.util.ErrorUtil;
 
 import javax.annotation.Nullable;
-
-import mezz.jei.api.recipe.IFocus.Mode;
 
 public final class Focus<V> implements IFocus<V> {
 	private final Mode mode;
@@ -54,15 +51,4 @@ public final class Focus<V> implements IFocus<V> {
 		return check(focus);
 	}
 
-	@Nullable
-	public static <V> Focus<V> cast(@Nullable Focus<?> focus, IIngredientType<V> ingredientType) {
-		if (focus != null) {
-			Class<? extends V> ingredientClass = ingredientType.getIngredientClass();
-			if (ingredientClass.isInstance(focus.getValue())) {
-				//noinspection unchecked
-				return (Focus<V>) focus;
-			}
-		}
-		return null;
-	}
 }

--- a/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
+++ b/src/main/java/mezz/jei/gui/ingredients/GuiIngredient.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiComponent;
@@ -86,12 +87,21 @@ public class GuiIngredient<T> extends GuiComponent implements IGuiIngredient<T> 
 		this.cycleTimer = new CycleTimer(cycleOffset);
 	}
 
+	@Override
+	public IIngredientType<T> getIngredientType() {
+		return ingredientHelper.getIngredientType();
+	}
+
 	public Rect2i getRect() {
 		return rect;
 	}
 
 	public boolean isMouseOver(double xOffset, double yOffset, double mouseX, double mouseY) {
-		return enabled && (mouseX >= xOffset + rect.getX()) && (mouseY >= yOffset + rect.getY()) && (mouseX < xOffset + rect.getX() + rect.getWidth()) && (mouseY < yOffset + rect.getY() + rect.getHeight());
+		return enabled &&
+			(mouseX >= xOffset + rect.getX()) &&
+			(mouseY >= yOffset + rect.getY()) &&
+			(mouseX < xOffset + rect.getX() + rect.getWidth()) &&
+			(mouseY < yOffset + rect.getY() + rect.getHeight());
 	}
 
 	@Nullable

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGrid.java
@@ -1,36 +1,24 @@
 package mezz.jei.gui.overlay;
 
-import com.mojang.blaze3d.vertex.PoseStack;
-
-import javax.annotation.Nullable;
-import java.util.Collection;
-
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.config.ClientConfig;
 import mezz.jei.config.IClientConfig;
-import mezz.jei.gui.GuiScreenHelper;
-import mezz.jei.gui.recipes.RecipesGui;
-import mezz.jei.input.IMouseHandler;
-import mezz.jei.input.click.MouseClickState;
-import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraftforge.items.ItemHandlerHelper;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.Rect2i;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-
 import mezz.jei.config.IEditModeConfig;
 import mezz.jei.config.IIngredientFilterConfig;
 import mezz.jei.config.IWorldConfig;
+import mezz.jei.gui.GuiScreenHelper;
 import mezz.jei.gui.TooltipRenderer;
 import mezz.jei.gui.ingredients.GuiIngredientProperties;
 import mezz.jei.gui.ingredients.IIngredientListElement;
+import mezz.jei.gui.recipes.RecipesGui;
 import mezz.jei.input.ClickedIngredient;
 import mezz.jei.input.IClickedIngredient;
+import mezz.jei.input.IMouseHandler;
 import mezz.jei.input.IShowsRecipeFocuses;
 import mezz.jei.input.MouseUtil;
+import mezz.jei.input.click.MouseClickState;
 import mezz.jei.network.Network;
 import mezz.jei.network.packets.PacketDeletePlayerItem;
 import mezz.jei.network.packets.PacketJei;
@@ -39,6 +27,18 @@ import mezz.jei.render.IngredientListElementRenderer;
 import mezz.jei.render.IngredientListSlot;
 import mezz.jei.util.GiveMode;
 import mezz.jei.util.MathUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Optional;
 
 /**
  * An ingredient grid displays a rectangular area of clickable recipe ingredients.
@@ -187,13 +187,9 @@ public class IngredientGrid implements IShowsRecipeFocuses {
 			!guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY);
 	}
 
-	@Nullable
-	public IIngredientListElement<?> getElementUnderMouse() {
-		IngredientListElementRenderer<?> hovered = guiIngredientSlots.getHovered(MouseUtil.getX(), MouseUtil.getY());
-		if (hovered != null) {
-			return hovered.getElement();
-		}
-		return null;
+	public <T> Optional<IIngredientListElement<T>> getElementUnderMouse(IIngredientType<T> ingredientType) {
+		return this.guiIngredientSlots.getHovered(MouseUtil.getX(), MouseUtil.getY(), ingredientType)
+			.map(IngredientListElementRenderer::getElement);
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -3,12 +3,14 @@ package mezz.jei.gui.overlay;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.input.CombinedMouseHandler;
 import mezz.jei.util.Rectangle2dBuilder;
 import net.minecraft.client.Options;
@@ -32,7 +34,6 @@ import mezz.jei.input.IPaged;
 import mezz.jei.input.IShowsRecipeFocuses;
 import mezz.jei.input.MouseUtil;
 import mezz.jei.render.IngredientListElementRenderer;
-import mezz.jei.render.IngredientListSlot;
 import mezz.jei.util.CommandUtil;
 import mezz.jei.util.MathUtil;
 import net.minecraft.util.Tuple;
@@ -189,9 +190,8 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IGhost
 		return this.ingredientGrid.getIngredientUnderMouse(mouseX, mouseY);
 	}
 
-	@Nullable
-	public IIngredientListElement<?> getElementUnderMouse() {
-		return this.ingredientGrid.getElementUnderMouse();
+	public <T> Optional<IIngredientListElement<T>> getElementUnderMouse(IIngredientType<T> ingredientType) {
+		return this.ingredientGrid.getElementUnderMouse(ingredientType);
 	}
 
 	@Override
@@ -199,15 +199,12 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IGhost
 		return this.ingredientGrid.canSetFocusWithMouse();
 	}
 
-	public List<IIngredientListElement<?>> getVisibleElements() {
-		List<IIngredientListElement<?>> visibleElements = new ArrayList<>();
-		for (IngredientListSlot slot : this.ingredientGrid.guiIngredientSlots.getAllGuiIngredientSlots()) {
-			IngredientListElementRenderer<?> renderer = slot.getIngredientRenderer();
-			if (renderer != null) {
-				visibleElements.add(renderer.getElement());
-			}
-		}
-		return visibleElements;
+	public <T> List<IIngredientListElement<T>> getVisibleElements(IIngredientType<T> ingredientType) {
+		return this.ingredientGrid.guiIngredientSlots.getAllGuiIngredientSlots().stream()
+			.map(slot -> slot.getIngredientRenderer(ingredientType))
+			.filter(Objects::nonNull)
+			.map(IngredientListElementRenderer::getElement)
+			.toList();
 	}
 
 	private class IngredientGridPaged implements IPaged, IMouseHandler {

--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -1,6 +1,5 @@
 package mezz.jei.gui.overlay;
 
-import com.google.common.collect.ImmutableList;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.gui.handlers.IGuiProperties;
 import mezz.jei.api.ingredients.IIngredientType;
@@ -14,6 +13,7 @@ import mezz.jei.gui.ghost.GhostIngredientDragManager;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.gui.recipes.RecipesGui;
 import mezz.jei.ingredients.IngredientManager;
+import mezz.jei.ingredients.IngredientTypeHelper;
 import mezz.jei.input.GuiTextFieldFilter;
 import mezz.jei.input.IClickedIngredient;
 import mezz.jei.input.IMouseHandler;
@@ -31,6 +31,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.util.Tuple;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -381,23 +382,11 @@ public class IngredientListOverlay implements IIngredientListOverlay, IShowsReci
 
 	@Nullable
 	@Override
-	public Object getIngredientUnderMouse() {
-		if (isListDisplayed()) {
-			IIngredientListElement<?> elementUnderMouse = this.contents.getElementUnderMouse();
-			if (elementUnderMouse != null) {
-				return elementUnderMouse.getIngredient();
-			}
-		}
-		return null;
-	}
-
-	@Nullable
-	@Override
 	public <T> T getIngredientUnderMouse(IIngredientType<T> ingredientType) {
-		Object ingredient = getIngredientUnderMouse();
-		Class<? extends T> ingredientClass = ingredientType.getIngredientClass();
-		if (ingredientClass.isInstance(ingredient)) {
-			return ingredientClass.cast(ingredient);
+		if (isListDisplayed()) {
+			return this.contents.getElementUnderMouse(ingredientType)
+				.map(IIngredientListElement::getIngredient)
+				.orElse(null);
 		}
 		return null;
 	}
@@ -407,16 +396,15 @@ public class IngredientListOverlay implements IIngredientListOverlay, IShowsReci
 		updateLayout(true);
 	}
 
-	@SuppressWarnings("UnstableApiUsage")
 	@Override
-	public ImmutableList<Object> getVisibleIngredients() {
+	public <T> List<T> getVisibleIngredients(IIngredientType<T> ingredientType) {
 		if (isListDisplayed()) {
-			List<IIngredientListElement<?>> visibleElements = this.contents.getVisibleElements();
+			List<IIngredientListElement<T>> visibleElements = this.contents.getVisibleElements(ingredientType);
 			return visibleElements.stream()
 				.map(IIngredientListElement::getIngredient)
-				.collect(ImmutableList.toImmutableList());
+				.toList();
 		}
-		return ImmutableList.of();
+		return Collections.emptyList();
 	}
 
 	private static class ClickResult {

--- a/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -13,7 +13,6 @@ import mezz.jei.gui.ghost.GhostIngredientDragManager;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.gui.recipes.RecipesGui;
 import mezz.jei.ingredients.IngredientManager;
-import mezz.jei.ingredients.IngredientTypeHelper;
 import mezz.jei.input.GuiTextFieldFilter;
 import mezz.jei.input.IClickedIngredient;
 import mezz.jei.input.IMouseHandler;

--- a/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
+++ b/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
@@ -1,6 +1,7 @@
 package mezz.jei.gui.overlay.bookmarks;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.runtime.IBookmarkOverlay;
 import mezz.jei.bookmarks.BookmarkList;
 import mezz.jei.config.ClientConfig;
@@ -143,16 +144,13 @@ public class BookmarkOverlay implements IShowsRecipeFocuses, ILeftAreaContent, I
 		return this.isListDisplayed() && this.contents.canSetFocusWithMouse();
 	}
 
-
-
 	@Nullable
 	@Override
-	public Object getIngredientUnderMouse() {
+	public <T> T getIngredientUnderMouse(IIngredientType<T> ingredientType) {
 		if (isListDisplayed()) {
-			IIngredientListElement<?> elementUnderMouse = this.contents.getElementUnderMouse();
-			if (elementUnderMouse != null) {
-				return elementUnderMouse.getIngredient();
-			}
+			return this.contents.getElementUnderMouse(ingredientType)
+				.map(IIngredientListElement::getIngredient)
+				.orElse(null);
 		}
 		return null;
 	}

--- a/src/main/java/mezz/jei/gui/recipes/RecipeGuiLogic.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipeGuiLogic.java
@@ -71,7 +71,7 @@ public class RecipeGuiLogic implements IRecipeGuiLogic {
 			if (openContainer != null) {
 				for (int i = 0; i < recipeCategories.size(); i++) {
 					IRecipeCategory<?> recipeCategory = recipeCategories.get(i);
-					IRecipeTransferHandler<?> recipeTransferHandler = recipeTransferManager.getRecipeTransferHandler(openContainer, recipeCategory);
+					IRecipeTransferHandler<?, ?> recipeTransferHandler = recipeTransferManager.getRecipeTransferHandler(openContainer, recipeCategory);
 					if (recipeTransferHandler != null) {
 						return i;
 					}

--- a/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -1,11 +1,13 @@
 package mezz.jei.gui.recipes;
 
-import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.Internal;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableStatic;
 import mezz.jei.api.helpers.IModIdHelper;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IRecipeManager;
 import mezz.jei.api.recipe.category.IRecipeCategory;
@@ -21,6 +23,7 @@ import mezz.jei.gui.ingredients.GuiIngredient;
 import mezz.jei.gui.overlay.IngredientListOverlay;
 import mezz.jei.gui.textures.Textures;
 import mezz.jei.ingredients.IngredientManager;
+import mezz.jei.ingredients.IngredientTypeHelper;
 import mezz.jei.input.ClickedIngredient;
 import mezz.jei.input.IClickedIngredient;
 import mezz.jei.input.IMouseHandler;
@@ -40,17 +43,17 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.Rect2i;
-import com.mojang.blaze3d.platform.InputConstants;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class RecipesGui extends Screen implements IRecipesGui, IShowsRecipeFocuses, IRecipeLogicStateListener {
@@ -434,12 +437,14 @@ public class RecipesGui extends Screen implements IRecipesGui, IShowsRecipeFocus
 
 	@Nullable
 	@Override
-	public Object getIngredientUnderMouse() {
-		IClickedIngredient<?> ingredient = getIngredientUnderMouse(MouseUtil.getX(), MouseUtil.getY());
-		if (ingredient != null) {
-			return ingredient.getValue();
-		}
-		return null;
+	public <T> T getIngredientUnderMouse(IIngredientType<T> ingredientType) {
+		double x = MouseUtil.getX();
+		double y = MouseUtil.getY();
+		IClickedIngredient<?> ingredient = getIngredientUnderMouse(x, y);
+		return Optional.ofNullable(ingredient)
+			.map(i -> IngredientTypeHelper.checkedCast(i, ingredientType))
+			.map(IClickedIngredient::getValue)
+			.orElse(null);
 	}
 
 	public void back() {

--- a/src/main/java/mezz/jei/ingredients/IngredientFilter.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilter.java
@@ -1,6 +1,5 @@
 package mezz.jei.ingredients;
 
-import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
 import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntIterator;
@@ -8,6 +7,7 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.config.IClientConfig;
@@ -228,14 +228,11 @@ public class IngredientFilter implements IIngredientGridSource {
 		return Collections.unmodifiableSet(this.modNamesForSorting);
 	}
 
-	public ImmutableList<Object> getFilteredIngredients(String filterText) {
-		List<IIngredientListElement<?>> elements = getIngredientList(filterText);
-		ImmutableList.Builder<Object> builder = ImmutableList.builder();
-		for (IIngredientListElement<?> element : elements) {
-			Object ingredient = element.getIngredient();
-			builder.add(ingredient);
-		}
-		return builder.build();
+	public <T> List<T> getFilteredIngredients(String filterText, IIngredientType<T> ingredientType) {
+		List<IIngredientListElement<?>> ingredientList = getIngredientList(filterText);
+		return IngredientTypeHelper.ofType(ingredientList.stream(), ingredientType)
+			.map(IIngredientListElement::getIngredient)
+			.toList();
 	}
 
 	private List<IIngredientListElementInfo<?>> getIngredientListUncached(String filterText) {

--- a/src/main/java/mezz/jei/ingredients/IngredientFilterApi.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientFilterApi.java
@@ -1,9 +1,11 @@
 package mezz.jei.ingredients;
 
-import com.google.common.collect.ImmutableList;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.runtime.IIngredientFilter;
 import mezz.jei.config.IWorldConfig;
 import mezz.jei.util.ErrorUtil;
+
+import java.util.List;
 
 public class IngredientFilterApi implements IIngredientFilter {
 	private final IngredientFilter ingredientFilter;
@@ -28,8 +30,8 @@ public class IngredientFilterApi implements IIngredientFilter {
 	}
 
 	@Override
-	public ImmutableList<Object> getFilteredIngredients() {
+	public <T> List<T> getFilteredIngredients(IIngredientType<T> ingredientType) {
 		String filterText = worldConfig.getFilterText();
-		return ingredientFilter.getFilteredIngredients(filterText);
+		return ingredientFilter.getFilteredIngredients(filterText, ingredientType);
 	}
 }

--- a/src/main/java/mezz/jei/ingredients/IngredientTypeHelper.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientTypeHelper.java
@@ -1,0 +1,67 @@
+package mezz.jei.ingredients;
+
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.gui.Focus;
+import mezz.jei.gui.ingredients.GuiIngredient;
+import mezz.jei.gui.ingredients.IIngredientListElement;
+import mezz.jei.input.IClickedIngredient;
+import mezz.jei.render.IngredientListElementRenderer;
+
+import javax.annotation.Nullable;
+import java.util.stream.Stream;
+
+public final class IngredientTypeHelper {
+	@SuppressWarnings("unchecked")
+	public static <T> Stream<IIngredientListElement<T>> ofType(Stream<IIngredientListElement<?>> stream, IIngredientType<T> ingredientType) {
+		Class<? extends T> ingredientClass = ingredientType.getIngredientClass();
+		return (Stream<IIngredientListElement<T>>) (Object) stream.filter(i -> ingredientClass.isInstance(i.getIngredient()));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public static <T> IClickedIngredient<T> checkedCast(IClickedIngredient<?> clicked, IIngredientType<T> ingredientType) {
+		Object ingredient = clicked.getValue();
+		Class<? extends T> ingredientClass = ingredientType.getIngredientClass();
+		if (ingredientClass.isInstance(ingredient)) {
+			return (IClickedIngredient<T>) clicked;
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public static <V> Focus<V> checkedCast(@Nullable Focus<?> focus, IIngredientType<V> ingredientType) {
+		if (focus == null) {
+			return null;
+		}
+		Class<? extends V> ingredientClass = ingredientType.getIngredientClass();
+		if (ingredientClass.isInstance(focus.getValue())) {
+			return (Focus<V>) focus;
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public static <T> IngredientListElementRenderer<T> checkedCast(@Nullable IngredientListElementRenderer<?> ingredientListElement, IIngredientType<T> ingredientType) {
+		if (ingredientListElement == null) {
+			return null;
+		}
+		Object ingredient = ingredientListElement.getElement().getIngredient();
+		Class<? extends T> ingredientClass = ingredientType.getIngredientClass();
+		if (ingredientClass.isInstance(ingredient)) {
+			return (IngredientListElementRenderer<T>) ingredientListElement;
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public static <T> GuiIngredient<T> checkedCast(GuiIngredient<?> guiIngredient, IIngredientType<T> ingredientType) {
+		if (guiIngredient.getIngredientType() == ingredientType) {
+			return (GuiIngredient<T>) guiIngredient;
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/mezz/jei/load/registration/RecipeCatalystRegistration.java
+++ b/src/main/java/mezz/jei/load/registration/RecipeCatalystRegistration.java
@@ -1,5 +1,6 @@
 package mezz.jei.load.registration;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import net.minecraft.resources.ResourceLocation;
 
 import com.google.common.collect.ImmutableListMultimap;
@@ -11,7 +12,9 @@ public class RecipeCatalystRegistration implements IRecipeCatalystRegistration {
 	private final ListMultiMap<ResourceLocation, Object> recipeCatalysts = new ListMultiMap<>();
 
 	@Override
-	public void addRecipeCatalyst(Object catalystIngredient, ResourceLocation... recipeCategoryUids) {
+	public <T> void addRecipeCatalyst(IIngredientType<T> ingredientType, T catalystIngredient, ResourceLocation... recipeCategoryUids) {
+		ErrorUtil.checkNotNull(ingredientType, "ingredientType");
+		ErrorUtil.checkIsInstance(ingredientType, catalystIngredient, "catalystIngredient");
 		ErrorUtil.checkIsValidIngredient(catalystIngredient, "catalystIngredient");
 		ErrorUtil.checkNotEmpty(recipeCategoryUids, "recipeCategoryUids");
 

--- a/src/main/java/mezz/jei/load/registration/RecipeTransferRegistration.java
+++ b/src/main/java/mezz/jei/load/registration/RecipeTransferRegistration.java
@@ -17,7 +17,7 @@ import mezz.jei.transfer.BasicRecipeTransferInfo;
 import mezz.jei.util.ErrorUtil;
 
 public class RecipeTransferRegistration implements IRecipeTransferRegistration {
-	private final Table<Class<?>, ResourceLocation, IRecipeTransferHandler<?>> recipeTransferHandlers = Table.hashBasedTable();
+	private final Table<Class<?>, ResourceLocation, IRecipeTransferHandler<?, ?>> recipeTransferHandlers = Table.hashBasedTable();
 	private final IStackHelper stackHelper;
 	private final IRecipeTransferHandlerHelper handlerHelper;
 	private final IJeiHelpers jeiHelpers;
@@ -43,36 +43,36 @@ public class RecipeTransferRegistration implements IRecipeTransferRegistration {
 		ErrorUtil.checkNotNull(containerClass, "containerClass");
 		ErrorUtil.checkNotNull(recipeCategoryUid, "recipeCategoryUid");
 
-		IRecipeTransferInfo<C> recipeTransferHelper = new BasicRecipeTransferInfo<>(containerClass, recipeCategoryUid, recipeSlotStart, recipeSlotCount, inventorySlotStart, inventorySlotCount);
+		IRecipeTransferInfo<C, Object> recipeTransferHelper = new BasicRecipeTransferInfo<>(containerClass, Object.class, recipeCategoryUid, recipeSlotStart, recipeSlotCount, inventorySlotStart, inventorySlotCount);
 		addRecipeTransferHandler(recipeTransferHelper);
 	}
 
 	@Override
-	public <C extends AbstractContainerMenu> void addRecipeTransferHandler(IRecipeTransferInfo<C> recipeTransferInfo) {
+	public <C extends AbstractContainerMenu, R> void addRecipeTransferHandler(IRecipeTransferInfo<C, R> recipeTransferInfo) {
 		ErrorUtil.checkNotNull(recipeTransferInfo, "recipeTransferInfo");
 
-		IRecipeTransferHandler<C> recipeTransferHandler = new BasicRecipeTransferHandler<>(stackHelper, handlerHelper, recipeTransferInfo);
+		IRecipeTransferHandler<C, R> recipeTransferHandler = new BasicRecipeTransferHandler<>(stackHelper, handlerHelper, recipeTransferInfo);
 		addRecipeTransferHandler(recipeTransferHandler, recipeTransferInfo.getRecipeCategoryUid());
 	}
 
 	@Override
-	public void addRecipeTransferHandler(IRecipeTransferHandler<?> recipeTransferHandler, ResourceLocation recipeCategoryUid) {
+	public <C extends AbstractContainerMenu, R> void addRecipeTransferHandler(IRecipeTransferHandler<C, R> recipeTransferHandler, ResourceLocation recipeCategoryUid) {
 		ErrorUtil.checkNotNull(recipeTransferHandler, "recipeTransferHandler");
 		ErrorUtil.checkNotNull(recipeCategoryUid, "recipeCategoryUid");
 
-		Class<?> containerClass = recipeTransferHandler.getContainerClass();
+		Class<C> containerClass = recipeTransferHandler.getContainerClass();
 		this.recipeTransferHandlers.put(containerClass, recipeCategoryUid, recipeTransferHandler);
 	}
 
 	@Override
-	public void addUniversalRecipeTransferHandler(IRecipeTransferHandler<?> recipeTransferHandler) {
+	public <C extends AbstractContainerMenu, R> void addUniversalRecipeTransferHandler(IRecipeTransferHandler<C, R> recipeTransferHandler) {
 		ErrorUtil.checkNotNull(recipeTransferHandler, "recipeTransferHandler");
 
 		Class<?> containerClass = recipeTransferHandler.getContainerClass();
 		this.recipeTransferHandlers.put(containerClass, Constants.UNIVERSAL_RECIPE_TRANSFER_UID, recipeTransferHandler);
 	}
 
-	public ImmutableTable<Class<?>, ResourceLocation, IRecipeTransferHandler<?>> getRecipeTransferHandlers() {
+	public ImmutableTable<Class<?>, ResourceLocation, IRecipeTransferHandler<?, ?>> getRecipeTransferHandlers() {
 		return recipeTransferHandlers.toImmutable();
 	}
 }

--- a/src/main/java/mezz/jei/plugins/debug/DebugRecipeCategory.java
+++ b/src/main/java/mezz/jei/plugins/debug/DebugRecipeCategory.java
@@ -5,9 +5,11 @@ import com.mojang.blaze3d.vertex.PoseStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.api.runtime.IBookmarkOverlay;
 import net.minecraft.client.renderer.GameRenderer;
@@ -125,14 +127,20 @@ public class DebugRecipeCategory implements IRecipeCategory<DebugRecipe> {
 			minecraft.font.draw(poseStack, ingredientFilter.getFilterText(), 20, 52, 0);
 
 			IIngredientListOverlay ingredientListOverlay = runtime.getIngredientListOverlay();
-			Object ingredientUnderMouse = ingredientListOverlay.getIngredientUnderMouse();
-			if (ingredientUnderMouse != null) {
-				drawIngredientName(minecraft, poseStack, ingredientUnderMouse);
-			} else {
-				IBookmarkOverlay bookmarkOverlay = runtime.getBookmarkOverlay();
-				ingredientUnderMouse = bookmarkOverlay.getIngredientUnderMouse();
+			IIngredientManager ingredientManager = runtime.getIngredientManager();
+			Collection<IIngredientType<?>> ingredientTypes = ingredientManager.getRegisteredIngredientTypes();
+			for (IIngredientType<?> ingredientType : ingredientTypes) {
+				Object ingredientUnderMouse = ingredientListOverlay.getIngredientUnderMouse(ingredientType);
 				if (ingredientUnderMouse != null) {
 					drawIngredientName(minecraft, poseStack, ingredientUnderMouse);
+					break;
+				} else {
+					IBookmarkOverlay bookmarkOverlay = runtime.getBookmarkOverlay();
+					ingredientUnderMouse = bookmarkOverlay.getIngredientUnderMouse(ingredientType);
+					if (ingredientUnderMouse != null) {
+						drawIngredientName(minecraft, poseStack, ingredientUnderMouse);
+						break;
+					}
 				}
 			}
 		}

--- a/src/main/java/mezz/jei/plugins/debug/JeiDebugPlugin.java
+++ b/src/main/java/mezz/jei/plugins/debug/JeiDebugPlugin.java
@@ -168,14 +168,14 @@ public class JeiDebugPlugin implements IModPlugin {
 	@Override
 	public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
 		if (ClientConfig.getInstance().isDebugModeEnabled()) {
-			registration.addRecipeCatalyst(new DebugIngredient(7), DebugRecipeCategory.UID);
-			registration.addRecipeCatalyst(new FluidStack(Fluids.WATER, FluidAttributes.BUCKET_VOLUME), DebugRecipeCategory.UID);
-			registration.addRecipeCatalyst(new ItemStack(Items.STICK), DebugRecipeCategory.UID);
+			registration.addRecipeCatalyst(DebugIngredient.TYPE, new DebugIngredient(7), DebugRecipeCategory.UID);
+			registration.addRecipeCatalyst(VanillaTypes.FLUID, new FluidStack(Fluids.WATER, FluidAttributes.BUCKET_VOLUME), DebugRecipeCategory.UID);
+			registration.addRecipeCatalyst(VanillaTypes.ITEM, new ItemStack(Items.STICK), DebugRecipeCategory.UID);
 			int i = 0;
 			for (Item item : ForgeRegistries.ITEMS.getValues()) {
 				ItemStack catalystIngredient = new ItemStack(item);
 				if (!catalystIngredient.isEmpty()) {
-					registration.addRecipeCatalyst(catalystIngredient, DebugRecipeCategory.UID);
+					registration.addRecipeCatalyst(VanillaTypes.ITEM, catalystIngredient, DebugRecipeCategory.UID);
 				}
 				i++;
 				if (i > 30) {

--- a/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
+++ b/src/main/java/mezz/jei/plugins/jei/ingredients/DebugIngredientHelper.java
@@ -2,6 +2,7 @@ package mezz.jei.plugins.jei.ingredients;
 
 import javax.annotation.Nullable;
 
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -13,6 +14,11 @@ import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.util.CommandUtilServer;
 
 public class DebugIngredientHelper implements IIngredientHelper<DebugIngredient> {
+	@Override
+	public IIngredientType<DebugIngredient> getIngredientType() {
+		return DebugIngredient.TYPE;
+	}
+
 	@Nullable
 	@Override
 	public DebugIngredient getMatch(Iterable<DebugIngredient> ingredients, DebugIngredient ingredientToMatch, UidContext context) {

--- a/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipe.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/anvil/AnvilRecipe.java
@@ -3,11 +3,12 @@ package mezz.jei.plugins.vanilla.anvil;
 import java.util.Collections;
 import java.util.List;
 
+import mezz.jei.api.recipe.vanilla.IJeiAnvilRecipe;
 import net.minecraft.world.item.ItemStack;
 
 import com.google.common.collect.ImmutableList;
 
-public class AnvilRecipe {
+public class AnvilRecipe implements IJeiAnvilRecipe {
 	private final List<List<ItemStack>> inputs;
 	private final List<List<ItemStack>> outputs;
 

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 import java.util.Collections;
 
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.ISubtypeManager;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.util.ErrorUtil;
@@ -30,6 +32,11 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 	public FluidStackHelper(ISubtypeManager subtypeManager, IColorHelper colorHelper) {
 		this.subtypeManager = subtypeManager;
 		this.colorHelper = colorHelper;
+	}
+
+	@Override
+	public IIngredientType<FluidStack> getIngredientType() {
+		return VanillaTypes.FLUID;
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -4,6 +4,8 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
@@ -30,6 +32,11 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 
 	public ItemStackHelper(StackHelper stackHelper) {
 		this.stackHelper = stackHelper;
+	}
+
+	@Override
+	public IIngredientType<ItemStack> getIngredientType() {
+		return VanillaTypes.ITEM;
 	}
 
 	@Override

--- a/src/main/java/mezz/jei/recipes/RecipeTransferManager.java
+++ b/src/main/java/mezz/jei/recipes/RecipeTransferManager.java
@@ -12,24 +12,26 @@ import mezz.jei.config.Constants;
 import mezz.jei.util.ErrorUtil;
 
 public class RecipeTransferManager {
-	private final ImmutableTable<Class<?>, ResourceLocation, IRecipeTransferHandler<?>> recipeTransferHandlers;
+	private final ImmutableTable<Class<?>, ResourceLocation, IRecipeTransferHandler<?, ?>> recipeTransferHandlers;
 
-	public RecipeTransferManager(ImmutableTable<Class<?>, ResourceLocation, IRecipeTransferHandler<?>> recipeTransferHandlers) {
+	public RecipeTransferManager(ImmutableTable<Class<?>, ResourceLocation, IRecipeTransferHandler<?, ?>> recipeTransferHandlers) {
 		this.recipeTransferHandlers = recipeTransferHandlers;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Nullable
-	public <T extends AbstractContainerMenu> IRecipeTransferHandler<? super T> getRecipeTransferHandler(T container, IRecipeCategory<?> recipeCategory) {
+	public <C extends AbstractContainerMenu, R> IRecipeTransferHandler<C, R> getRecipeTransferHandler(C container, IRecipeCategory<R> recipeCategory) {
 		ErrorUtil.checkNotNull(container, "container");
 		ErrorUtil.checkNotNull(recipeCategory, "recipeCategory");
 
 		Class<? extends AbstractContainerMenu> containerClass = container.getClass();
-		IRecipeTransferHandler<?> recipeTransferHandler = recipeTransferHandlers.get(containerClass, recipeCategory.getUid());
+		IRecipeTransferHandler<?, ?> recipeTransferHandler = recipeTransferHandlers.get(containerClass, recipeCategory.getUid());
 		if (recipeTransferHandler != null) {
-			return (IRecipeTransferHandler<? super T>) recipeTransferHandler;
+			if (recipeTransferHandler.getRecipeClass().isAssignableFrom(recipeCategory.getRecipeClass())) {
+				return (IRecipeTransferHandler<C, R>) recipeTransferHandler;
+			}
 		}
 
-		return (IRecipeTransferHandler<? super T>) recipeTransferHandlers.get(containerClass, Constants.UNIVERSAL_RECIPE_TRANSFER_UID);
+		return (IRecipeTransferHandler<C, R>) recipeTransferHandlers.get(containerClass, Constants.UNIVERSAL_RECIPE_TRANSFER_UID);
 	}
 }

--- a/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
+++ b/src/main/java/mezz/jei/render/IngredientListBatchRenderer.java
@@ -1,31 +1,32 @@
 package mezz.jei.render;
 
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.vertex.PoseStack;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-
-import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.entity.ItemRenderer;
-import com.mojang.blaze3d.platform.Lighting;
-import net.minecraft.client.resources.model.BakedModel;
-import net.minecraft.client.renderer.texture.TextureManager;
-import net.minecraft.world.inventory.InventoryMenu;
-import net.minecraft.world.item.ItemStack;
-
 import com.google.common.base.Preconditions;
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.platform.Lighting;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.ISlowRenderItem;
 import mezz.jei.config.IEditModeConfig;
 import mezz.jei.config.IWorldConfig;
 import mezz.jei.gui.ingredients.IIngredientListElement;
 import mezz.jei.input.ClickedIngredient;
 import mezz.jei.util.ErrorUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.inventory.InventoryMenu;
+import net.minecraft.world.item.ItemStack;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public class IngredientListBatchRenderer {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -144,6 +145,14 @@ public class IngredientListBatchRenderer {
 			}
 		}
 		return null;
+	}
+
+	public <T> Optional<IngredientListElementRenderer<T>> getHovered(double mouseX, double mouseY, IIngredientType<T> ingredientType) {
+		return this.slots.stream()
+			.filter(s -> s.isMouseOver(mouseX, mouseY))
+			.map(s -> s.getIngredientRenderer(ingredientType))
+			.filter(Objects::nonNull)
+			.findFirst();
 	}
 
 	/**

--- a/src/main/java/mezz/jei/render/IngredientListSlot.java
+++ b/src/main/java/mezz/jei/render/IngredientListSlot.java
@@ -2,6 +2,8 @@ package mezz.jei.render;
 
 import javax.annotation.Nullable;
 
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.ingredients.IngredientTypeHelper;
 import net.minecraft.client.renderer.Rect2i;
 
 import mezz.jei.util.MathUtil;
@@ -22,6 +24,11 @@ public class IngredientListSlot {
 	@Nullable
 	public IngredientListElementRenderer<?> getIngredientRenderer() {
 		return ingredientRenderer;
+	}
+
+	@Nullable
+	public <T> IngredientListElementRenderer<T> getIngredientRenderer(IIngredientType<T> ingredientType) {
+		return IngredientTypeHelper.checkedCast(ingredientRenderer, ingredientType);
 	}
 
 	public void clear() {

--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferInfo.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferInfo.java
@@ -9,16 +9,18 @@ import net.minecraft.resources.ResourceLocation;
 
 import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
 
-public class BasicRecipeTransferInfo<C extends AbstractContainerMenu> implements IRecipeTransferInfo<C> {
+public class BasicRecipeTransferInfo<C extends AbstractContainerMenu, R> implements IRecipeTransferInfo<C, R> {
 	private final Class<C> containerClass;
+	private final Class<R> recipeClass;
 	private final ResourceLocation recipeCategoryUid;
 	private final int recipeSlotStart;
 	private final int recipeSlotCount;
 	private final int inventorySlotStart;
 	private final int inventorySlotCount;
 
-	public BasicRecipeTransferInfo(Class<C> containerClass, ResourceLocation recipeCategoryUid, int recipeSlotStart, int recipeSlotCount, int inventorySlotStart, int inventorySlotCount) {
+	public BasicRecipeTransferInfo(Class<C> containerClass, Class<R> recipeClass, ResourceLocation recipeCategoryUid, int recipeSlotStart, int recipeSlotCount, int inventorySlotStart, int inventorySlotCount) {
 		this.containerClass = containerClass;
+		this.recipeClass = recipeClass;
 		this.recipeCategoryUid = recipeCategoryUid;
 		this.recipeSlotStart = recipeSlotStart;
 		this.recipeSlotCount = recipeSlotCount;
@@ -32,17 +34,22 @@ public class BasicRecipeTransferInfo<C extends AbstractContainerMenu> implements
 	}
 
 	@Override
+	public Class<R> getRecipeClass() {
+		return recipeClass;
+	}
+
+	@Override
 	public ResourceLocation getRecipeCategoryUid() {
 		return recipeCategoryUid;
 	}
 
 	@Override
-	public boolean canHandle(C container) {
+	public boolean canHandle(C container, R recipe) {
 		return true;
 	}
 
 	@Override
-	public List<Slot> getRecipeSlots(C container) {
+	public List<Slot> getRecipeSlots(C container, R recipe) {
 		List<Slot> slots = new ArrayList<>();
 		for (int i = recipeSlotStart; i < recipeSlotStart + recipeSlotCount; i++) {
 			Slot slot = container.getSlot(i);
@@ -52,7 +59,7 @@ public class BasicRecipeTransferInfo<C extends AbstractContainerMenu> implements
 	}
 
 	@Override
-	public List<Slot> getInventorySlots(C container) {
+	public List<Slot> getInventorySlots(C container, R recipe) {
 		List<Slot> slots = new ArrayList<>();
 		for (int i = inventorySlotStart; i < inventorySlotStart + inventorySlotCount; i++) {
 			Slot slot = container.getSlot(i);

--- a/src/main/java/mezz/jei/transfer/PlayerRecipeTransferHandler.java
+++ b/src/main/java/mezz/jei/transfer/PlayerRecipeTransferHandler.java
@@ -29,20 +29,21 @@ import mezz.jei.network.Network;
 import mezz.jei.network.packets.PacketRecipeTransfer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.crafting.CraftingRecipe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class PlayerRecipeTransferHandler implements IRecipeTransferHandler<InventoryMenu> {
+public class PlayerRecipeTransferHandler implements IRecipeTransferHandler<InventoryMenu, CraftingRecipe> {
 	private static final Logger LOGGER = LogManager.getLogger();
 
 	private final IStackHelper stackHelper;
 	private final IRecipeTransferHandlerHelper handlerHelper;
-	private final IRecipeTransferInfo<InventoryMenu> transferHelper;
+	private final IRecipeTransferInfo<InventoryMenu, CraftingRecipe> transferHelper;
 
 	public PlayerRecipeTransferHandler(IStackHelper stackhelper, IRecipeTransferHandlerHelper handlerHelper) {
 		this.stackHelper = stackhelper;
 		this.handlerHelper = handlerHelper;
-		this.transferHelper = new BasicRecipeTransferInfo<>(InventoryMenu.class, VanillaRecipeCategoryUid.CRAFTING, 1, 4, 9, 36);
+		this.transferHelper = new BasicRecipeTransferInfo<>(InventoryMenu.class, CraftingRecipe.class, VanillaRecipeCategoryUid.CRAFTING, 1, 4, 9, 36);
 	}
 
 	@Override
@@ -50,25 +51,30 @@ public class PlayerRecipeTransferHandler implements IRecipeTransferHandler<Inven
 		return transferHelper.getContainerClass();
 	}
 
+	@Override
+	public Class<CraftingRecipe> getRecipeClass() {
+		return transferHelper.getRecipeClass();
+	}
+
 	@Nullable
 	@Override
-	public IRecipeTransferError transferRecipe(InventoryMenu container, Object recipe, IRecipeLayout recipeLayout, Player player, boolean maxTransfer, boolean doTransfer) {
+	public IRecipeTransferError transferRecipe(InventoryMenu container, CraftingRecipe recipe, IRecipeLayout recipeLayout, Player player, boolean maxTransfer, boolean doTransfer) {
 		if (!ServerInfo.isJeiOnServer()) {
 			Component tooltipMessage = new TranslatableComponent("jei.tooltip.error.recipe.transfer.no.server");
 			return handlerHelper.createUserErrorWithTooltip(tooltipMessage);
 		}
 
-		if (!transferHelper.canHandle(container)) {
+		if (!transferHelper.canHandle(container, recipe)) {
 			return handlerHelper.createInternalError();
 		}
 
 		Map<Integer, Slot> inventorySlots = new HashMap<>();
-		for (Slot slot : transferHelper.getInventorySlots(container)) {
+		for (Slot slot : transferHelper.getInventorySlots(container, recipe)) {
 			inventorySlots.put(slot.index, slot);
 		}
 
 		Map<Integer, Slot> craftingSlots = new HashMap<>();
-		for (Slot slot : transferHelper.getRecipeSlots(container)) {
+		for (Slot slot : transferHelper.getRecipeSlots(container, recipe)) {
 			craftingSlots.put(slot.index, slot);
 		}
 

--- a/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
+++ b/src/main/java/mezz/jei/transfer/RecipeTransferUtil.java
@@ -10,6 +10,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import mezz.jei.api.ingredients.subtypes.UidContext;
+import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
@@ -44,13 +45,21 @@ public final class RecipeTransferUtil {
 	}
 
 	@Nullable
-	private static <T extends AbstractContainerMenu> IRecipeTransferError transferRecipe(RecipeTransferManager recipeTransferManager, T container, RecipeLayout<?> recipeLayout, Player player, boolean maxTransfer, boolean doTransfer) {
+	private static <C extends AbstractContainerMenu, R> IRecipeTransferError transferRecipe(
+		RecipeTransferManager recipeTransferManager,
+		C container,
+		RecipeLayout<R> recipeLayout,
+		Player player,
+		boolean maxTransfer,
+		boolean doTransfer
+	) {
 		final JeiRuntime runtime = Internal.getRuntime();
 		if (runtime == null) {
 			return RecipeTransferErrorInternal.INSTANCE;
 		}
 
-		final IRecipeTransferHandler<? super T> transferHandler = recipeTransferManager.getRecipeTransferHandler(container, recipeLayout.getRecipeCategory());
+		IRecipeCategory<R> recipeCategory = recipeLayout.getRecipeCategory();
+		final IRecipeTransferHandler<C, R> transferHandler = recipeTransferManager.getRecipeTransferHandler(container, recipeCategory);
 		if (transferHandler == null) {
 			if (doTransfer) {
 				LOGGER.error("No Recipe Transfer handler for container {}", container.getClass());

--- a/src/main/java/mezz/jei/util/ErrorUtil.java
+++ b/src/main/java/mezz/jei/util/ErrorUtil.java
@@ -269,6 +269,15 @@ public final class ErrorUtil {
 		}
 	}
 
+	public static <T> void checkIsInstance(IIngredientType<T> ingredientType, @Nullable T ingredient, String name) {
+		checkNotNull(ingredient, name);
+		Class<? extends T> ingredientClass = ingredientType.getIngredientClass();
+		if (!ingredientClass.isInstance(ingredient)) {
+			throw new IllegalArgumentException("Invalid ingredient found. Parameter Name: " + name +
+				" Should be an instance of: " + ingredientClass + " Instead got: " + ingredient.getClass());
+		}
+	}
+
 	public static <T> void checkIsValidIngredient(@Nullable T ingredient, String name) {
 		checkNotNull(ingredient, name);
 		IngredientManager ingredientManager = Internal.getIngredientManager();

--- a/src/main/java/mezz/jei/util/ErrorUtil.java
+++ b/src/main/java/mezz/jei/util/ErrorUtil.java
@@ -177,7 +177,8 @@ public final class ErrorUtil {
 		return itemStack + " " + itemName;
 	}
 
-	public static String getFluidStackInfo(@Nullable FluidStack fluidStack) {
+	@SuppressWarnings("ConstantConditions")
+	public static String getFluidStackInfo(FluidStack fluidStack) {
 		if (fluidStack == null) {
 			return "null";
 		}
@@ -197,7 +198,8 @@ public final class ErrorUtil {
 		return fluidStack + " " + fluidName;
 	}
 
-	public static void checkNotEmpty(@Nullable ItemStack itemStack) {
+	@SuppressWarnings("ConstantConditions")
+	public static void checkNotEmpty(ItemStack itemStack) {
 		if (itemStack == null) {
 			throw new NullPointerException("ItemStack must not be null.");
 		} else if (itemStack.isEmpty()) {
@@ -206,7 +208,8 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static void checkNotEmpty(@Nullable ItemStack itemStack, String name) {
+	@SuppressWarnings("ConstantConditions")
+	public static void checkNotEmpty(ItemStack itemStack, String name) {
 		if (itemStack == null) {
 			throw new NullPointerException(name + " must not be null.");
 		} else if (itemStack.isEmpty()) {
@@ -215,7 +218,8 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static void checkNotEmpty(@Nullable FluidStack fluidStack) {
+	@SuppressWarnings("ConstantConditions")
+	public static void checkNotEmpty(FluidStack fluidStack) {
 		if (fluidStack == null) {
 			throw new NullPointerException("FluidStack must not be null.");
 		} else if (fluidStack.isEmpty()) {
@@ -224,7 +228,8 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static <T> void checkNotEmpty(@Nullable T[] values, String name) {
+	@SuppressWarnings("ConstantConditions")
+	public static <T> void checkNotEmpty(T[] values, String name) {
 		if (values == null) {
 			throw new NullPointerException(name + " must not be null.");
 		} else if (values.length <= 0) {
@@ -237,7 +242,8 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static void checkNotEmpty(@Nullable Collection<?> values, String name) {
+	@SuppressWarnings("ConstantConditions")
+	public static void checkNotEmpty(Collection<?> values, String name) {
 		if (values == null) {
 			throw new NullPointerException(name + " must not be null.");
 		} else if (values.isEmpty()) {
@@ -251,13 +257,15 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static <T> void checkNotNull(@Nullable T object, String name) {
+	@SuppressWarnings("ConstantConditions")
+	public static <T> void checkNotNull(T object, String name) {
 		if (object == null) {
 			throw new NullPointerException(name + " must not be null.");
 		}
 	}
 
-	public static void checkNotNull(@Nullable Collection<?> values, String name) {
+	@SuppressWarnings("ConstantConditions")
+	public static void checkNotNull(Collection<?> values, String name) {
 		if (values == null) {
 			throw new NullPointerException(name + " must not be null.");
 		} else if (!(values instanceof NonNullList)) {
@@ -269,7 +277,7 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static <T> void checkIsInstance(IIngredientType<T> ingredientType, @Nullable T ingredient, String name) {
+	public static <T> void checkIsInstance(IIngredientType<T> ingredientType, T ingredient, String name) {
 		checkNotNull(ingredient, name);
 		Class<? extends T> ingredientClass = ingredientType.getIngredientClass();
 		if (!ingredientClass.isInstance(ingredient)) {
@@ -278,7 +286,7 @@ public final class ErrorUtil {
 		}
 	}
 
-	public static <T> void checkIsValidIngredient(@Nullable T ingredient, String name) {
+	public static <T> void checkIsValidIngredient(T ingredient, String name) {
 		checkNotNull(ingredient, name);
 		IngredientManager ingredientManager = Internal.getIngredientManager();
 		IIngredientHelper<T> ingredientHelper = ingredientManager.getIngredientHelper(ingredient);

--- a/src/test/java/mezz/jei/test/lib/TestIngredientHelper.java
+++ b/src/test/java/mezz/jei/test/lib/TestIngredientHelper.java
@@ -4,9 +4,15 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 
 import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 
 public class TestIngredientHelper implements IIngredientHelper<TestIngredient> {
+	@Override
+	public IIngredientType<TestIngredient> getIngredientType() {
+		return TestIngredient.TYPE;
+	}
+
 	@Nullable
 	@Override
 	public TestIngredient getMatch(Iterable<TestIngredient> ingredients, TestIngredient ingredientToMatch, UidContext context) {


### PR DESCRIPTION
This adds some more typed methods to replace ones that returned a raw `Object` ingredient.
The idea is to remove most `Object` references because they don't offer any type safety, with `Object` it's easy to make a mistake and pass in a recipe category or something else instead of a recipe or ingredient.