### PR TITLE
Add support to open the config screen with Configured mod

### DIFF
--- a/src/main/java/mezz/jei/config/JEIClientConfig.java
+++ b/src/main/java/mezz/jei/config/JEIClientConfig.java
@@ -1,15 +1,23 @@
 package mezz.jei.config;
 
+import mezz.jei.api.constants.ModIds;
 import mezz.jei.events.EventBusHelper;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.util.text.event.ClickEvent;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ExtensionPoint;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 public class JEIClientConfig {
 	private static final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -43,12 +51,18 @@ public class JEIClientConfig {
 			return;
 		}
 
-		ClickEvent clickEvent = new ClickEvent(ClickEvent.Action.OPEN_URL, "https://www.curseforge.com/minecraft/mc-mods/configured");
-		Style style = Style.EMPTY
-				.setUnderlined(true)
-				.withClickEvent(clickEvent);
-		TranslationTextComponent textComponent = new TranslationTextComponent("jei.message.configured");
-		ITextComponent message = textComponent.setStyle(style);
-		mc.player.displayClientMessage(message, false);
+        ModContainer jeiContainer = ModList.get().getModContainerById(ModIds.JEI_ID).get();
+        Optional<BiFunction<Minecraft, Screen, Screen>> configGuiFactory = jeiContainer.getCustomExtension(ExtensionPoint.CONFIGGUIFACTORY);
+        if (configGuiFactory.isPresent()) {
+            mc.setScreen(configGuiFactory.get().apply(mc, mc.screen));
+        } else {
+            ClickEvent clickEvent = new ClickEvent(ClickEvent.Action.OPEN_URL, "https://www.curseforge.com/minecraft/mc-mods/configured");
+            Style style = Style.EMPTY
+                    .setUnderlined(true)
+                    .withClickEvent(clickEvent);
+            TranslationTextComponent textComponent = new TranslationTextComponent("jei.message.configured");
+            ITextComponent message = textComponent.setStyle(style);
+            mc.player.displayClientMessage(message, false);
+        }
 	}
 }


### PR DESCRIPTION
Changed the JEI settings button to open config screen if a mod that adds one exists. Otherwise, it will show the download configured message. Fixes #2538 