### PR TITLE
Port to 1.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 org.gradle.daemon=false
 
 # Minecraft
-minecraft_version=1.18.1
-minecraft_version_range=[1.18.1, 1.19)
+minecraft_version=1.18.2
+minecraft_version_range=[1.18.2, 1.19)
 
 # Forge
-forge_version=39.0.89
-loader_version_range=[39,)
-forge_version_range=[39.0.0,)
+forge_version=40.0.1
+loader_version_range=[40,)
+forge_version_range=[40.0.0,)
 forge_group=net.minecraftforge
 
 # Mappings
 mapping_channel=official
-mapping_version=1.18.1
+mapping_version=1.18.2
 
 # Publishing
 curse_project_id=238222

--- a/src/main/java/mezz/jei/ingredients/IngredientSorterComparators.java
+++ b/src/main/java/mezz/jei/ingredients/IngredientSorterComparators.java
@@ -6,10 +6,10 @@ import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.config.sorting.IngredientTypeSortingConfig;
 import mezz.jei.config.sorting.ModNameSortingConfig;
 import mezz.jei.gui.ingredients.IListElement;
+import net.minecraft.core.HolderSet.ListBacked;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.ItemTags;
-import net.minecraft.tags.Tag;
-import net.minecraft.tags.TagCollection;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -279,10 +279,10 @@ public class IngredientSorterComparators {
 		if (tagId.toString().equals("itemfilters:check_nbt")) {
 			return 0;
 		}
-		TagCollection<Item> allTags = ItemTags.getAllTags();
-		Tag<Item> tags = allTags.getTagOrEmpty(tagId);
-		List<Item> values = tags.getValues();
-		return values.size();
+		TagKey<Item> tagKey = TagKey.create(Registry.ITEM_REGISTRY, tagId);
+		return Registry.ITEM.getTag(tagKey)
+			.map(ListBacked::size)
+			.orElse(0);
 	}
 
 	private boolean hasTag(IListElementInfo<?> elementInfo) {

--- a/src/main/java/mezz/jei/plugins/vanilla/crafting/replacers/ShulkerBoxColoringRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/crafting/replacers/ShulkerBoxColoringRecipeMaker.java
@@ -3,7 +3,7 @@ package mezz.jei.plugins.vanilla.crafting.replacers;
 import mezz.jei.api.constants.ModIds;
 import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.item.Item;
@@ -28,7 +28,7 @@ public final class ShulkerBoxColoringRecipeMaker {
 			.map(color -> {
 				DyeItem dye = DyeItem.byColor(color);
 				ItemStack dyeStack = new ItemStack(dye);
-				Tag<Item> colorTag = color.getTag();
+				TagKey<Item> colorTag = color.getTag();
 				Ingredient.Value dyeList = new Ingredient.ItemValue(dyeStack);
 				Ingredient.Value colorList = new Ingredient.TagValue(colorTag);
 				Stream<Ingredient.Value> colorIngredientStream = Stream.of(dyeList, colorList);

--- a/src/main/java/mezz/jei/plugins/vanilla/crafting/replacers/SuspiciousStewRecipeMaker.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/crafting/replacers/SuspiciousStewRecipeMaker.java
@@ -1,10 +1,14 @@
 package mezz.jei.plugins.vanilla.crafting.replacers;
 
 import mezz.jei.api.constants.ModIds;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet.ListBacked;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.SuspiciousStewItem;
@@ -24,7 +28,12 @@ public final class SuspiciousStewRecipeMaker {
 		Ingredient redMushroom = Ingredient.of(Blocks.RED_MUSHROOM.asItem());
 		Ingredient bowl = Ingredient.of(Items.BOWL);
 
-		return BlockTags.SMALL_FLOWERS.getValues().stream()
+		return Registry.ITEM.getTag(ItemTags.SMALL_FLOWERS)
+			.stream()
+			.flatMap(ListBacked::stream)
+			.map(Holder::value)
+			.filter(BlockItem.class::isInstance)
+			.map(item -> ((BlockItem) item).getBlock())
 			.filter(FlowerBlock.class::isInstance)
 			.map(FlowerBlock.class::cast)
 			.map(flowerBlock -> {

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/fluid/FluidStackHelper.java
@@ -11,10 +11,10 @@ import mezz.jei.util.ErrorUtil;
 import mezz.jei.util.TagUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -143,7 +143,7 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 
 	@Override
 	public Collection<ResourceLocation> getTags(FluidStack ingredient) {
-		return ingredient.getFluid().getTags();
+		return TagUtil.getTags(ingredient.getFluid().builtInRegistryHolder());
 	}
 
 	@Override
@@ -172,6 +172,6 @@ public class FluidStackHelper implements IIngredientHelper<FluidStack> {
 
 	@Override
 	public Optional<ResourceLocation> getTagEquivalent(Collection<FluidStack> ingredients) {
-		return TagUtil.getTagEquivalent(ingredients, FluidStack::getFluid, FluidTags.getAllTags());
+		return TagUtil.getTagEquivalent(ingredients, FluidStack::getFluid, Registry.FLUID::getTags);
 	}
 }

--- a/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
+++ b/src/main/java/mezz/jei/plugins/vanilla/ingredients/item/ItemStackHelper.java
@@ -8,9 +8,9 @@ import mezz.jei.color.ColorGetter;
 import mezz.jei.util.ErrorUtil;
 import mezz.jei.util.StackHelper;
 import mezz.jei.util.TagUtil;
+import net.minecraft.core.Registry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -145,7 +145,7 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 
 	@Override
 	public Collection<ResourceLocation> getTags(ItemStack ingredient) {
-		return ingredient.getItem().getTags();
+		return TagUtil.getTags(ingredient.getTags());
 	}
 
 	@Override
@@ -168,6 +168,6 @@ public class ItemStackHelper implements IIngredientHelper<ItemStack> {
 
 	@Override
 	public Optional<ResourceLocation> getTagEquivalent(Collection<ItemStack> ingredients) {
-		return TagUtil.getTagEquivalent(ingredients, ItemStack::getItem, ItemTags.getAllTags());
+		return TagUtil.getTagEquivalent(ingredients, ItemStack::getItem, Registry.ITEM::getTags);
 	}
 }

--- a/src/main/java/mezz/jei/util/TagUtil.java
+++ b/src/main/java/mezz/jei/util/TagUtil.java
@@ -1,20 +1,35 @@
 package mezz.jei.util;
 
+import com.mojang.datafixers.util.Pair;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
-import net.minecraft.tags.TagCollection;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import net.minecraft.tags.TagKey;
 
 public class TagUtil {
+
+	public static <TYPE> Collection<ResourceLocation> getTags(Holder.Reference<TYPE> reference) {
+		return getTags(reference.tags());
+	}
+
+	public static <TYPE> Collection<ResourceLocation> getTags(Stream<TagKey<TYPE>> tags) {
+		return tags.map(TagKey::location)
+			.collect(Collectors.toUnmodifiableSet());
+	}
+
 	public static <VALUE, STACK> Optional<ResourceLocation> getTagEquivalent(
 		Collection<STACK> stacks,
 		Function<STACK, VALUE> stackToValue,
-		TagCollection<VALUE> tagCollection
+		Supplier<Stream<Pair<TagKey<VALUE>, HolderSet.Named<VALUE>>>> tagSupplier
 	) {
 		if (stacks.size() < 2) {
 			return Optional.empty();
@@ -24,16 +39,20 @@ public class TagUtil {
 			.map(stackToValue)
 			.toList();
 
-		return tagCollection
-			.getAllTags()
-			.entrySet()
-			.stream()
+		return tagSupplier.get()
 			.filter(e -> {
-				Tag<VALUE> valueTags = e.getValue();
-				List<VALUE> tagValues = valueTags.getValues();
-				return tagValues.equals(values);
+				HolderSet.Named<VALUE> tag = e.getSecond();
+				int count = tag.size();
+				if (count == values.size()) {
+					return IntStream.range(0, count).allMatch(i -> {
+						VALUE tagValue = tag.get(i).value();
+						VALUE value = values.get(i);
+						return value.equals(tagValue);
+					});
+				}
+				return false;
 			})
-			.map(Map.Entry::getKey)
+			.map(e -> e.getFirst().location())
 			.findFirst();
 	}
 }


### PR DESCRIPTION
Initial port to 1.18.2 that seems to work fine. I didn't test the ingredient sort comparator as I was not quite sure how to best do so. I also changed the suspicious stew recipe creator to more closely mimic the recipe itself as it is based on the item tag not the block tag. For vanilla flowers this shouldn't make a difference but for purposes of modded flowers where maybe the flower is only added to one of the tags this fixes the discrepancy.

I am also slightly unsure if accessing things via the vanilla registry is the correct way to do things but it seems like that is how things are done now and there doesn't appear to be a way to do so (at least yet) via the forge registry.