### PR TITLE
[1.19] Fix improper property use causing invalid dependency POM

### DIFF
--- a/FabricApi/build.gradle.kts
+++ b/FabricApi/build.gradle.kts
@@ -103,7 +103,7 @@ publishing {
                 dependencyProjects.forEach {
                     val dependencyNode = dependenciesNode.appendNode("dependency")
                     dependencyNode.appendNode("groupId", it.group)
-                    dependencyNode.appendNode("artifactId", it.base.archivesName)
+                    dependencyNode.appendNode("artifactId", it.base.archivesName.get())
                     dependencyNode.appendNode("version", it.version)
                 }
             }

--- a/Forge/build.gradle.kts
+++ b/Forge/build.gradle.kts
@@ -186,7 +186,7 @@ publishing {
 				dependencyProjects.forEach {
 					val dependencyNode = dependenciesNode.appendNode("dependency")
 					dependencyNode.appendNode("groupId", it.group)
-					dependencyNode.appendNode("artifactId", it.base.archivesName)
+					dependencyNode.appendNode("artifactId", it.base.archivesName.get())
 					dependencyNode.appendNode("version", it.version)
 				}
 			}

--- a/ForgeApi/build.gradle.kts
+++ b/ForgeApi/build.gradle.kts
@@ -92,7 +92,7 @@ publishing {
 				dependencyProjects.forEach {
 					val dependencyNode = dependenciesNode.appendNode("dependency")
 					dependencyNode.appendNode("groupId", it.group)
-					dependencyNode.appendNode("artifactId", it.base.archivesName)
+					dependencyNode.appendNode("artifactId", it.base.archivesName.get())
 					dependencyNode.appendNode("version", it.version)
 				}
 			}


### PR DESCRIPTION
The `archivesName` property of `BasePluginExtension` is a `Property<String>`. The default implementation of `toString()` for a `Property` is to print out their name and owning object, and not the `toString()` of their contents.

This meant that passing `archivesName` to `Node#appendNode` as a value, which calls `toString()` on it to make it into a String, results in e.g. `extension 'base' property 'archivesName'` instead of the expected value of e.g. `jei-1.19-common-api`.

The simple fix is to call `Property#get()` on `archivesName` to get its actual value and pass that on as the node value.