### PR TITLE
Allow recipe transfer errors to set button color highlight

### DIFF
--- a/Common/src/main/java/mezz/jei/common/gui/recipes/layout/RecipeTransferButton.java
+++ b/Common/src/main/java/mezz/jei/common/gui/recipes/layout/RecipeTransferButton.java
@@ -76,7 +76,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 	public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
 		super.render(poseStack, mouseX, mouseY, partialTicks);
 		if (this.visible && this.recipeTransferError != null && this.recipeTransferError.getType() == IRecipeTransferError.Type.COSMETIC) {
-			fill(poseStack, this.x, this.y, this.x + this.width, this.y + this.height, 0x80FFA500);
+			fill(poseStack, this.x, this.y, this.x + this.width, this.y + this.height, this.recipeTransferError.getButtonHighlightColor());
 		}
 	}
 

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -37,7 +37,7 @@ public interface IRecipeTransferError {
 	Type getType();
 
 	/**
-	 * Return the RGBA color of the additional button highlight for {@link Type#COSMETIC}.
+	 * Return the ARGB color of the additional button highlight for {@link Type#COSMETIC}.
 	 * For example, return 0 to disable the colored highlight. Default color is orange.
 	 *
 	 * @since 11.2.1

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -37,6 +37,14 @@ public interface IRecipeTransferError {
 	Type getType();
 
 	/**
+	 * Return the RGBA color of the additional button highlight for {@link Type#COSMETIC}.
+	 * For example, return 0 to disable the colored highlight. Default color is orange.
+	 */
+	default int getButtonHighlightColor() {
+		return 0x80FFA500;
+	}
+
+	/**
 	 * Called on {@link Type#USER_FACING} errors.
 	 *
 	 * @since 9.3.0

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -39,6 +39,8 @@ public interface IRecipeTransferError {
 	/**
 	 * Return the RGBA color of the additional button highlight for {@link Type#COSMETIC}.
 	 * For example, return 0 to disable the colored highlight. Default color is orange.
+	 *
+	 * @since 11.2.1
 	 */
 	default int getButtonHighlightColor() {
 		return 0x80FFA500;

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ curseHomepageUrl=https://www.curseforge.com/minecraft/mc-mods/jei
 jUnitVersion=5.8.2
 
 # Version
-specificationVersion=11.2.0
+specificationVersion=11.2.1
 
 # Workaround for Spotless bug
 # https://github.com/diffplug/spotless/issues/834


### PR DESCRIPTION
I modified the `RecipeTransferErrorTooltip` to test this.

- **Use case 1**: render useful info but keep the normal display of the button (by returning `0`). Can also be used to change the tooltip message (for example `Encode pattern` instead of `Move items` for AE2).
![image](https://user-images.githubusercontent.com/13494793/187446728-73b8c902-f56d-4250-aa03-ea4484e203cb.png)
- **Use case 2**: change color of the button to indicate different behavior. For example, in AE2, I will use orange when some items are missing, transparent when everything is available, and blue when everything is available or craftable. Image when I use `return 0x804545FF;`:
![image](https://user-images.githubusercontent.com/13494793/187447805-228c433d-08ef-4986-9393-1fb45aece1a4.png)
