### PR TITLE
Make the `Show Recipes` tooltip optional in the API

### DIFF
--- a/Common/src/main/java/mezz/jei/common/gui/GuiEventHandler.java
+++ b/Common/src/main/java/mezz/jei/common/gui/GuiEventHandler.java
@@ -90,6 +90,7 @@ public class GuiEventHandler {
 			int guiLeft = screenHelper.getGuiLeft(guiContainer);
 			int guiTop = screenHelper.getGuiTop(guiContainer);
 			guiScreenHelper.getGuiClickableArea(guiContainer, mouseX - guiLeft, mouseY - guiTop)
+				.filter(IGuiClickableArea::isTooltipEnabled)
 				.map(IGuiClickableArea::getTooltipStrings)
 				.ifPresent(tooltipStrings -> {
 					if (tooltipStrings.isEmpty()) {

--- a/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -24,6 +24,8 @@ public interface IGuiClickableArea {
 	 * Returns whether the area should render a tooltip when hovered over.
 	 * The tooltip can be modified by overriding {@link #getTooltipStrings()}.
 	 * This will also disable the default "Show Recipes" message.
+	 *
+	 * @since 11.2.2
 	 */
 	default boolean isTooltipEnabled() {
 		return true;
@@ -57,6 +59,11 @@ public interface IGuiClickableArea {
 			@Override
 			public Rect2i getArea() {
 				return area;
+			}
+
+			@Override
+			public boolean isTooltipEnabled() {
+				return false;
 			}
 
 			@Override

--- a/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -21,6 +21,15 @@ public interface IGuiClickableArea {
 	Rect2i getArea();
 
 	/**
+	 * Returns whether the area should render a tooltip when hovered over.
+	 * The tooltip can be modified by overriding {@link #getTooltipStrings()}.
+	 * This will also disable the default "Show Recipes" message.
+	 */
+	default boolean isTooltipEnabled() {
+		return true;
+	}
+
+	/**
 	 * Returns the strings to be shown on the tooltip when this area is hovered over.
 	 * Return an empty list to display the default "Show Recipes" message.
 	 */

--- a/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -62,11 +62,6 @@ public interface IGuiClickableArea {
 			}
 
 			@Override
-			public boolean isTooltipEnabled() {
-				return false;
-			}
-
-			@Override
 			public void onClick(IFocusFactory focusFactory, IRecipesGui recipesGui) {
 				recipesGui.showTypes(recipeTypesList);
 			}

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ curseHomepageUrl=https://www.curseforge.com/minecraft/mc-mods/jei
 jUnitVersion=5.8.2
 
 # Version
-specificationVersion=11.2.1
+specificationVersion=11.2.2
 
 # Workaround for Spotless bug
 # https://github.com/diffplug/spotless/issues/834


### PR DESCRIPTION
fixes #2794

This PR adds the ability to disable the default `Show Recipes` tooltip on the `IGuiClickableArea`.

Since the default implementation returns `true`, this does not break any functionality. I tested it by returning `false` for the basic `IGuiClickableArea` which is used for the vanilla plugin. The tooltip does not show up anymore and if you click, the recipes are still visible.

The use case:
I display a lot of information about the current recipe when hovering over the progress arrow in my custom screen. Since I don't want to break the general convention of opening the recipe page when clicking the progress arrow, I want this new API endpoint to avoid an overlapping tooltip.

Since the current implementation will also show the default tooltip when returning an empty list, I think a new default method is the best way. This could maybe changed in future versions as a breaking change because it doesn't make much sense that an empty list also uses the default tooltip. Why would you overwrite the method then?

I'd also appreciate a backport to 1.18.2 if possible.