### PR TITLE
Make the `Show Recipes` tooltip optional in the API (#2972)

### DIFF
--- a/Common/src/main/java/mezz/jei/common/gui/GuiEventHandler.java
+++ b/Common/src/main/java/mezz/jei/common/gui/GuiEventHandler.java
@@ -90,6 +90,7 @@ public class GuiEventHandler {
 			int guiLeft = screenHelper.getGuiLeft(guiContainer);
 			int guiTop = screenHelper.getGuiTop(guiContainer);
 			guiScreenHelper.getGuiClickableArea(guiContainer, mouseX - guiLeft, mouseY - guiTop)
+				.filter(IGuiClickableArea::isTooltipEnabled)
 				.map(IGuiClickableArea::getTooltipStrings)
 				.ifPresent(tooltipStrings -> {
 					if (tooltipStrings.isEmpty()) {

--- a/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiClickableArea.java
@@ -24,6 +24,17 @@ public interface IGuiClickableArea {
 	Rect2i getArea();
 
 	/**
+	 * Returns whether the area should render a tooltip when hovered over.
+	 * The tooltip can be modified by overriding {@link #getTooltipStrings()}.
+	 * This will also disable the default "Show Recipes" message.
+	 *
+	 * @since 10.1.4
+	 */
+	default boolean isTooltipEnabled() {
+		return true;
+	}
+
+	/**
 	 * Returns the strings to be shown on the tooltip when this area is hovered over.
 	 * Return an empty list to display the default "Show Recipes" message.
 	 */

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ curseHomepageUrl=https://www.curseforge.com/minecraft/mc-mods/jei
 jUnitVersion=5.8.2
 
 # Version
-specificationVersion=10.1.3
+specificationVersion=10.1.4
 
 # Workaround for Spotless bug
 # https://github.com/diffplug/spotless/issues/834


### PR DESCRIPTION
JEI v10 backport of https://github.com/mezz/JustEnoughItems/pull/2972