### PR TITLE
Prefer more abundant items first for recipe transfer

### DIFF
--- a/Common/src/main/java/mezz/jei/common/transfer/BasicRecipeTransferHandlerServer.java
+++ b/Common/src/main/java/mezz/jei/common/transfer/BasicRecipeTransferHandlerServer.java
@@ -39,7 +39,7 @@ public final class BasicRecipeTransferHandlerServer {
 			return;
 		}
 
-		Map<Slot, Pair<Slot, ItemStack>> recipeSlotToRequiredItemStack = calculateRequiredStacks(transferOperations, player);
+		Map<Slot, ItemStackWithSlotHint> recipeSlotToRequiredItemStack = calculateRequiredStacks(transferOperations, player);
 		if (recipeSlotToRequiredItemStack == null) {
 			return;
 		}
@@ -133,8 +133,8 @@ public final class BasicRecipeTransferHandlerServer {
 	}
 
 	@Nullable
-	private static Map<Slot, Pair<Slot, ItemStack>> calculateRequiredStacks(List<TransferOperation> transferOperations, Player player) {
-		Map<Slot, Pair<Slot, ItemStack>> recipeSlotToRequired = new HashMap<>(transferOperations.size());
+	private static Map<Slot, ItemStackWithSlotHint> calculateRequiredStacks(List<TransferOperation> transferOperations, Player player) {
+		Map<Slot, ItemStackWithSlotHint> recipeSlotToRequired = new HashMap<>(transferOperations.size());
 		for (TransferOperation transferOperation : transferOperations) {
 			Slot recipeSlot = transferOperation.craftingSlot();
 			Slot inventorySlot = transferOperation.inventorySlot();
@@ -157,7 +157,7 @@ public final class BasicRecipeTransferHandlerServer {
 			}
 			ItemStack stack = slotStack.copy();
 			stack.setCount(1);
-			recipeSlotToRequired.put(recipeSlot, new Pair<>(inventorySlot, stack));
+			recipeSlotToRequired.put(recipeSlot, new ItemStackWithSlotHint(inventorySlot, stack));
 		}
 		return recipeSlotToRequired;
 	}
@@ -165,7 +165,7 @@ public final class BasicRecipeTransferHandlerServer {
 	@Nonnull
 	private static Map<Slot, ItemStack> takeItemsFromInventory(
 		Player player,
-		Map<Slot, Pair<Slot, ItemStack>> recipeSlotToRequiredItemStack,
+		Map<Slot, ItemStackWithSlotHint> recipeSlotToRequiredItemStack,
 		List<Slot> craftingSlots,
 		List<Slot> inventorySlots,
 		boolean transferAsCompleteSets,
@@ -209,7 +209,7 @@ public final class BasicRecipeTransferHandlerServer {
 
 	private static Map<Slot, ItemStack> removeOneSetOfItemsFromInventory(
 		Player player,
-		Map<Slot, Pair<Slot, ItemStack>> recipeSlotToRequiredItemStack,
+		Map<Slot, ItemStackWithSlotHint> recipeSlotToRequiredItemStack,
 		List<Slot> craftingSlots,
 		List<Slot> inventorySlots,
 		boolean transferAsCompleteSets
@@ -225,10 +225,10 @@ public final class BasicRecipeTransferHandlerServer {
 		// us to simply ignore the map's contents when a complete set isn't found.
 		final Map<Slot, ItemStack> foundItemsInSet = new HashMap<>(recipeSlotToRequiredItemStack.size());
 
-		for (Map.Entry<Slot, Pair<Slot, ItemStack>> entry : recipeSlotToRequiredItemStack.entrySet()) { // for each item in set
+		for (Map.Entry<Slot, ItemStackWithSlotHint> entry : recipeSlotToRequiredItemStack.entrySet()) { // for each item in set
 			final Slot recipeSlot = entry.getKey();
-			final ItemStack requiredStack = entry.getValue().second();
-			final Slot hint = entry.getValue().first();
+			final ItemStack requiredStack = entry.getValue().stack;
+			final Slot hint = entry.getValue().hint;
 
 			// Locate a slot that has what we need.
 			final Slot slot = getSlotWithStack(player, requiredStack, craftingSlots, inventorySlots, hint);
@@ -287,7 +287,11 @@ public final class BasicRecipeTransferHandlerServer {
 		Slot slot = getSlotWithStack(player, craftingSlots, stack);
 
 		if (slot == null) {
-			if (!hint.getItem().isEmpty() && ItemStack.isSameItemSameTags(stack, hint.getItem()) && hint.mayPickup(player)) {
+			if (
+				hint.mayPickup(player) &&
+				!hint.getItem().isEmpty() &&
+				ItemStack.isSameItemSameTags(stack, hint.getItem())
+			) {
 				return hint;
 			}
 
@@ -358,4 +362,6 @@ public final class BasicRecipeTransferHandlerServer {
 		}
 		return null;
 	}
+
+	private record ItemStackWithSlotHint(Slot hint, ItemStack stack) {}
 }


### PR DESCRIPTION
This change makes JEI provided recipe transferer smarter, by searching for most abundant ingredient(s) first.

This resolves cases of frustation where player quickly presses quickfill button, without checking *what* was filled in recipe slots, such as filling valuable resource (e.g. treated sticks) which is less abundant (in inventory) than common resource (e.g. regular sticks), and then crafting recipe, wasting valuable less-abundant resource.

New logic at deciding which ingredient to use is as follows:

- Search for all slots matching each ingredient
- Split all matched slots inside one ingredient into "equal" item groups (oak planks go to other oak planks, spruce to spruce, etc)
- Sort all result group lists to make groups with most items go first
- Sort all result group' sublists to make slots with least items go first
- Select first-match item from result stream

Demo:

https://user-images.githubusercontent.com/6339511/189647631-b94eeb48-0b9b-45da-8b8c-1de0fdef5354.mp4


https://user-images.githubusercontent.com/6339511/189647641-a914b8e9-2b1e-477d-a9a8-3b8b73cf5100.mp4


https://user-images.githubusercontent.com/6339511/189647642-4f33f3a8-100b-4853-a1f9-50246432f80b.mp4


https://user-images.githubusercontent.com/6339511/189647654-d6da4038-84e1-4cfb-ab9c-0bd7dabcbee1.mp4

