### PR TITLE
Improve performance of checking fuels on Fabric

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/platform/ItemStackHelper.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/platform/ItemStackHelper.java
@@ -1,28 +1,26 @@
 package mezz.jei.fabric.platform;
 
 import mezz.jei.common.platform.IPlatformItemStackHelper;
+import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 
 public class ItemStackHelper implements IPlatformItemStackHelper {
     private static final Logger LOGGER = LogManager.getLogger();
 
     @Override
     public int getBurnTime(ItemStack itemStack) {
-        Map<Item, Integer> fuels = AbstractFurnaceBlockEntity.getFuel();
-        return fuels.getOrDefault(itemStack.getItem(), 0);
+        return Objects.requireNonNullElse(FuelRegistry.INSTANCE.get(itemStack.getItem()), 0);
     }
 
     @Override


### PR DESCRIPTION
I noticed that initializing fuels was taking around 500 ms in my MI dev, and with the help of the profiler I found the culprit. :wink:

![image](https://user-images.githubusercontent.com/13494793/192161372-f7106e71-24e7-4d81-93c2-176b711267ce.png)
