### PR TITLE
Allow recipe transfer errors to set button color highlight (#2971)

### DIFF
--- a/Common/src/main/java/mezz/jei/common/gui/recipes/RecipeCategoryTab.java
+++ b/Common/src/main/java/mezz/jei/common/gui/recipes/RecipeCategoryTab.java
@@ -8,7 +8,6 @@ import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.ingredients.IIngredientRenderer;
 import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.category.IRecipeCategory;
-import mezz.jei.common.config.KeyBindings;
 import mezz.jei.common.gui.textures.Textures;
 import mezz.jei.common.ingredients.RegisteredIngredients;
 import mezz.jei.common.input.IKeyBindings;

--- a/Common/src/main/java/mezz/jei/common/gui/recipes/layout/RecipeTransferButton.java
+++ b/Common/src/main/java/mezz/jei/common/gui/recipes/layout/RecipeTransferButton.java
@@ -78,7 +78,7 @@ public class RecipeTransferButton extends GuiIconButtonSmall {
 	public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
 		super.render(poseStack, mouseX, mouseY, partialTicks);
 		if (this.visible && this.recipeTransferError != null && this.recipeTransferError.getType() == IRecipeTransferError.Type.COSMETIC) {
-			fill(poseStack, this.x, this.y, this.x + this.width, this.y + this.height, 0x80FFA500);
+			fill(poseStack, this.x, this.y, this.x + this.width, this.y + this.height, this.recipeTransferError.getButtonHighlightColor());
 		}
 	}
 

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotView.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotView.java
@@ -7,11 +7,8 @@ import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
-import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
-import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -38,6 +38,16 @@ public interface IRecipeTransferError {
 	Type getType();
 
 	/**
+	 * Return the ARGB color of the additional button highlight for {@link Type#COSMETIC}.
+	 * For example, return 0 to disable the colored highlight. Default color is orange.
+	 *
+	 * @since 11.2.1
+	 */
+	default int getButtonHighlightColor() {
+		return 0x80FFA500;
+	}
+
+	/**
 	 * Called on {@link Type#USER_FACING} errors.
 	 *
 	 * @implNote JEI also calls {@link #showError(PoseStack, int, int, IRecipeLayout, int, int)}

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferError.java
@@ -41,7 +41,7 @@ public interface IRecipeTransferError {
 	 * Return the ARGB color of the additional button highlight for {@link Type#COSMETIC}.
 	 * For example, return 0 to disable the colored highlight. Default color is orange.
 	 *
-	 * @since 11.2.1
+	 * @since 10.1.5
 	 */
 	default int getButtonHighlightColor() {
 		return 0x80FFA500;

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ curseHomepageUrl=https://www.curseforge.com/minecraft/mc-mods/jei
 jUnitVersion=5.8.2
 
 # Version
-specificationVersion=10.1.4
+specificationVersion=10.1.5
 
 # Workaround for Spotless bug
 # https://github.com/diffplug/spotless/issues/834


### PR DESCRIPTION
Backport #2971 to 1.18.2

The unrelated changes are from running spotlessApply (the 1.18 branch HEAD had some violations).