### PR TITLE
[1.19.3] JEI menus use creative TooltipFlags instead of non-creative ones to match with the Creative Menu.

### DIFF
--- a/Common/src/main/java/mezz/jei/common/util/IngredientTooltipHelper.java
+++ b/Common/src/main/java/mezz/jei/common/util/IngredientTooltipHelper.java
@@ -20,6 +20,7 @@ public class IngredientTooltipHelper {
 		try {
 			Minecraft minecraft = Minecraft.getInstance();
 			TooltipFlag.Default tooltipFlag = minecraft.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL;
+			tooltipFlag = tooltipFlag.asCreative();
 			List<Component> tooltip = ingredientRenderer.getTooltip(ingredient, tooltipFlag);
 			return new ArrayList<>(tooltip);
 		} catch (RuntimeException | LinkageError e) {

--- a/Fabric/src/main/java/mezz/jei/fabric/platform/ItemStackHelper.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/platform/ItemStackHelper.java
@@ -35,7 +35,7 @@ public class ItemStackHelper implements IPlatformItemStackHelper {
     @Override
     public List<Component> getTestTooltip(@Nullable Player player, ItemStack itemStack) {
         try {
-            return itemStack.getTooltipLines(player, TooltipFlag.Default.NORMAL);
+            return itemStack.getTooltipLines(player, TooltipFlag.Default.NORMAL.asCreative());
         } catch (LinkageError | RuntimeException e) {
             LOGGER.error("Error while Testing for mod name formatting", e);
         }

--- a/Forge/src/main/java/mezz/jei/forge/platform/ItemStackHelper.java
+++ b/Forge/src/main/java/mezz/jei/forge/platform/ItemStackHelper.java
@@ -50,7 +50,7 @@ public class ItemStackHelper implements IPlatformItemStackHelper {
         try {
             List<Component> tooltip = new ArrayList<>();
             tooltip.add(Component.literal("JEI Tooltip Testing for mod name formatting"));
-            ItemTooltipEvent tooltipEvent = ForgeEventFactory.onItemTooltip(itemStack, player, tooltip, TooltipFlag.Default.NORMAL);
+            ItemTooltipEvent tooltipEvent = ForgeEventFactory.onItemTooltip(itemStack, player, tooltip, TooltipFlag.Default.NORMAL.asCreative());
             return tooltipEvent.getToolTip();
         } catch (LinkageError | RuntimeException e) {
             LOGGER.error("Error while Testing for mod name formatting", e);

--- a/Forge/src/test/java/mezz/jei/test/IngredientFilterTest.java
+++ b/Forge/src/test/java/mezz/jei/test/IngredientFilterTest.java
@@ -180,7 +180,7 @@ public class IngredientFilterTest {
 	}
 
 	public static List<String> getTooltipStrings(IIngredientRenderer<TestIngredient> ingredientRenderer, TestIngredient testIngredient) {
-		List<Component> tooltip = ingredientRenderer.getTooltip(testIngredient, TooltipFlag.Default.NORMAL);
+		List<Component> tooltip = ingredientRenderer.getTooltip(testIngredient, TooltipFlag.Default.NORMAL.asCreative());
 		return tooltip.stream()
 			.map(Component::getString)
 			.map(Translator::toLowercaseWithLocale)

--- a/Gui/src/main/java/mezz/jei/gui/ingredients/IngredientInformationUtil.java
+++ b/Gui/src/main/java/mezz/jei/gui/ingredients/IngredientInformationUtil.java
@@ -25,6 +25,7 @@ public final class IngredientInformationUtil {
 	@Unmodifiable
 	public static <T> List<String> getTooltipStrings(T ingredient, IIngredientRenderer<T> ingredientRenderer, Set<String> toRemove, IIngredientFilterConfig config) {
 		TooltipFlag.Default tooltipFlag = config.getSearchAdvancedTooltips() ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL;
+		tooltipFlag = tooltipFlag.asCreative();
 		List<Component> tooltip = ingredientRenderer.getTooltip(ingredient, tooltipFlag);
 		return tooltip.stream()
 			.map(Component::getString)


### PR DESCRIPTION
As of 1.19.3, a new type of TooltipFlag was added on to the pre-existing NORMAL and ADVANCED ones, gotten by using `TooltipFlag.Default#asCreative()` on either of these flags. This is used in the Creative menu as a way of having additional tooltip information for items displayed in tabs and not in the player's inventory.

This PR applies the change made to Creative menu tooltips to JEI's menus as well, due to the similar case of item display, which can be useful for mods that use this new way of determining what to display in a tooltip to have additional information tied to an item outside of the inventory.

![2023-01-25_19 58 26](https://user-images.githubusercontent.com/67203206/214756574-464485ee-866b-4242-80ef-804bc72fec3d.png)
![2023-01-25_19 58 37](https://user-images.githubusercontent.com/67203206/214756578-d780b2d8-0c7a-45a5-b62e-326e852f2474.png)
