### PR TITLE
Add a 1.19 config for the position of new bookmarks

### DIFF
--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -137,7 +137,7 @@
   "config.jei.advanced.giveMode": "Give Mode",
   "config.jei.advanced.giveMode.comment": "Choose if JEI should give ingredients direct to the inventory (inventory) or pick them up with the mouse (mouse_pickup).",
   "config.jei.advanced.addBookmarksToFront": "Prepend New Bookmarks",
-  "config.jei.advanced.addBookmarksToFront.comment": "When enabled, adds new bookmarks to the front of the bookmark list.",
+  "config.jei.advanced.addBookmarksToFront.comment": "When true, adds new bookmarks to the front of the bookmark list. When false, adds new bookmarks to the end of the bookmark list",
 
   "_comment": "Hide Ingredients Mode",
   "gui.jei.editMode.description": "JEI Hide Ingredients Mode:",

--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -136,6 +136,8 @@
   "config.jei.advanced.maxRecipeGuiHeight.comment": "The maximum height of the recipe GUI.",
   "config.jei.advanced.giveMode": "Give Mode",
   "config.jei.advanced.giveMode.comment": "Choose if JEI should give ingredients direct to the inventory (inventory) or pick them up with the mouse (mouse_pickup).",
+  "config.jei.advanced.addBookmarksToFront": "Prepend New Bookmarks",
+  "config.jei.advanced.addBookmarksToFront.comment": "When enabled, adds new bookmarks to the front of the bookmark list.",
 
   "_comment": "Hide Ingredients Mode",
   "gui.jei.editMode.description": "JEI Hide Ingredients Mode:",

--- a/Forge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
+++ b/Forge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
@@ -29,6 +29,11 @@ public class TestClientConfig implements IClientConfig {
 	}
 
 	@Override
+	public boolean isAddingBookmarksToFront() {
+		return false;
+	}
+
+	@Override
 	public GiveMode getGiveMode() {
 		return GiveMode.INVENTORY;
 	}

--- a/Gui/src/main/java/mezz/jei/gui/bookmarks/BookmarkList.java
+++ b/Gui/src/main/java/mezz/jei/gui/bookmarks/BookmarkList.java
@@ -5,6 +5,7 @@ import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.gui.config.IBookmarkConfig;
+import mezz.jei.gui.config.IClientConfig;
 import mezz.jei.gui.overlay.IIngredientGridSource;
 import net.minecraft.world.item.ItemStack;
 
@@ -17,18 +18,20 @@ public class BookmarkList implements IIngredientGridSource {
 	private final List<ITypedIngredient<?>> list = new LinkedList<>();
 	private final IIngredientManager ingredientManager;
 	private final IBookmarkConfig bookmarkConfig;
+	private final IClientConfig clientConfig;
 	private final List<SourceListChangedListener> listeners = new ArrayList<>();
 
-	public BookmarkList(IIngredientManager ingredientManager, IBookmarkConfig bookmarkConfig) {
+	public BookmarkList(IIngredientManager ingredientManager, IBookmarkConfig bookmarkConfig, IClientConfig clientConfig) {
 		this.ingredientManager = ingredientManager;
 		this.bookmarkConfig = bookmarkConfig;
+		this.clientConfig = clientConfig;
 	}
 
 	public <T> boolean add(ITypedIngredient<T> value) {
 		if (contains(value)) {
 			return false;
 		}
-		addToList(value, true);
+		addToList(value, clientConfig.isAddingBookmarksToFrontConfig());
 		notifyListenersOfChange();
 		bookmarkConfig.saveBookmarks(ingredientManager, list);
 		return true;

--- a/Gui/src/main/java/mezz/jei/gui/bookmarks/BookmarkList.java
+++ b/Gui/src/main/java/mezz/jei/gui/bookmarks/BookmarkList.java
@@ -31,7 +31,7 @@ public class BookmarkList implements IIngredientGridSource {
 		if (contains(value)) {
 			return false;
 		}
-		addToList(value, clientConfig.isAddingBookmarksToFrontConfig());
+		addToList(value, clientConfig.isAddingBookmarksToFront());
 		notifyListenersOfChange();
 		bookmarkConfig.saveBookmarks(ingredientManager, list);
 		return true;

--- a/Gui/src/main/java/mezz/jei/gui/config/ClientConfig.java
+++ b/Gui/src/main/java/mezz/jei/gui/config/ClientConfig.java
@@ -19,6 +19,7 @@ public final class ClientConfig implements IClientConfig {
 	private final Supplier<Boolean> centerSearchBarEnabled;
 	private final Supplier<Boolean> lowMemorySlowSearchEnabled;
 	private final Supplier<Boolean> cheatToHotbarUsingHotkeysEnabled;
+	private final Supplier<Boolean> addBookmarksToFront;
 	private final Supplier<GiveMode> giveMode;
 	private final Supplier<Integer> maxRecipeGuiHeight;
 	private final Supplier<List<IngredientSortStage>> ingredientSorterStages;
@@ -41,6 +42,11 @@ public final class ClientConfig implements IClientConfig {
 			"CheatToHotbarUsingHotkeysEnabled",
 			false,
 			"Enable cheating items into the hotbar by using the shift+number keys."
+		);
+		addBookmarksToFront = advanced.addBoolean(
+			"AddBookmarksToFrontEnabled",
+			false,
+			"Enable adding new bookmarks to the front of the bookmark list."
 		);
 		giveMode = advanced.addEnum(
 			"GiveMode",
@@ -86,6 +92,11 @@ public final class ClientConfig implements IClientConfig {
 	@Override
 	public boolean isCheatToHotbarUsingHotkeysEnabled() {
 		return cheatToHotbarUsingHotkeysEnabled.get();
+	}
+
+	@Override
+	public boolean isAddingBookmarksToFront() {
+		return addBookmarksToFront.get();
 	}
 
 	@Override

--- a/Gui/src/main/java/mezz/jei/gui/config/ClientConfig.java
+++ b/Gui/src/main/java/mezz/jei/gui/config/ClientConfig.java
@@ -45,7 +45,7 @@ public final class ClientConfig implements IClientConfig {
 		);
 		addBookmarksToFront = advanced.addBoolean(
 			"AddBookmarksToFrontEnabled",
-			false,
+			true,
 			"Enable adding new bookmarks to the front of the bookmark list."
 		);
 		giveMode = advanced.addEnum(

--- a/Gui/src/main/java/mezz/jei/gui/config/IClientConfig.java
+++ b/Gui/src/main/java/mezz/jei/gui/config/IClientConfig.java
@@ -16,6 +16,8 @@ public interface IClientConfig {
 
 	boolean isCheatToHotbarUsingHotkeysEnabled();
 
+    boolean isAddingBookmarksToFront();
+
 	GiveMode getGiveMode();
 
 	int getMaxRecipeGuiHeight();

--- a/Gui/src/main/java/mezz/jei/gui/config/IClientConfig.java
+++ b/Gui/src/main/java/mezz/jei/gui/config/IClientConfig.java
@@ -16,7 +16,7 @@ public interface IClientConfig {
 
 	boolean isCheatToHotbarUsingHotkeysEnabled();
 
-    boolean isAddingBookmarksToFront();
+	boolean isAddingBookmarksToFront();
 
 	GiveMode getGiveMode();
 

--- a/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
+++ b/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
@@ -142,7 +142,7 @@ public class JeiGuiStarter {
         );
         registration.setIngredientListOverlay(ingredientListOverlay);
 
-        BookmarkList bookmarkList = new BookmarkList(ingredientManager, bookmarkConfig);
+        BookmarkList bookmarkList = new BookmarkList(ingredientManager, bookmarkConfig, clientConfig);
         bookmarkConfig.loadBookmarks(ingredientManager, bookmarkList);
 
         BookmarkOverlay bookmarkOverlay = OverlayHelper.createBookmarkOverlay(


### PR DESCRIPTION
This PR adds a new (advanced) config option to control if a new bookmark is prepended or appended. This also changes the default behavior to append.

I dont know what the lang controls in-game, but I followed the pattern of the other lang entries.