### PR TITLE
Add a 1.12.2 config for the position of new bookmarks

### DIFF
--- a/src/main/java/mezz/jei/bookmarks/BookmarkList.java
+++ b/src/main/java/mezz/jei/bookmarks/BookmarkList.java
@@ -46,7 +46,7 @@ public class BookmarkList implements IIngredientGridSource {
 	public <T> boolean add(T ingredient) {
 		Object normalized = normalize(ingredient);
 		if (!contains(normalized)) {
-			if (addToLists(normalized, true)) {
+			if (addToLists(normalized, Config.isAddingBookmarksToFront())) {
 				notifyListenersOfChange();
 				saveBookmarks();
 				return true;

--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -183,6 +183,10 @@ public final class Config {
 		return values.optimizeMemoryUsage;
 	}
 
+	public static boolean isAddingBookmarksToFront() {
+		return values.addBookmarksToFront;
+	}
+
 	public static GiveMode getGiveMode() {
 		return values.giveMode;
 	}
@@ -404,6 +408,8 @@ public final class Config {
 		values.centerSearchBarEnabled = config.getBoolean(CATEGORY_ADVANCED, "centerSearchBarEnabled", defaultValues.centerSearchBarEnabled);
 
 		values.optimizeMemoryUsage = config.getBoolean(CATEGORY_ADVANCED, "optimizeMemoryUsage", defaultValues.optimizeMemoryUsage);
+
+		values.addBookmarksToFront = config.getBoolean(CATEGORY_ADVANCED, "addBookmarksToFront", defaultValues.addBookmarksToFront);
 
 		values.giveMode = config.getEnum("giveMode", CATEGORY_ADVANCED, defaultValues.giveMode, GiveMode.values());
 

--- a/src/main/java/mezz/jei/config/ConfigValues.java
+++ b/src/main/java/mezz/jei/config/ConfigValues.java
@@ -7,6 +7,7 @@ public class ConfigValues {
 	public boolean debugModeEnabled = false;
 	public boolean centerSearchBarEnabled = false;
 	public boolean optimizeMemoryUsage = true;
+	public boolean addBookmarksToFront = false;
 	public GiveMode giveMode = GiveMode.MOUSE_PICKUP;
 	public String modNameFormat = Config.parseFriendlyModNameFormat(Config.defaultModNameFormatFriendly);
 	public int maxColumns = 100;

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -103,6 +103,8 @@ config.jei.advanced.giveMode=Give Mode
 config.jei.advanced.giveMode.comment=Choose if JEI should give ingredients direct to the inventory (inventory) or pick them up with the mouse (mouse_pickup).
 config.jei.advanced.optimizeMemoryUsage=Optimize Memory Usage
 config.jei.advanced.optimizeMemoryUsage.comment=Enable JEI memory usage optimizations.
+config.jei.advanced.addBookmarksToFront=Prepend New Bookmarks
+config.jei.advanced.addBookmarksToFront.comment=When enabled, adds new bookmarks to the front of the bookmark list
 
 # Hide Ingredients Mode
 gui.jei.editMode.description=JEI Hide Ingredients Mode:

--- a/src/main/resources/assets/jei/lang/en_us.lang
+++ b/src/main/resources/assets/jei/lang/en_us.lang
@@ -104,7 +104,7 @@ config.jei.advanced.giveMode.comment=Choose if JEI should give ingredients direc
 config.jei.advanced.optimizeMemoryUsage=Optimize Memory Usage
 config.jei.advanced.optimizeMemoryUsage.comment=Enable JEI memory usage optimizations.
 config.jei.advanced.addBookmarksToFront=Prepend New Bookmarks
-config.jei.advanced.addBookmarksToFront.comment=When enabled, adds new bookmarks to the front of the bookmark list
+config.jei.advanced.addBookmarksToFront.comment=When true, adds new bookmarks to the front of the bookmark list. When false, adds new bookmarks to the end of the bookmark list.
 
 # Hide Ingredients Mode
 gui.jei.editMode.description=JEI Hide Ingredients Mode:


### PR DESCRIPTION
This PR adds a new (advanced) config option to control if a new bookmark is prepended or appended. This also changes the default behavior to append.

this idea was first contributed to a similar project here: https://github.com/CleanroomMC/HadEnoughItems/pull/14