### PR TITLE
Move the 1.12.2 bookmark location out of the config folder

### DIFF
--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -303,11 +303,24 @@ public final class Config {
 			}
 		}
 
+		bookmarkFile = new File("./", "jei_bookmarks.ini");
+		File oldBookmarkFile = new File(jeiConfigurationDir, "bookmarks.ini");
+		if (!bookmarkFile.exists() && oldBookmarkFile.exists()) {
+			try {
+				if (!oldBookmarkFile.renameTo(bookmarkFile)) {
+					Log.get().error("Could not move the old bookmark file from {} to {}", jeiConfigurationDir, "./");
+					return;
+				}
+			} catch (SecurityException e) {
+				Log.get().error("Could not move the old bookmark file from {} to {}", jeiConfigurationDir, "./", e);
+				return;
+			}
+		}
+
 		final File configFile = new File(jeiConfigurationDir, "jei.cfg");
 		final File itemBlacklistConfigFile = new File(jeiConfigurationDir, "itemBlacklist.cfg");
 		final File searchColorsConfigFile = new File(jeiConfigurationDir, "searchColors.cfg");
 		final File worldConfigFile = new File(jeiConfigurationDir, "worldSettings.cfg");
-		bookmarkFile = new File(jeiConfigurationDir, "bookmarks.ini");
 		worldConfig = new Configuration(worldConfigFile, "0.1.0");
 		config = new LocalizedConfiguration(configKeyPrefix, configFile, "0.4.0");
 		itemBlacklistConfig = new LocalizedConfiguration(configKeyPrefix, itemBlacklistConfigFile, "0.1.0");

--- a/src/main/java/mezz/jei/config/Config.java
+++ b/src/main/java/mezz/jei/config/Config.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigCategory;
@@ -303,7 +304,8 @@ public final class Config {
 			}
 		}
 
-		bookmarkFile = new File("./", "jei_bookmarks.ini");
+		File minecraftDir = new File(Loader.instance().getConfigDir().getParent());
+		bookmarkFile = new File(minecraftDir, "jei_bookmarks.ini");
 		File oldBookmarkFile = new File(jeiConfigurationDir, "bookmarks.ini");
 		if (!bookmarkFile.exists() && oldBookmarkFile.exists()) {
 			try {


### PR DESCRIPTION
something like this was suggested in #1564, but was settled via having bookmarks be per-world. Since 1.12.2 has settled on configs being per-instance, having it be directly in the instance folder (akin to journeymap) is a reasonable solution.
to make sure its purpose is understood, it was also renamed from `bookmarks.ini` to `jei_bookmarks.ini`.

this idea was first contributed to a similar project here: https://github.com/CleanroomMC/HadEnoughItems/pull/12