### PR TITLE
[1.19.4] Add option for asynchronous JEI reloading

### DIFF
--- a/Common/src/main/java/mezz/jei/common/async/JeiAsyncStartInterrupt.java
+++ b/Common/src/main/java/mezz/jei/common/async/JeiAsyncStartInterrupt.java
@@ -1,0 +1,6 @@
+package mezz.jei.common.async;
+
+final class JeiAsyncStartInterrupt extends Error {
+    public JeiAsyncStartInterrupt() {
+    }
+}

--- a/Common/src/main/java/mezz/jei/common/async/JeiStartTask.java
+++ b/Common/src/main/java/mezz/jei/common/async/JeiStartTask.java
@@ -1,0 +1,46 @@
+package mezz.jei.common.async;
+
+public class JeiStartTask extends Thread {
+    private final Runnable startTask;
+    private boolean isCancelled = false;
+
+    public JeiStartTask(Runnable startTask) {
+        this.startTask = startTask;
+        this.setName("JEI Start");
+    }
+
+    public void interruptStart() {
+        isCancelled = true;
+    }
+
+    /**
+     * Check whether the startup should be interrupted. If this is not running on a JEI startup thread,
+     * false is returned.
+     */
+    private static boolean isStartInterrupted() {
+        Thread t = Thread.currentThread();
+        if(t instanceof JeiStartTask) {
+            return ((JeiStartTask)t).isCancelled;
+        } else
+            return false;
+    }
+
+    private static final JeiAsyncStartInterrupt INTERRUPT_START = new JeiAsyncStartInterrupt();
+
+    public static void checkStartInterruption() {
+        if(isStartInterrupted())
+            forceInterrupt();
+    }
+
+    public static void forceInterrupt() {
+        throw INTERRUPT_START;
+    }
+
+    @Override
+    public void run() {
+        try {
+            startTask.run();
+        } catch(JeiAsyncStartInterrupt ignored) {
+        }
+    }
+}

--- a/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
@@ -5,6 +5,7 @@ import mezz.jei.common.config.file.IConfigCategoryBuilder;
 import mezz.jei.common.config.file.IConfigSchemaBuilder;
 import mezz.jei.common.config.file.serializers.EnumSerializer;
 import mezz.jei.common.config.file.serializers.ListSerializer;
+import mezz.jei.common.config.file.serializers.StringSerializer;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public final class ClientConfig implements IClientConfig {
 	private final Supplier<Boolean> lowMemorySlowSearchEnabled;
 	private final Supplier<Boolean> cheatToHotbarUsingHotkeysEnabled;
 	private final Supplier<Boolean> asyncLoadingEnabled;
+	private final Supplier<List<String>> mainThreadPluginUids;
 	private final Supplier<Boolean> addBookmarksToFront;
 	private final Supplier<GiveMode> giveMode;
 	private final Supplier<Integer> maxRecipeGuiHeight;
@@ -64,6 +66,11 @@ public final class ClientConfig implements IClientConfig {
 				false,
 				"Whether JEI should load asynchronously"
 		);
+		mainThreadPluginUids = advanced.addList("AsyncPluginCompat",
+				List.of("namespace:mod"),
+				new ListSerializer<>(new StringSerializer()),
+				"List of plugin UIDs that should be loaded on the main thread"
+		);
 
 		IConfigCategoryBuilder sorting = schema.addCategory("sorting");
 		ingredientSorterStages = sorting.addList(
@@ -101,6 +108,11 @@ public final class ClientConfig implements IClientConfig {
 	@Override
 	public boolean isAsyncLoadingEnabled() {
 		return asyncLoadingEnabled.get();
+	}
+
+	@Override
+	public List<String> getAsyncCompatPluginUids() {
+		return mainThreadPluginUids.get();
 	}
 
 	@Override

--- a/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
@@ -17,6 +17,7 @@ public final class ClientConfig implements IClientConfig {
 	private final Supplier<Boolean> centerSearchBarEnabled;
 	private final Supplier<Boolean> lowMemorySlowSearchEnabled;
 	private final Supplier<Boolean> cheatToHotbarUsingHotkeysEnabled;
+	private final Supplier<Boolean> asyncLoadingEnabled;
 	private final Supplier<Boolean> addBookmarksToFront;
 	private final Supplier<GiveMode> giveMode;
 	private final Supplier<Integer> maxRecipeGuiHeight;
@@ -58,6 +59,11 @@ public final class ClientConfig implements IClientConfig {
 			Integer.MAX_VALUE,
 			"Max. recipe gui height"
 		);
+		asyncLoadingEnabled = advanced.addBoolean(
+				"AsyncLoading",
+				false,
+				"Whether JEI should load asynchronously"
+		);
 
 		IConfigCategoryBuilder sorting = schema.addCategory("sorting");
 		ingredientSorterStages = sorting.addList(
@@ -90,6 +96,11 @@ public final class ClientConfig implements IClientConfig {
 	@Override
 	public boolean isCheatToHotbarUsingHotkeysEnabled() {
 		return cheatToHotbarUsingHotkeysEnabled.get();
+	}
+
+	@Override
+	public boolean isAsyncLoadingEnabled() {
+		return asyncLoadingEnabled.get();
 	}
 
 	@Override

--- a/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
@@ -13,6 +13,8 @@ public interface IClientConfig {
 
 	boolean isCheatToHotbarUsingHotkeysEnabled();
 
+	boolean isAsyncLoadingEnabled();
+
 	boolean isAddingBookmarksToFront();
 
 	GiveMode getGiveMode();

--- a/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
@@ -14,6 +14,7 @@ public interface IClientConfig {
 	boolean isCheatToHotbarUsingHotkeysEnabled();
 
 	boolean isAsyncLoadingEnabled();
+	List<String> getAsyncCompatPluginUids();
 
 	boolean isAddingBookmarksToFront();
 

--- a/Common/src/main/java/mezz/jei/common/config/file/serializers/StringSerializer.java
+++ b/Common/src/main/java/mezz/jei/common/config/file/serializers/StringSerializer.java
@@ -1,0 +1,37 @@
+package mezz.jei.common.config.file.serializers;
+
+import mezz.jei.api.runtime.config.IJeiConfigValueSerializer;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public class StringSerializer implements IJeiConfigValueSerializer<String> {
+    @Override
+    public String serialize(String value) {
+        return value;
+    }
+
+    @Override
+    public IDeserializeResult<String> deserialize(String string) {
+        string = string.trim();
+        if (string.startsWith("\"") && string.endsWith("\"")) {
+            string = string.substring(1, string.length() - 1);
+        };
+        return new DeserializeResult<>(string);
+    }
+
+    @Override
+    public boolean isValid(String value) {
+        return true;
+    }
+
+    @Override
+    public Optional<Collection<String>> getAllValidValues() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String getValidValuesDescription() {
+        return "";
+    }
+}

--- a/CommonApi/src/main/java/mezz/jei/api/IModPlugin.java
+++ b/CommonApi/src/main/java/mezz/jei/api/IModPlugin.java
@@ -16,6 +16,8 @@ import mezz.jei.api.registration.ISubtypeRegistration;
 import mezz.jei.api.registration.IVanillaCategoryExtensionRegistration;
 import mezz.jei.api.runtime.IJeiRuntime;
 
+import java.util.EnumSet;
+
 /**
  * The main class to implement to create a JEI plugin. Everything communicated between a mod and JEI is through this class.
  * IModPlugins must have the {@link JeiPlugin} annotation to get loaded by JEI.
@@ -136,5 +138,17 @@ public interface IModPlugin {
 	 */
 	default void onConfigManagerAvailable(IJeiConfigManager configManager) {
 
+	}
+
+	/**
+	 * Called to find out whether this plugin wants to load on the main thread (legacy behavior), instead of the async
+	 * loading thread.
+	 * <p></p>
+	 * Most plugins should use Minecraft.getInstance().executeBlocking() for their purposes, as plugins loading on the
+	 * main thread will cause lag spikes.
+	 * @since TODO
+	 */
+	default boolean needsLoadingOnClientThread() {
+		return false;
 	}
 }

--- a/CommonApi/src/main/java/mezz/jei/api/helpers/IJeiHelpers.java
+++ b/CommonApi/src/main/java/mezz/jei/api/helpers/IJeiHelpers.java
@@ -7,6 +7,7 @@ import mezz.jei.api.runtime.IIngredientManager;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.Optional;
+import java.util.concurrent.Executor;
 
 /**
  * {@link IJeiHelpers} provides helpers and tools for addon mods.
@@ -67,4 +68,9 @@ public interface IJeiHelpers {
 	 * @since 11.5.0
 	 */
 	IIngredientManager getIngredientManager();
+
+	/**
+	 * Get access to the client executor, which budgets running background tasks on the main thread.
+	 */
+	Executor getClientExecutor();
 }

--- a/CommonApi/src/main/java/mezz/jei/api/registration/IRuntimeRegistration.java
+++ b/CommonApi/src/main/java/mezz/jei/api/registration/IRuntimeRegistration.java
@@ -12,8 +12,6 @@ import mezz.jei.api.runtime.IIngredientVisibility;
 import mezz.jei.api.runtime.IRecipesGui;
 import mezz.jei.api.runtime.IScreenHelper;
 
-import java.util.concurrent.Executor;
-
 /**
  * Allows mods to override the runtime classes for JEI with their own implementation.
  *
@@ -90,9 +88,4 @@ public interface IRuntimeRegistration {
      * This is used by JEI's GUI and can be used by other mods that want to use the same information from JEI.
      */
     IEditModeConfig getEditModeConfig();
-
-    /**
-     * Get access to the client executor, which budgets. running background tasks on the main thread
-     */
-    Executor getClientExecutor();
 }

--- a/CommonApi/src/main/java/mezz/jei/api/registration/IRuntimeRegistration.java
+++ b/CommonApi/src/main/java/mezz/jei/api/registration/IRuntimeRegistration.java
@@ -12,6 +12,8 @@ import mezz.jei.api.runtime.IIngredientVisibility;
 import mezz.jei.api.runtime.IRecipesGui;
 import mezz.jei.api.runtime.IScreenHelper;
 
+import java.util.concurrent.Executor;
+
 /**
  * Allows mods to override the runtime classes for JEI with their own implementation.
  *
@@ -88,4 +90,9 @@ public interface IRuntimeRegistration {
      * This is used by JEI's GUI and can be used by other mods that want to use the same information from JEI.
      */
     IEditModeConfig getEditModeConfig();
+
+    /**
+     * Get access to the client executor, which budgets. running background tasks on the main thread
+     */
+    Executor getClientExecutor();
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/events/JeiLifecycleEvents.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/events/JeiLifecycleEvents.java
@@ -36,6 +36,14 @@ public class JeiLifecycleEvents {
                 }
             });
 
+    public static final Event<Runnable> CLIENT_TICK_END =
+            EventFactory.createArrayBacked(Runnable.class, callbacks -> () -> {
+                for (Runnable callback : callbacks) {
+                    callback.run();
+                }
+            });
+
+
     @Environment(EnvType.CLIENT)
     @FunctionalInterface
     public interface RegisterResourceReloadListener {

--- a/Fabric/src/main/java/mezz/jei/fabric/mixin/MinecraftMixin.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/mixin/MinecraftMixin.java
@@ -48,4 +48,11 @@ public class MinecraftMixin {
     public void clearLevel(Screen screen, CallbackInfo ci) {
         JeiLifecycleEvents.GAME_STOP.invoker().run();
     }
+    @Inject(
+        method = "tick",
+        at = @At("TAIL")
+    )
+    private void jeiOnTickEnd(CallbackInfo ci) {
+        JeiLifecycleEvents.CLIENT_TICK_END.invoker().run();
+    }
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/startup/ClientLifecycleHandler.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/startup/ClientLifecycleHandler.java
@@ -54,6 +54,7 @@ public class ClientLifecycleHandler {
 			})
 		);
 		JeiLifecycleEvents.GAME_STOP.register(this::stopJei);
+		JeiLifecycleEvents.CLIENT_TICK_END.register(this.jeiStarter::tick);
 	}
 
 	public ResourceManagerReloadListener getReloadListener() {

--- a/Forge/src/main/java/mezz/jei/forge/JustEnoughItemsClient.java
+++ b/Forge/src/main/java/mezz/jei/forge/JustEnoughItemsClient.java
@@ -50,7 +50,7 @@ public class JustEnoughItemsClient {
 
 		JeiStarter jeiStarter = new JeiStarter(startData);
 
-		this.startEventObserver = new StartEventObserver(jeiStarter::start, jeiStarter::stop);
+		this.startEventObserver = new StartEventObserver(jeiStarter::start, jeiStarter::stop, jeiStarter::tick);
 		this.startEventObserver.register(subscriptions);
 	}
 

--- a/Forge/src/main/java/mezz/jei/forge/startup/StartEventObserver.java
+++ b/Forge/src/main/java/mezz/jei/forge/startup/StartEventObserver.java
@@ -10,6 +10,7 @@ import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.RecipesUpdatedEvent;
 import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.event.TagsUpdatedEvent;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.Event;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,11 +38,13 @@ public class StartEventObserver implements ResourceManagerReloadListener {
 	private final Set<Class<? extends Event>> observedEvents = new HashSet<>();
 	private final Runnable startRunnable;
 	private final Runnable stopRunnable;
+	private final Runnable tickRunnable;
 	private State state = State.DISABLED;
 
-	public StartEventObserver(Runnable startRunnable, Runnable stopRunnable) {
+	public StartEventObserver(Runnable startRunnable, Runnable stopRunnable, Runnable tickRunnable) {
 		this.startRunnable = startRunnable;
 		this.stopRunnable = stopRunnable;
+		this.tickRunnable = tickRunnable;
 	}
 
 	public void register(PermanentEventSubscriptions subscriptions) {
@@ -77,6 +80,12 @@ public class StartEventObserver implements ResourceManagerReloadListener {
 					transitionState(State.ENABLED);
 					transitionState(State.JEI_STARTED);
 				}
+			}
+		});
+
+		subscriptions.register(TickEvent.ClientTickEvent.class, event -> {
+			if(event.phase == TickEvent.Phase.END && this.state == State.JEI_STARTED) {
+				this.tickRunnable.run();
 			}
 		});
 	}

--- a/Forge/src/test/java/mezz/jei/test/IngredientFilterTest.java
+++ b/Forge/src/test/java/mezz/jei/test/IngredientFilterTest.java
@@ -1,5 +1,6 @@
 package mezz.jei.test;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import mezz.jei.api.helpers.IColorHelper;
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.ingredients.IIngredientRenderer;
@@ -95,7 +96,8 @@ public class IngredientFilterTest {
 			baseList,
 			modIdHelper,
 			ingredientVisibility,
-			colorHelper
+			colorHelper,
+			MoreExecutors.directExecutor()
 		);
 
 		this.ingredientManager.registerIngredientListener(ingredientFilter);

--- a/Gui/src/main/java/mezz/jei/gui/ingredients/IListElementInfo.java
+++ b/Gui/src/main/java/mezz/jei/gui/ingredients/IListElementInfo.java
@@ -3,6 +3,8 @@ package mezz.jei.gui.ingredients;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 
 import mezz.jei.api.ingredients.ITypedIngredient;
@@ -37,5 +39,7 @@ public interface IListElementInfo<V> {
 	void setSortedIndex(int sortIndex);
 
 	int getSortedIndex();
+
+	CompletableFuture<Void> cacheTooltips(IIngredientFilterConfig config, IIngredientManager ingredientManager, Executor clientExecutor);
 
 }

--- a/Gui/src/main/java/mezz/jei/gui/ingredients/IngredientFilter.java
+++ b/Gui/src/main/java/mezz/jei/gui/ingredients/IngredientFilter.java
@@ -8,6 +8,7 @@ import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.api.runtime.IIngredientVisibility;
+import mezz.jei.common.async.JeiStartTask;
 import mezz.jei.common.config.DebugConfig;
 import mezz.jei.common.util.Translator;
 import mezz.jei.common.config.IClientConfig;
@@ -95,7 +96,12 @@ public class IngredientFilter implements IIngredientGridSource, IIngredientManag
 		});
 	}
 
+	/* used to check for interruption periodically */
+	private int ingredientNum = 0;
+
 	public <V> void addIngredient(IListElementInfo<V> info) {
+		if(((ingredientNum++) % 100) == 0)
+			JeiStartTask.checkStartInterruption();
 		IListElement<V> element = info.getElement();
 		updateHiddenState(element);
 

--- a/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
+++ b/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
@@ -114,7 +114,8 @@ public class JeiGuiStarter {
             ingredientList,
             modIdHelper,
             ingredientVisibility,
-            colorHelper
+            colorHelper,
+            registration.getClientExecutor()
         );
         ingredientManager.registerIngredientListener(ingredientFilter);
         ingredientVisibility.registerListener(ingredientFilter::onIngredientVisibilityChanged);

--- a/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
+++ b/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
@@ -115,7 +115,7 @@ public class JeiGuiStarter {
             modIdHelper,
             ingredientVisibility,
             colorHelper,
-            registration.getClientExecutor()
+            jeiHelpers.getClientExecutor()
         );
         ingredientManager.registerIngredientListener(ingredientFilter);
         ingredientVisibility.registerListener(ingredientFilter::onIngredientVisibilityChanged);

--- a/Library/src/main/java/mezz/jei/library/load/PluginCaller.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginCaller.java
@@ -2,6 +2,7 @@ package mezz.jei.library.load;
 
 import com.google.common.base.Stopwatch;
 import mezz.jei.api.IModPlugin;
+import mezz.jei.common.async.JeiStartTask;
 import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,6 +22,7 @@ public class PluginCaller {
 			List<IModPlugin> erroredPlugins = new ArrayList<>();
 
 			for (IModPlugin plugin : plugins) {
+				JeiStartTask.checkStartInterruption();
 				try {
 					ResourceLocation pluginUid = plugin.getPluginUid();
 					timer.begin(title, pluginUid);

--- a/Library/src/main/java/mezz/jei/library/load/PluginCaller.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginCaller.java
@@ -2,13 +2,19 @@ package mezz.jei.library.load;
 
 import com.google.common.base.Stopwatch;
 import mezz.jei.api.IModPlugin;
+import mezz.jei.common.Internal;
 import mezz.jei.common.async.JeiStartTask;
+import mezz.jei.library.startup.JeiStarter;
+import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 public class PluginCaller {
@@ -26,7 +32,10 @@ public class PluginCaller {
 				try {
 					ResourceLocation pluginUid = plugin.getPluginUid();
 					timer.begin(title, pluginUid);
-					func.accept(plugin);
+					if(plugin.needsLoadingOnClientThread() || isLegacyPlugin(plugin.getPluginUid())) {
+						Minecraft.getInstance().executeBlocking(() -> func.accept(plugin));
+					} else
+						func.accept(plugin);
 					timer.end();
 				} catch (RuntimeException | LinkageError e) {
 					LOGGER.error("Caught an error from mod plugin: {} {}", plugin.getClass(), plugin.getPluginUid(), e);
@@ -37,5 +46,12 @@ public class PluginCaller {
 		}
 
 		LOGGER.info("{} took {}", title, stopwatch);
+	}
+
+	private static boolean isLegacyPlugin(ResourceLocation uid) {
+		String uidString = uid.toString();
+		// scales poorly if there are many plugins, but there shouldn't be as modders should support this mode
+		// in the worst case, this can be cached
+		return Internal.getJeiClientConfigs().getClientConfig().getAsyncCompatPluginUids().contains(uidString);
 	}
 }

--- a/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
@@ -51,6 +51,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 public class PluginLoader {
 	private final StartData data;
@@ -58,7 +59,7 @@ public class PluginLoader {
 	private final IIngredientManager ingredientManager;
 	private final JeiHelpers jeiHelpers;
 
-	public PluginLoader(StartData data, IModIdFormatConfig modIdFormatConfig, IColorHelper colorHelper) {
+	public PluginLoader(StartData data, IModIdFormatConfig modIdFormatConfig, IColorHelper colorHelper, Executor clientExecutor) {
 		this.data = data;
 		this.timer = new LoggedTimer();
 
@@ -80,7 +81,7 @@ public class PluginLoader {
 		GuiHelper guiHelper = new GuiHelper(ingredientManager);
 		FocusFactory focusFactory = new FocusFactory(ingredientManager);
 		IModIdHelper modIdHelper = new ModIdHelper(modIdFormatConfig, ingredientManager);
-		this.jeiHelpers = new JeiHelpers(guiHelper, stackHelper, modIdHelper, focusFactory, colorHelper, ingredientManager);
+		this.jeiHelpers = new JeiHelpers(guiHelper, stackHelper, modIdHelper, focusFactory, colorHelper, ingredientManager, clientExecutor);
 	}
 
 	@Unmodifiable

--- a/Library/src/main/java/mezz/jei/library/load/registration/RuntimeRegistration.java
+++ b/Library/src/main/java/mezz/jei/library/load/registration/RuntimeRegistration.java
@@ -17,6 +17,8 @@ import mezz.jei.library.gui.IngredientListOverlayDummy;
 import mezz.jei.library.gui.recipes.RecipesGuiDummy;
 import mezz.jei.library.ingredients.IngredientFilterApiDummy;
 
+import java.util.concurrent.Executor;
+
 public class RuntimeRegistration implements IRuntimeRegistration {
     private final IRecipeManager recipeManager;
     private final IJeiHelpers jeiHelpers;
@@ -25,6 +27,7 @@ public class RuntimeRegistration implements IRuntimeRegistration {
     private final IIngredientVisibility ingredientVisibility;
     private final IRecipeTransferManager recipeTransferManager;
     private final IScreenHelper screenHelper;
+    private final Executor clientExecutor;
 
     private IIngredientListOverlay ingredientListOverlay = IngredientListOverlayDummy.INSTANCE;
     private IBookmarkOverlay bookmarkOverlay = BookmarkOverlayDummy.INSTANCE;
@@ -38,7 +41,8 @@ public class RuntimeRegistration implements IRuntimeRegistration {
         IIngredientManager ingredientManager,
         IIngredientVisibility ingredientVisibility,
         IRecipeTransferManager recipeTransferManager,
-        IScreenHelper screenHelper
+        IScreenHelper screenHelper,
+        Executor clientExecutor
     ) {
         this.recipeManager = recipeManager;
         this.jeiHelpers = jeiHelpers;
@@ -47,6 +51,7 @@ public class RuntimeRegistration implements IRuntimeRegistration {
         this.ingredientVisibility = ingredientVisibility;
         this.recipeTransferManager = recipeTransferManager;
         this.screenHelper = screenHelper;
+        this.clientExecutor = clientExecutor;
     }
 
     @Override
@@ -118,5 +123,10 @@ public class RuntimeRegistration implements IRuntimeRegistration {
 
     public IIngredientFilter getIngredientFilter() {
         return this.ingredientFilter;
+    }
+
+    @Override
+    public Executor getClientExecutor() {
+        return this.clientExecutor;
     }
 }

--- a/Library/src/main/java/mezz/jei/library/load/registration/RuntimeRegistration.java
+++ b/Library/src/main/java/mezz/jei/library/load/registration/RuntimeRegistration.java
@@ -17,8 +17,6 @@ import mezz.jei.library.gui.IngredientListOverlayDummy;
 import mezz.jei.library.gui.recipes.RecipesGuiDummy;
 import mezz.jei.library.ingredients.IngredientFilterApiDummy;
 
-import java.util.concurrent.Executor;
-
 public class RuntimeRegistration implements IRuntimeRegistration {
     private final IRecipeManager recipeManager;
     private final IJeiHelpers jeiHelpers;
@@ -27,7 +25,6 @@ public class RuntimeRegistration implements IRuntimeRegistration {
     private final IIngredientVisibility ingredientVisibility;
     private final IRecipeTransferManager recipeTransferManager;
     private final IScreenHelper screenHelper;
-    private final Executor clientExecutor;
 
     private IIngredientListOverlay ingredientListOverlay = IngredientListOverlayDummy.INSTANCE;
     private IBookmarkOverlay bookmarkOverlay = BookmarkOverlayDummy.INSTANCE;
@@ -41,8 +38,7 @@ public class RuntimeRegistration implements IRuntimeRegistration {
         IIngredientManager ingredientManager,
         IIngredientVisibility ingredientVisibility,
         IRecipeTransferManager recipeTransferManager,
-        IScreenHelper screenHelper,
-        Executor clientExecutor
+        IScreenHelper screenHelper
     ) {
         this.recipeManager = recipeManager;
         this.jeiHelpers = jeiHelpers;
@@ -51,7 +47,6 @@ public class RuntimeRegistration implements IRuntimeRegistration {
         this.ingredientVisibility = ingredientVisibility;
         this.recipeTransferManager = recipeTransferManager;
         this.screenHelper = screenHelper;
-        this.clientExecutor = clientExecutor;
     }
 
     @Override
@@ -123,10 +118,5 @@ public class RuntimeRegistration implements IRuntimeRegistration {
 
     public IIngredientFilter getIngredientFilter() {
         return this.ingredientFilter;
-    }
-
-    @Override
-    public Executor getClientExecutor() {
-        return this.clientExecutor;
     }
 }

--- a/Library/src/main/java/mezz/jei/library/recipes/RecipeManagerInternal.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/RecipeManagerInternal.java
@@ -9,6 +9,7 @@ import mezz.jei.api.recipe.advanced.IRecipeManagerPlugin;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.api.runtime.IIngredientVisibility;
+import mezz.jei.common.async.JeiStartTask;
 import mezz.jei.common.util.ErrorUtil;
 import mezz.jei.library.config.RecipeCategorySortingConfig;
 import mezz.jei.library.ingredients.IIngredientSupplier;
@@ -116,6 +117,7 @@ public class RecipeManagerInternal {
 				if (ingredientSupplier == null) {
 					return false;
 				}
+				JeiStartTask.checkStartInterruption();
 				return addRecipe(recipeCategory, recipe, ingredientSupplier);
 			})
 			.toList();

--- a/Library/src/main/java/mezz/jei/library/runtime/JeiHelpers.java
+++ b/Library/src/main/java/mezz/jei/library/runtime/JeiHelpers.java
@@ -18,6 +18,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 
 public class JeiHelpers implements IJeiHelpers {
 	private final GuiHelper guiHelper;
@@ -27,6 +28,7 @@ public class JeiHelpers implements IJeiHelpers {
 	private final IColorHelper colorHelper;
 	private final IIngredientManager ingredientManager;
 	private final IPlatformFluidHelper<?> platformFluidHelper;
+	private final Executor clientExecutor;
 	private @Nullable Collection<IRecipeCategory<?>> recipeCategories;
 
 	public JeiHelpers(
@@ -35,7 +37,8 @@ public class JeiHelpers implements IJeiHelpers {
 		IModIdHelper modIdHelper,
 		IFocusFactory focusFactory,
 		IColorHelper colorHelper,
-		IIngredientManager ingredientManager
+		IIngredientManager ingredientManager,
+		Executor clientExecutor
 	) {
 		this.guiHelper = guiHelper;
 		this.stackHelper = stackHelper;
@@ -44,6 +47,7 @@ public class JeiHelpers implements IJeiHelpers {
 		this.colorHelper = colorHelper;
 		this.ingredientManager = ingredientManager;
 		this.platformFluidHelper = Services.PLATFORM.getFluidHelper();
+		this.clientExecutor = clientExecutor;
 	}
 
 	public void setRecipeCategories(Collection<IRecipeCategory<?>> recipeCategories) {
@@ -93,5 +97,10 @@ public class JeiHelpers implements IJeiHelpers {
 	@Override
 	public IIngredientManager getIngredientManager() {
 		return ingredientManager;
+	}
+
+	@Override
+	public Executor getClientExecutor() {
+		return clientExecutor;
 	}
 }

--- a/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
+++ b/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
@@ -179,7 +179,8 @@ public final class JeiStarter {
 			ingredientManager,
 			ingredientVisibility,
 			recipeTransferManager,
-			screenHelper
+			screenHelper,
+			taskExecutor
 		);
 		PluginCaller.callOnPlugins("Registering Runtime", plugins, p -> p.registerRuntime(runtimeRegistration));
 

--- a/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
+++ b/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
@@ -41,6 +41,7 @@ import mezz.jei.library.recipes.RecipeTransferManager;
 import mezz.jei.library.runtime.JeiHelpers;
 import mezz.jei.library.runtime.JeiRuntime;
 import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,6 +49,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;

--- a/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
+++ b/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
@@ -140,7 +140,7 @@ public final class JeiStarter {
 
 		IClientToggleState toggleState = Internal.getClientToggleState();
 
-		PluginLoader pluginLoader = new PluginLoader(data, modIdFormatConfig, colorHelper);
+		PluginLoader pluginLoader = new PluginLoader(data, modIdFormatConfig, colorHelper, taskExecutor);
 		JeiHelpers jeiHelpers = pluginLoader.getJeiHelpers();
 		IModIdHelper modIdHelper = jeiHelpers.getModIdHelper();
 
@@ -181,8 +181,7 @@ public final class JeiStarter {
 			ingredientManager,
 			ingredientVisibility,
 			recipeTransferManager,
-			screenHelper,
-			taskExecutor
+			screenHelper
 		);
 		PluginCaller.callOnPlugins("Registering Runtime", plugins, p -> p.registerRuntime(runtimeRegistration));
 

--- a/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
+++ b/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
@@ -235,7 +235,11 @@ public final class JeiStarter {
 
 		@Override
 		public void execute(@NotNull Runnable runnable) {
-			this.startTasks.add(runnable);
+			// sanity check, in case a task is submitted from the main thread to the main thread
+			if(Minecraft.getInstance().isSameThread())
+				runnable.run();
+			else
+				this.startTasks.add(runnable);
 		}
 	}
 


### PR DESCRIPTION
This PR introduces a new config option, `AsyncLoading` that enables JEI loading to take place on a background thread rather than delaying world load. The implementation is based on the patches I implemented in ModernFix for the 1.16 version of JEI.

The intent of this PR is not to be a complete or perfect implementation of async loading but rather to add the necessary framework for supporting this. It will be easier to review these architectural changes in pieces rather than one huge monolithic commit. The feature is disabled by default and thus should have no impact on regular users.