### PR TITLE
Add JeiHelpers access to VanillaCategoryExtension

### DIFF
--- a/CommonApi/src/main/java/mezz/jei/api/registration/IVanillaCategoryExtensionRegistration.java
+++ b/CommonApi/src/main/java/mezz/jei/api/registration/IVanillaCategoryExtensionRegistration.java
@@ -16,6 +16,8 @@ import mezz.jei.api.recipe.category.extensions.vanilla.crafting.ICraftingCategor
 public interface IVanillaCategoryExtensionRegistration {
 	/**
 	 * {@link IJeiHelpers} provides helpers and tools for addon mods.
+	 *
+	 * @since 12.4.0
 	 */
 	IJeiHelpers getJeiHelpers();
 	/**

--- a/CommonApi/src/main/java/mezz/jei/api/registration/IVanillaCategoryExtensionRegistration.java
+++ b/CommonApi/src/main/java/mezz/jei/api/registration/IVanillaCategoryExtensionRegistration.java
@@ -1,6 +1,7 @@
 package mezz.jei.api.registration;
 
 import mezz.jei.api.IModPlugin;
+import mezz.jei.api.helpers.IJeiHelpers;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 
 import mezz.jei.api.recipe.category.extensions.IExtendableRecipeCategory;
@@ -13,6 +14,10 @@ import mezz.jei.api.recipe.category.extensions.vanilla.crafting.ICraftingCategor
  * {@link IModPlugin#registerVanillaCategoryExtensions(IVanillaCategoryExtensionRegistration)}
  */
 public interface IVanillaCategoryExtensionRegistration {
+	/**
+	 * {@link IJeiHelpers} provides helpers and tools for addon mods.
+	 */
+	IJeiHelpers getJeiHelpers();
 	/**
 	 * Get the vanilla crafting category, to extend it with your own mod's crafting category extensions.
 	 */

--- a/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
@@ -89,7 +89,7 @@ public class PluginLoader {
 		PluginCaller.callOnPlugins("Registering categories", plugins, p -> p.registerCategories(recipeCategoryRegistration));
 		CraftingRecipeCategory craftingCategory = vanillaPlugin.getCraftingCategory()
 			.orElseThrow(() -> new NullPointerException("vanilla crafting category"));
-		VanillaCategoryExtensionRegistration vanillaCategoryExtensionRegistration = new VanillaCategoryExtensionRegistration(craftingCategory);
+		VanillaCategoryExtensionRegistration vanillaCategoryExtensionRegistration = new VanillaCategoryExtensionRegistration(craftingCategory, jeiHelpers);
 		PluginCaller.callOnPlugins("Registering vanilla category extensions", plugins, p -> p.registerVanillaCategoryExtensions(vanillaCategoryExtensionRegistration));
 		return recipeCategoryRegistration.getRecipeCategories();
 	}

--- a/Library/src/main/java/mezz/jei/library/load/registration/VanillaCategoryExtensionRegistration.java
+++ b/Library/src/main/java/mezz/jei/library/load/registration/VanillaCategoryExtensionRegistration.java
@@ -1,5 +1,7 @@
 package mezz.jei.library.load.registration;
 
+import mezz.jei.api.helpers.IJeiHelpers;
+import mezz.jei.library.runtime.JeiHelpers;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 
 import mezz.jei.api.recipe.category.extensions.IExtendableRecipeCategory;
@@ -8,13 +10,20 @@ import mezz.jei.api.registration.IVanillaCategoryExtensionRegistration;
 
 public class VanillaCategoryExtensionRegistration implements IVanillaCategoryExtensionRegistration {
 	private final IExtendableRecipeCategory<CraftingRecipe, ICraftingCategoryExtension> craftingCategory;
+	private final JeiHelpers jeiHelpers;
 
-	public VanillaCategoryExtensionRegistration(IExtendableRecipeCategory<CraftingRecipe, ICraftingCategoryExtension> craftingCategory) {
+	public VanillaCategoryExtensionRegistration(IExtendableRecipeCategory<CraftingRecipe, ICraftingCategoryExtension> craftingCategory, JeiHelpers jeiHelpers) {
 		this.craftingCategory = craftingCategory;
+		this.jeiHelpers = jeiHelpers;
 	}
 
 	@Override
 	public IExtendableRecipeCategory<CraftingRecipe, ICraftingCategoryExtension> getCraftingCategory() {
 		return craftingCategory;
+	}
+
+	@Override
+	public IJeiHelpers getJeiHelpers() {
+		return jeiHelpers;
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ curseHomepageUrl=https://www.curseforge.com/minecraft/mc-mods/jei
 jUnitVersion=5.8.2
 
 # Version
-specificationVersion=12.3.0
+specificationVersion=12.4.0
 
 # Workaround for Spotless bug
 # https://github.com/diffplug/spotless/issues/834


### PR DESCRIPTION
I made these changes because I would like to draw an item in the gui when using the `IVanillaCategoryExtensionRegistration` interface.
I have attached an example of how I would like to do the GUI.

![Screenshot 2023-03-20 alle 20 49 15](https://user-images.githubusercontent.com/25778604/226450360-5b42ea61-32ca-4831-ba76-3cd595eabbfd.png)
