### PR TITLE
Add ability to return IRecipeManagerPlugin to the IJeiRuntime

### DIFF
--- a/CommonApi/src/main/java/mezz/jei/api/runtime/IJeiRuntime.java
+++ b/CommonApi/src/main/java/mezz/jei/api/runtime/IJeiRuntime.java
@@ -1,10 +1,13 @@
 package mezz.jei.api.runtime;
 
+import javax.annotation.Nullable
+
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.recipe.IRecipeManager;
 import mezz.jei.api.recipe.transfer.IRecipeTransferManager;
 import mezz.jei.api.runtime.config.IJeiConfigManager;
+import mezz.jei.api.recipe.advanced.IRecipeManagerPlugin;
 
 /**
  * Gives access to JEI functions that are available once everything has loaded.
@@ -101,4 +104,14 @@ public interface IJeiRuntime {
 	 * @since 12.1.0
 	 */
 	IJeiConfigManager getConfigManager();
+
+        /**
+         * Returns the default JEI RecipeManagerPlugin
+         *
+         * @return returns null if you are not the default JEI runtime and don't have a IRecipeManagerPlugin of your own
+        */
+        @Nullable
+        default IRecipeManagerPlugin getRecipeManagerPlugin() {
+            return null;
+        }
 }

--- a/Library/src/main/java/mezz/jei/library/recipes/PluginManager.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/PluginManager.java
@@ -21,9 +21,12 @@ import java.util.stream.Stream;
 public class PluginManager {
 	private static final Logger LOGGER = LogManager.getLogger();
 
+	public final IRecipeManagerPlugin defaultIRecipeManagerPlugin;
+	
 	private final List<IRecipeManagerPlugin> plugins = new ArrayList<>();
 
 	public PluginManager(IRecipeManagerPlugin internalRecipeManagerPlugin, List<IRecipeManagerPlugin> plugins) {
+		defaultIRecipeManagerPlugin = internalRecipeManagerPlugin;
 		this.plugins.add(internalRecipeManagerPlugin);
 		this.plugins.addAll(plugins);
 	}

--- a/Library/src/main/java/mezz/jei/library/recipes/RecipeManager.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/RecipeManager.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public class RecipeManager implements IRecipeManager {
-	private final RecipeManagerInternal internal;
+	public final RecipeManagerInternal internal;
 	private final IModIdHelper modIdHelper;
 	private final IIngredientManager ingredientManager;
 	private final Textures textures;

--- a/Library/src/main/java/mezz/jei/library/recipes/RecipeManagerInternal.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/RecipeManagerInternal.java
@@ -41,7 +41,7 @@ public class RecipeManagerInternal {
 	private final RecipeTypeDataMap recipeTypeDataMap;
 	private final Comparator<IRecipeCategory<?>> recipeCategoryComparator;
 	private final EnumMap<RecipeIngredientRole, RecipeMap> recipeMaps;
-	private final PluginManager pluginManager;
+	public final PluginManager pluginManager;
 	private final Set<RecipeType<?>> hiddenRecipeTypes = new HashSet<>();
 	private final IIngredientVisibility ingredientVisibility;
 

--- a/Library/src/main/java/mezz/jei/library/runtime/JeiRuntime.java
+++ b/Library/src/main/java/mezz/jei/library/runtime/JeiRuntime.java
@@ -2,6 +2,7 @@ package mezz.jei.library.runtime;
 
 import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.recipe.IRecipeManager;
+import mezz.jei.api.recipe.advanced.IRecipeManagerPlugin;
 import mezz.jei.api.recipe.transfer.IRecipeTransferManager;
 import mezz.jei.api.runtime.IBookmarkOverlay;
 import mezz.jei.api.runtime.IEditModeConfig;
@@ -14,6 +15,7 @@ import mezz.jei.api.runtime.IJeiRuntime;
 import mezz.jei.api.runtime.IRecipesGui;
 import mezz.jei.api.runtime.IScreenHelper;
 import mezz.jei.api.runtime.config.IJeiConfigManager;
+import mezz.jei.library.recipes.RecipeManager;
 
 
 public class JeiRuntime implements IJeiRuntime {
@@ -125,4 +127,10 @@ public class JeiRuntime implements IJeiRuntime {
 	public IJeiConfigManager getConfigManager() {
 		return configManager;
 	}
+
+        @Override
+        public IRecipeManagerPlugin getRecipeManagerPlugin() {
+        	return ((RecipeManager) getRecipeManager()).internal.pluginManager.defaultIRecipeManagerPlugin;
+
+        }
 }


### PR DESCRIPTION
Allows IJeiRuntimes to return their default handling of the IRecipeManagerPlugin

This allows for more general custom handling for recipe lookups. For example, you can hit 'R' on an item that contains a fluid, get the fluid from the item, and then return the result of looking up the fluid.

To prevent forks of JEI from breaking, the implementation in the interface returns null by default

I did this in notepad for reference, so apologies if the spaces are kinda borked