### PR TITLE
Add JeiRegistrationDelegate API

### DIFF
--- a/CommonApi/src/main/java/mezz/jei/api/registration/JeiRegistrationDelegate.java
+++ b/CommonApi/src/main/java/mezz/jei/api/registration/JeiRegistrationDelegate.java
@@ -1,0 +1,29 @@
+package mezz.jei.api.registration;
+
+import mezz.jei.api.IModPlugin;
+
+import java.util.function.Consumer;
+
+/**
+ * Advanced API to provide a stand-between when JEI is calling methods on the registered plugins.
+ * Only one registration delegate may exist. By default, it simply calls the method with no further
+ * logic.
+ */
+public interface JeiRegistrationDelegate {
+
+	static void set(JeiRegistrationDelegate delegate) {
+		JeiRegistrationDelegateHolder.current = delegate;
+	}
+
+	static JeiRegistrationDelegate get() {
+		return JeiRegistrationDelegateHolder.current;
+	}
+
+	void callOnPlugin(JeiRegistrationStep step, IModPlugin plugin, Consumer<IModPlugin> func);
+
+}
+
+// Can't have a private in an interface, including an inner class. So this will do.
+class JeiRegistrationDelegateHolder {
+	static JeiRegistrationDelegate current = (step, plugin, func) -> func.accept(plugin);
+}

--- a/CommonApi/src/main/java/mezz/jei/api/registration/JeiRegistrationStep.java
+++ b/CommonApi/src/main/java/mezz/jei/api/registration/JeiRegistrationStep.java
@@ -1,0 +1,33 @@
+package mezz.jei.api.registration;
+
+/**
+ * The order of values in this enum is not guaranteed. Use {@code ordinal()} with caution, if ever.
+ * @see JeiRegistrationDelegate
+ */
+public enum JeiRegistrationStep {
+	ITEM_SUBTYPES("Registering item subtypes"),
+	FLUID_SUBTYPES("Registering fluid subtypes"),
+	INGREDIENTS("Registering ingredients"),
+	CATEGORIES("Registering categories"),
+	VANILLA_CATEGORY_EXTENSIONS("Registering vanilla category extensions"),
+	RECIPES("Registering recipes"),
+	RECIPE_TRANSFER_HANDLERS("Registering recipes transfer handlers"),
+	RECIPE_CATALYSTS("Registering recipe catalysts"),
+	GUI_HANDLERS("Registering gui handlers"),
+	ADVANCED("Registering advanced plugins"),
+	RUNTIME("Registering Runtime"),
+	RUNTIME_AVAILABLE("Sending Runtime"),
+	RUNTIME_UNAVAILABLE("Sending Runtime Unavailable"),
+	CONFIG_MANAGER("Sending ConfigManager");
+
+	private final String description;
+
+	JeiRegistrationStep(String description) {
+		this.description = description;
+	}
+
+	public String toString() {
+		return description;
+	}
+
+}

--- a/Library/src/main/java/mezz/jei/library/load/PluginCaller.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginCaller.java
@@ -2,6 +2,8 @@ package mezz.jei.library.load;
 
 import com.google.common.base.Stopwatch;
 import mezz.jei.api.IModPlugin;
+import mezz.jei.api.registration.JeiRegistrationDelegate;
+import mezz.jei.api.registration.JeiRegistrationStep;
 import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,8 +15,8 @@ import java.util.function.Consumer;
 public class PluginCaller {
 	private static final Logger LOGGER = LogManager.getLogger();
 
-	public static void callOnPlugins(String title, List<IModPlugin> plugins, Consumer<IModPlugin> func) {
-		LOGGER.info("{}...", title);
+	public static void callOnPlugins(JeiRegistrationStep step, List<IModPlugin> plugins, Consumer<IModPlugin> func) {
+		LOGGER.info("{}...", step);
 		Stopwatch stopwatch = Stopwatch.createStarted();
 
 		try (PluginCallerTimer timer = new PluginCallerTimer()) {
@@ -23,8 +25,8 @@ public class PluginCaller {
 			for (IModPlugin plugin : plugins) {
 				try {
 					ResourceLocation pluginUid = plugin.getPluginUid();
-					timer.begin(title, pluginUid);
-					func.accept(plugin);
+					timer.begin(step.toString(), pluginUid);
+					JeiRegistrationDelegate.get().callOnPlugin(step, plugin, func);
 					timer.end();
 				} catch (RuntimeException | LinkageError e) {
 					LOGGER.error("Caught an error from mod plugin: {} {}", plugin.getClass(), plugin.getPluginUid(), e);
@@ -34,6 +36,6 @@ public class PluginCaller {
 			plugins.removeAll(erroredPlugins);
 		}
 
-		LOGGER.info("{} took {}", title, stopwatch);
+		LOGGER.info("{} took {}", step, stopwatch);
 	}
 }

--- a/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
+++ b/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
@@ -7,6 +7,7 @@ import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
 import mezz.jei.api.recipe.transfer.IRecipeTransferManager;
+import mezz.jei.api.registration.JeiRegistrationStep;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.api.runtime.IIngredientVisibility;
 import mezz.jei.api.runtime.IScreenHelper;
@@ -93,7 +94,7 @@ public final class JeiStarter {
 
 		this.recipeCategorySortingConfig = new RecipeCategorySortingConfig(configDir.resolve("recipe-category-sort-order.ini"));
 
-		PluginCaller.callOnPlugins("Sending ConfigManager", plugins, p -> p.onConfigManagerAvailable(configManager));
+		PluginCaller.callOnPlugins(JeiRegistrationStep.CONFIG_MANAGER, plugins, p -> p.onConfigManagerAvailable(configManager));
 	}
 
 	public void start() {
@@ -153,7 +154,7 @@ public final class JeiStarter {
 			recipeTransferManager,
 			screenHelper
 		);
-		PluginCaller.callOnPlugins("Registering Runtime", plugins, p -> p.registerRuntime(runtimeRegistration));
+		PluginCaller.callOnPlugins(JeiRegistrationStep.RUNTIME, plugins, p -> p.registerRuntime(runtimeRegistration));
 
 		JeiRuntime jeiRuntime = new JeiRuntime(
 			recipeManager,
@@ -172,7 +173,7 @@ public final class JeiStarter {
 		);
 		timer.stop();
 
-		PluginCaller.callOnPlugins("Sending Runtime", plugins, p -> p.onRuntimeAvailable(jeiRuntime));
+		PluginCaller.callOnPlugins(JeiRegistrationStep.RUNTIME_AVAILABLE, plugins, p -> p.onRuntimeAvailable(jeiRuntime));
 
 		totalTime.stop();
 	}
@@ -180,6 +181,6 @@ public final class JeiStarter {
 	public void stop() {
 		LOGGER.info("Stopping JEI");
 		List<IModPlugin> plugins = data.plugins();
-		PluginCaller.callOnPlugins("Sending Runtime Unavailable", plugins, IModPlugin::onRuntimeUnavailable);
+		PluginCaller.callOnPlugins(JeiRegistrationStep.RUNTIME_UNAVAILABLE, plugins, IModPlugin::onRuntimeUnavailable);
 	}
 }


### PR DESCRIPTION
Adds an advanced API to provide a stand-between when JEI is calling methods on the registered plugins. Only one registration delegate may exist. By default, it simply calls the method with no further logic — equivalent to current behavior.

This is useful in certain cases to override other plugins, especially JEI's built-in vanilla plugins. It also makes the JEI loading process more inspectable and debuggable without code modification.

I confirmed this builds and runs for Fabric, but I cannot build Forge due to the following error:

```
> Task :Forge:compileTestJava FAILED
/home/una/Source/JustEnoughItems/Forge/src/test/java/mezz/jei/test/lib/TestClientConfig.java:9: error:
  TestClientConfig is not abstract and does not override abstract method isLookupFluidContents() in IClientConfig

public class TestClientConfig implements IClientConfig {
       ^
1 error

FAILURE: Build failed with an exception.
```