### PR TITLE
[1.12] Fix duplication glitch when shift-clicking crafting recipes

### DIFF
--- a/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
+++ b/src/main/java/mezz/jei/transfer/BasicRecipeTransferHandlerServer.java
@@ -87,6 +87,8 @@ public final class BasicRecipeTransferHandlerServer {
 		for (ItemStack oldCraftingItem : clearedCraftingItems) {
 			int added = addStack(container, inventorySlots, oldCraftingItem);
 			if (added < oldCraftingItem.getCount()) {
+				// only drop the items which were not added to the inventory
+				oldCraftingItem.shrink(added);
 				if (!player.inventory.addItemStackToInventory(oldCraftingItem)) {
 					player.dropItem(oldCraftingItem, false);
 				}


### PR DESCRIPTION
This PR fixes a duplication glitch when shift-clicking the "+" button to import recipes into the crafting table. 

When clearing the crafting grid, there is a scenario where not all of the items can fit into the player's inventory. JEI currently drops the items on the ground when this occurs. In doing so, it does not account for any items that were added to the player's inventory beforehand, so it drops the entire stack present in the grid. As a result, extra items are given to the player, and then the original stack is dropped on the ground.

This PR resolves this issue by subtracting the inserted amount before dropping the stack.

Reported issue where this bug was initially discovered: https://github.com/GregTechCEu/GregTech/issues/1775.
