### PR TITLE
Fix mismatch between display names

### DIFF
--- a/Forge/src/test/java/mezz/jei/test/lib/TestIngredientHelper.java
+++ b/Forge/src/test/java/mezz/jei/test/lib/TestIngredientHelper.java
@@ -16,7 +16,7 @@ public class TestIngredientHelper implements IIngredientHelper<TestIngredient> {
 
 	@Override
 	public String getDisplayName(TestIngredient ingredient) {
-		return "Test Ingredient Display Name " + ingredient;
+		return "§eTest Ingredient Display Name " + ingredient;
 	}
 
 	@Override

--- a/Gui/src/main/java/mezz/jei/gui/ingredients/IngredientFilter.java
+++ b/Gui/src/main/java/mezz/jei/gui/ingredients/IngredientFilter.java
@@ -120,7 +120,7 @@ public class IngredientFilter implements IIngredientGridSource, IIngredientManag
 		IIngredientType<V> type = typedIngredient.getType();
 		Function<ITypedIngredient<V>, String> uidFunction = (i) -> ingredientHelper.getUniqueId(i.getIngredient(), UidContext.Ingredient);
 		String ingredientUid = uidFunction.apply(typedIngredient);
-		String displayName = ingredientHelper.getDisplayName(ingredient);
+		String displayName = IngredientInformationUtil.getDisplayName(ingredient, ingredientHelper);
 		String lowercaseDisplayName = Translator.toLowercaseWithLocale(displayName);
 
 		ElementPrefixParser.TokenInfo tokenInfo = new ElementPrefixParser.TokenInfo(lowercaseDisplayName, ElementPrefixParser.NO_PREFIX);


### PR DESCRIPTION
`IngredientManager.removeIngredientsAtRuntime` is broken for items with chat formatting codes. The problem is when adding an ingredient `IngredientInformationUtil.getDisplayName` is used which strips chat formatting after `ingredientHelper.getDisplayName`, while when removing only `ingredientHelper.getDisplayName` is used, so `ItemFilter` couldn't find any matching ingredient to delete. For example, this phenomenon occurs for AllTheCompressed mod's atm star blocks and nether star blocks.