### PR TITLE
[1.18.1] Suppressed "Gave 0 [Air]" message when trying to obtain item with full stack of the item already in cursor.

### DIFF
--- a/src/main/java/mezz/jei/util/CommandUtil.java
+++ b/src/main/java/mezz/jei/util/CommandUtil.java
@@ -57,6 +57,7 @@ public final class CommandUtil {
 		if (ServerInfo.isJeiOnServer()) {
 			ItemStack sendStack = ItemHandlerHelper.copyStackWithSize(itemStack, itemStack.getMaxStackSize());
 			PacketSetHotbarItemStack packet = new PacketSetHotbarItemStack(sendStack, hotbarSlot);
+			// test commit
 			if (player.inventoryMenu.getCarried().getCount() < player.inventoryMenu.getCarried().getMaxStackSize()) {
 				Network.sendPacketToServer(packet);
 			}

--- a/src/main/java/mezz/jei/util/CommandUtil.java
+++ b/src/main/java/mezz/jei/util/CommandUtil.java
@@ -57,7 +57,9 @@ public final class CommandUtil {
 		if (ServerInfo.isJeiOnServer()) {
 			ItemStack sendStack = ItemHandlerHelper.copyStackWithSize(itemStack, itemStack.getMaxStackSize());
 			PacketSetHotbarItemStack packet = new PacketSetHotbarItemStack(sendStack, hotbarSlot);
-			Network.sendPacketToServer(packet);
+			if (player.inventoryMenu.getCarried().getCount() < player.inventoryMenu.getCarried().getMaxStackSize()-1) {
+				Network.sendPacketToServer(packet);
+			}
 		}
 	}
 

--- a/src/main/java/mezz/jei/util/CommandUtil.java
+++ b/src/main/java/mezz/jei/util/CommandUtil.java
@@ -57,7 +57,6 @@ public final class CommandUtil {
 		if (ServerInfo.isJeiOnServer()) {
 			ItemStack sendStack = ItemHandlerHelper.copyStackWithSize(itemStack, itemStack.getMaxStackSize());
 			PacketSetHotbarItemStack packet = new PacketSetHotbarItemStack(sendStack, hotbarSlot);
-			// test commit
 			if (player.inventoryMenu.getCarried().getCount() < player.inventoryMenu.getCarried().getMaxStackSize()) {
 				Network.sendPacketToServer(packet);
 			}

--- a/src/main/java/mezz/jei/util/CommandUtil.java
+++ b/src/main/java/mezz/jei/util/CommandUtil.java
@@ -57,7 +57,7 @@ public final class CommandUtil {
 		if (ServerInfo.isJeiOnServer()) {
 			ItemStack sendStack = ItemHandlerHelper.copyStackWithSize(itemStack, itemStack.getMaxStackSize());
 			PacketSetHotbarItemStack packet = new PacketSetHotbarItemStack(sendStack, hotbarSlot);
-			if (player.inventoryMenu.getCarried().getCount() < player.inventoryMenu.getCarried().getMaxStackSize()-1) {
+			if (player.inventoryMenu.getCarried().getCount() < player.inventoryMenu.getCarried().getMaxStackSize()) {
 				Network.sendPacketToServer(packet);
 			}
 		}


### PR DESCRIPTION
Fixes issue #2677.

Added the following if-statement to check if the current stack on the cursor is less than the maximum stack allowed. This makes it so that the game doesn't unnecessarily try to give you more of the item than it can. As a result, the "Give Air" message does not appear in the chat and console log.
```
if (player.inventoryMenu.getCarried().getCount() < player.inventoryMenu.getCarried().getMaxStackSize()) {
	Network.sendPacketToServer(packet);
}
```