### PR TITLE
Fix keybinds not being configurable for Fabric

### DIFF
--- a/Fabric/build.gradle.kts
+++ b/Fabric/build.gradle.kts
@@ -19,6 +19,12 @@ repositories {
     exclusiveMaven("https://maven.parchmentmc.org") {
         includeGroupByRegex("org\\.parchmentmc.*")
     }
+    maven("https://maven.siphalor.de/") {
+        // for optional AMECS integration
+        content {
+            includeGroup("de.siphalor")
+        }
+    }
 }
 
 // gradle.properties
@@ -34,6 +40,8 @@ val modJavaVersion: String by extra
 val parchmentMinecraftVersion: String by extra
 val parchmentVersionFabric: String by extra
 val modrinthId: String by extra
+val amecsVersionFabric: String by extra
+val amecsMinecraftVersion: String by extra
 
 // set by ORG_GRADLE_PROJECT_modrinthToken in Jenkinsfile
 val modrinthToken: String? by project
@@ -98,6 +106,11 @@ dependencies {
         group = "com.google.code.findbugs",
         name = "jsr305",
         version = "3.0.1"
+    )
+    modImplementation(
+        group = "de.siphalor",
+        name = "amecsapi-${amecsMinecraftVersion}",
+        version = amecsVersionFabric
     )
     dependencyProjects.forEach {
         implementation(it)

--- a/Fabric/src/main/java/mezz/jei/fabric/input/AbstractJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/AbstractJeiKeyMapping.java
@@ -1,0 +1,47 @@
+package mezz.jei.fabric.input;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import java.util.function.Consumer;
+import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
+import mezz.jei.common.input.keys.JeiKeyConflictContext;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.network.chat.Component;
+
+public abstract class AbstractJeiKeyMapping implements IJeiKeyMappingInternal {
+	protected final JeiKeyConflictContext context;
+
+	public AbstractJeiKeyMapping(JeiKeyConflictContext context) {
+		this.context = context;
+	}
+
+	protected abstract KeyMapping getMapping();
+
+	protected abstract InputConstants.Key getMappedKey();
+
+	@Override
+	public boolean isActiveAndMatches(InputConstants.Key key) {
+		if (isUnbound()) {
+			return false;
+		}
+		if (!this.getMappedKey().equals(key)) {
+			return false;
+		}
+		return context.isActive();
+	}
+
+	@Override
+	public boolean isUnbound() {
+		return this.getMapping().isUnbound();
+	}
+
+	@Override
+	public Component getTranslatedKeyMessage() {
+		return this.getMapping().getTranslatedKeyMessage();
+	}
+
+	@Override
+	public IJeiKeyMappingInternal register(Consumer<KeyMapping> registerMethod) {
+		registerMethod.accept(this.getMapping());
+		return this;
+	}
+}

--- a/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMapping.java
@@ -8,12 +8,21 @@ import mezz.jei.common.input.keys.JeiKeyConflictContext;
 import mezz.jei.common.input.keys.JeiKeyModifier;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 
-public class AmecsJeiKeyMapping extends FabricJeiKeyMapping {
+public class AmecsJeiKeyMapping extends AbstractJeiKeyMapping {
 	protected final AmecsKeyBinding amecsMapping;
 
 	public AmecsJeiKeyMapping(AmecsKeyBinding amecsMapping, JeiKeyConflictContext context) {
-		super(amecsMapping, context);
+		super(context);
 		this.amecsMapping = amecsMapping;
+	}
+
+	protected AmecsKeyBinding getMapping() {
+		return this.amecsMapping;
+	}
+
+	protected InputConstants.Key getMappedKey()
+	{
+		return KeyBindingHelper.getBoundKeyOf(this.amecsMapping);
 	}
 
 	@Override
@@ -21,7 +30,7 @@ public class AmecsJeiKeyMapping extends FabricJeiKeyMapping {
 		if (isUnbound()) {
 			return false;
 		}
-		if (!KeyBindingHelper.getBoundKeyOf(this.keyMapping).equals(key)) {
+		if (!this.getMappedKey().equals(key)) {
 			return false;
 		}
 		if (!context.isActive()) return false;

--- a/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMapping.java
@@ -20,8 +20,7 @@ public class AmecsJeiKeyMapping extends AbstractJeiKeyMapping {
 		return this.amecsMapping;
 	}
 
-	protected InputConstants.Key getMappedKey()
-	{
+	protected InputConstants.Key getMappedKey() {
 		return KeyBindingHelper.getBoundKeyOf(this.amecsMapping);
 	}
 
@@ -33,12 +32,23 @@ public class AmecsJeiKeyMapping extends AbstractJeiKeyMapping {
 		if (!this.getMappedKey().equals(key)) {
 			return false;
 		}
-		if (!context.isActive()) return false;
+		if (!context.isActive()) {
+			return false;
+		}
+
 		KeyModifiers modifier = KeyBindingUtils.getBoundModifiers(this.amecsMapping);
-		if (modifier.getControl() && !JeiKeyModifier.CONTROL_OR_COMMAND.isActive(context)) return false;
-		if (modifier.getShift() && !JeiKeyModifier.SHIFT.isActive(context)) return false;
-		if (modifier.getAlt() && !JeiKeyModifier.ALT.isActive(context)) return false;
-		if (modifier.isUnset() && !JeiKeyModifier.NONE.isActive(context)) return false;
+		if (modifier.getControl() && !JeiKeyModifier.CONTROL_OR_COMMAND.isActive(context)) {
+			return false;
+		}
+		if (modifier.getShift() && !JeiKeyModifier.SHIFT.isActive(context)) {
+			return false;
+		}
+		if (modifier.getAlt() && !JeiKeyModifier.ALT.isActive(context)) {
+			return false;
+		}
+		if (modifier.isUnset() && !JeiKeyModifier.NONE.isActive(context)) {
+			return false;
+		}
 		return true;
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMapping.java
@@ -1,0 +1,35 @@
+package mezz.jei.fabric.input;
+
+import de.siphalor.amecs.api.AmecsKeyBinding;
+import de.siphalor.amecs.api.KeyBindingUtils;
+import de.siphalor.amecs.api.KeyModifiers;
+import com.mojang.blaze3d.platform.InputConstants;
+import mezz.jei.common.input.keys.JeiKeyConflictContext;
+import mezz.jei.common.input.keys.JeiKeyModifier;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+
+public class AmecsJeiKeyMapping extends FabricJeiKeyMapping {
+	protected final AmecsKeyBinding amecsMapping;
+
+	public AmecsJeiKeyMapping(AmecsKeyBinding amecsMapping, JeiKeyConflictContext context) {
+		super(amecsMapping, context);
+		this.amecsMapping = amecsMapping;
+	}
+
+	@Override
+	public boolean isActiveAndMatches(InputConstants.Key key) {
+		if (isUnbound()) {
+			return false;
+		}
+		if (!KeyBindingHelper.getBoundKeyOf(this.keyMapping).equals(key)) {
+			return false;
+		}
+		if (!context.isActive()) return false;
+		KeyModifiers modifier = KeyBindingUtils.getBoundModifiers(this.amecsMapping);
+		if (modifier.getControl() && !JeiKeyModifier.CONTROL_OR_COMMAND.isActive(context)) return false;
+		if (modifier.getShift() && !JeiKeyModifier.SHIFT.isActive(context)) return false;
+		if (modifier.getAlt() && !JeiKeyModifier.ALT.isActive(context)) return false;
+		if (modifier.isUnset() && !JeiKeyModifier.NONE.isActive(context)) return false;
+		return true;
+	}
+}

--- a/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMappingBuilder.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/AmecsJeiKeyMappingBuilder.java
@@ -1,0 +1,46 @@
+package mezz.jei.fabric.input;
+
+import de.siphalor.amecs.api.AmecsKeyBinding;
+import de.siphalor.amecs.api.KeyModifiers;
+import com.mojang.blaze3d.platform.InputConstants;
+import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
+import mezz.jei.common.input.keys.IJeiKeyMappingBuilder;
+import mezz.jei.common.input.keys.JeiKeyModifier;
+
+public class AmecsJeiKeyMappingBuilder extends FabricJeiKeyMappingBuilder {
+	protected KeyModifiers modifier = new KeyModifiers();
+
+	public AmecsJeiKeyMappingBuilder(String category, String description) {
+		super(category, description);
+		this.modifier = new KeyModifiers();
+	}
+
+	@Override
+	public IJeiKeyMappingBuilder setModifier(JeiKeyModifier modifier) {
+		this.modifier.unset();
+		switch (modifier) {
+			case CONTROL_OR_COMMAND:
+				this.modifier.setControl(true);
+				break;
+			case SHIFT:
+				this.modifier.setShift(true);
+				break;
+			case ALT:
+				this.modifier.setAlt(true);
+				break;
+		}
+		return this;
+	}
+
+	@Override
+	protected IJeiKeyMappingInternal buildMouse(int mouseButton) {
+		AmecsKeyBinding keyMapping = new AmecsKeyBinding(description, InputConstants.Type.MOUSE, mouseButton, category, modifier);
+		return new AmecsJeiKeyMapping(keyMapping, context);
+	}
+
+	@Override
+	public IJeiKeyMappingInternal buildKeyboardKey(int key) {
+		AmecsKeyBinding keyMapping = new AmecsKeyBinding(description, InputConstants.Type.KEYSYM, key, category, modifier);
+		return new AmecsJeiKeyMapping(keyMapping, context);
+	}
+}

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
@@ -15,8 +15,7 @@ public class FabricJeiKeyMapping extends AbstractJeiKeyMapping {
 		return this.fabricMapping;
 	}
 
-	protected InputConstants.Key getMappedKey()
-	{
+	protected InputConstants.Key getMappedKey() {
 		return this.fabricMapping.realKey;
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
@@ -4,44 +4,43 @@ import com.mojang.blaze3d.platform.InputConstants;
 import java.util.function.Consumer;
 import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
 import mezz.jei.common.input.keys.JeiKeyConflictContext;
-import mezz.jei.common.input.keys.JeiKeyModifier;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 
 public class FabricJeiKeyMapping implements IJeiKeyMappingInternal {
-    protected final KeyMapping keyMapping;
-    protected final JeiKeyConflictContext context;
+	protected final KeyMapping keyMapping;
+	protected final JeiKeyConflictContext context;
 
-    public FabricJeiKeyMapping(KeyMapping keyMapping, JeiKeyConflictContext context) {
-        this.keyMapping = keyMapping;
-        this.context = context;
-    }
+	public FabricJeiKeyMapping(KeyMapping keyMapping, JeiKeyConflictContext context) {
+		this.keyMapping = keyMapping;
+		this.context = context;
+	}
 
-    @Override
-    public boolean isActiveAndMatches(InputConstants.Key key) {
-        if (isUnbound()) {
-            return false;
-        }
-        if (!KeyBindingHelper.getBoundKeyOf(this.keyMapping).equals(key)) {
-            return false;
-        }
-        return context.isActive();
-    }
+	@Override
+	public boolean isActiveAndMatches(InputConstants.Key key) {
+		if (isUnbound()) {
+			return false;
+		}
+		if (!KeyBindingHelper.getBoundKeyOf(this.keyMapping).equals(key)) {
+			return false;
+		}
+		return context.isActive();
+	}
 
-    @Override
-    public boolean isUnbound() {
-        return this.keyMapping.isUnbound();
-    }
+	@Override
+	public boolean isUnbound() {
+		return this.keyMapping.isUnbound();
+	}
 
-    @Override
-    public Component getTranslatedKeyMessage() {
-        return this.keyMapping.getTranslatedKeyMessage();
-    }
+	@Override
+	public Component getTranslatedKeyMessage() {
+		return this.keyMapping.getTranslatedKeyMessage();
+	}
 
-    @Override
-    public IJeiKeyMappingInternal register(Consumer<KeyMapping> registerMethod) {
-        registerMethod.accept(this.keyMapping);
-        return this;
-    }
+	@Override
+	public IJeiKeyMappingInternal register(Consumer<KeyMapping> registerMethod) {
+		registerMethod.accept(this.keyMapping);
+		return this;
+	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
@@ -5,56 +5,43 @@ import java.util.function.Consumer;
 import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
 import mezz.jei.common.input.keys.JeiKeyConflictContext;
 import mezz.jei.common.input.keys.JeiKeyModifier;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
 
 public class FabricJeiKeyMapping implements IJeiKeyMappingInternal {
-	private final String category;
-	private final String description;
-	private final JeiKeyConflictContext context;
-	private final JeiKeyModifier modifier;
-	private final InputConstants.Type type;
-	private final InputConstants.Key key;
+    protected final KeyMapping keyMapping;
+    protected final JeiKeyConflictContext context;
 
-	public FabricJeiKeyMapping(
-		String category,
-		String description,
-		JeiKeyConflictContext context,
-		JeiKeyModifier modifier,
-		InputConstants.Type type,
-		int keyCode
-	) {
-		this.category = category;
-		this.description = description;
-		this.context = context;
-		this.modifier = modifier;
-		this.type = type;
-		this.key = type.getOrCreate(keyCode);
-	}
+    public FabricJeiKeyMapping(KeyMapping keyMapping, JeiKeyConflictContext context) {
+        this.keyMapping = keyMapping;
+        this.context = context;
+    }
 
-	@Override
-	public boolean isActiveAndMatches(InputConstants.Key key) {
-		if (isUnbound()) {
-			return false;
-		}
-		if (!this.key.equals(key)) {
-			return false;
-		}
-		return context.isActive() && modifier.isActive(context);
-	}
+    @Override
+    public boolean isActiveAndMatches(InputConstants.Key key) {
+        if (isUnbound()) {
+            return false;
+        }
+        if (!KeyBindingHelper.getBoundKeyOf(this.keyMapping).equals(key)) {
+            return false;
+        }
+        return context.isActive();
+    }
 
-	@Override
-	public boolean isUnbound() {
-		return this.key.equals(InputConstants.UNKNOWN);
-	}
+    @Override
+    public boolean isUnbound() {
+        return this.keyMapping.isUnbound();
+    }
 
-	@Override
-	public Component getTranslatedKeyMessage() {
-		return modifier.getCombinedName(key);
-	}
+    @Override
+    public Component getTranslatedKeyMessage() {
+        return this.keyMapping.getTranslatedKeyMessage();
+    }
 
-	@Override
-	public IJeiKeyMappingInternal register(Consumer<KeyMapping> registerMethod) {
-		return this;
-	}
+    @Override
+    public IJeiKeyMappingInternal register(Consumer<KeyMapping> registerMethod) {
+        registerMethod.accept(this.keyMapping);
+        return this;
+    }
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMapping.java
@@ -1,46 +1,22 @@
 package mezz.jei.fabric.input;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import java.util.function.Consumer;
-import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
 import mezz.jei.common.input.keys.JeiKeyConflictContext;
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.minecraft.client.KeyMapping;
-import net.minecraft.network.chat.Component;
 
-public class FabricJeiKeyMapping implements IJeiKeyMappingInternal {
-	protected final KeyMapping keyMapping;
-	protected final JeiKeyConflictContext context;
+public class FabricJeiKeyMapping extends AbstractJeiKeyMapping {
+	protected final FabricKeyMapping fabricMapping;
 
-	public FabricJeiKeyMapping(KeyMapping keyMapping, JeiKeyConflictContext context) {
-		this.keyMapping = keyMapping;
-		this.context = context;
+	public FabricJeiKeyMapping(FabricKeyMapping fabricMapping, JeiKeyConflictContext context) {
+		super(context);
+		this.fabricMapping = fabricMapping;
 	}
 
-	@Override
-	public boolean isActiveAndMatches(InputConstants.Key key) {
-		if (isUnbound()) {
-			return false;
-		}
-		if (!KeyBindingHelper.getBoundKeyOf(this.keyMapping).equals(key)) {
-			return false;
-		}
-		return context.isActive();
+	protected FabricKeyMapping getMapping() {
+		return this.fabricMapping;
 	}
 
-	@Override
-	public boolean isUnbound() {
-		return this.keyMapping.isUnbound();
-	}
-
-	@Override
-	public Component getTranslatedKeyMessage() {
-		return this.keyMapping.getTranslatedKeyMessage();
-	}
-
-	@Override
-	public IJeiKeyMappingInternal register(Consumer<KeyMapping> registerMethod) {
-		registerMethod.accept(this.keyMapping);
-		return this;
+	protected InputConstants.Key getMappedKey()
+	{
+		return this.fabricMapping.realKey;
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingBuilder.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingBuilder.java
@@ -6,51 +6,38 @@ import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
 import mezz.jei.common.input.keys.IJeiKeyMappingBuilder;
 import mezz.jei.common.input.keys.JeiKeyConflictContext;
 import mezz.jei.common.input.keys.JeiKeyModifier;
+import net.minecraft.client.KeyMapping;
 
 public class FabricJeiKeyMappingBuilder extends AbstractJeiKeyMappingBuilder {
-	private final String category;
-	private final String description;
-	private JeiKeyConflictContext context = JeiKeyConflictContext.UNIVERSAL;
-	private JeiKeyModifier modifier = JeiKeyModifier.NONE;
+    protected final String category;
+    protected final String description;
+    protected JeiKeyConflictContext context = JeiKeyConflictContext.UNIVERSAL;
 
-	public FabricJeiKeyMappingBuilder(String category, String description) {
-		this.category = category;
-		this.description = description;
-	}
+    public FabricJeiKeyMappingBuilder(String category, String description) {
+        this.category = category;
+        this.description = description;
+    }
 
-	@Override
-	public IJeiKeyMappingBuilder setContext(JeiKeyConflictContext context) {
-		this.context = context;
-		return this;
-	}
+    @Override
+    public IJeiKeyMappingBuilder setContext(JeiKeyConflictContext context) {
+        this.context = context;
+        return this;
+    }
 
-	@Override
-	public IJeiKeyMappingBuilder setModifier(JeiKeyModifier modifier) {
-		this.modifier = modifier;
-		return this;
-	}
+    @Override
+    public IJeiKeyMappingBuilder setModifier(JeiKeyModifier modifier) {
+        return this;
+    }
 
-	@Override
-	protected IJeiKeyMappingInternal buildMouse(int mouseButton) {
-		return new FabricJeiKeyMapping(
-			category,
-			description,
-			context,
-			modifier,
-			InputConstants.Type.MOUSE,
-			mouseButton
-		);
-	}
+    @Override
+    protected IJeiKeyMappingInternal buildMouse(int mouseButton) {
+        KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.MOUSE, mouseButton, category);
+        return new FabricJeiKeyMapping(keyMapping, context);
+    }
 
-	@Override
-	public IJeiKeyMappingInternal buildKeyboardKey(int key) {
-		return new FabricJeiKeyMapping(
-			category,
-			description,
-			context,
-			modifier,
-			InputConstants.Type.KEYSYM,
-			key
-		);
-	}
+    @Override
+    public IJeiKeyMappingInternal buildKeyboardKey(int key) {
+        KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.KEYSYM, key, category);
+        return new FabricJeiKeyMapping(keyMapping, context);
+    }
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingBuilder.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingBuilder.java
@@ -9,35 +9,35 @@ import mezz.jei.common.input.keys.JeiKeyModifier;
 import net.minecraft.client.KeyMapping;
 
 public class FabricJeiKeyMappingBuilder extends AbstractJeiKeyMappingBuilder {
-    protected final String category;
-    protected final String description;
-    protected JeiKeyConflictContext context = JeiKeyConflictContext.UNIVERSAL;
+	protected final String category;
+	protected final String description;
+	protected JeiKeyConflictContext context = JeiKeyConflictContext.UNIVERSAL;
 
-    public FabricJeiKeyMappingBuilder(String category, String description) {
-        this.category = category;
-        this.description = description;
-    }
+	public FabricJeiKeyMappingBuilder(String category, String description) {
+		this.category = category;
+		this.description = description;
+	}
 
-    @Override
-    public IJeiKeyMappingBuilder setContext(JeiKeyConflictContext context) {
-        this.context = context;
-        return this;
-    }
+	@Override
+	public IJeiKeyMappingBuilder setContext(JeiKeyConflictContext context) {
+		this.context = context;
+		return this;
+	}
 
-    @Override
-    public IJeiKeyMappingBuilder setModifier(JeiKeyModifier modifier) {
-        return this;
-    }
+	@Override
+	public IJeiKeyMappingBuilder setModifier(JeiKeyModifier modifier) {
+		return this;
+	}
 
-    @Override
-    protected IJeiKeyMappingInternal buildMouse(int mouseButton) {
-        KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.MOUSE, mouseButton, category);
-        return new FabricJeiKeyMapping(keyMapping, context);
-    }
+	@Override
+	protected IJeiKeyMappingInternal buildMouse(int mouseButton) {
+		KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.MOUSE, mouseButton, category);
+		return new FabricJeiKeyMapping(keyMapping, context);
+	}
 
-    @Override
-    public IJeiKeyMappingInternal buildKeyboardKey(int key) {
-        KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.KEYSYM, key, category);
-        return new FabricJeiKeyMapping(keyMapping, context);
-    }
+	@Override
+	public IJeiKeyMappingInternal buildKeyboardKey(int key) {
+		KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.KEYSYM, key, category);
+		return new FabricJeiKeyMapping(keyMapping, context);
+	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingBuilder.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingBuilder.java
@@ -6,7 +6,6 @@ import mezz.jei.common.input.keys.IJeiKeyMappingInternal;
 import mezz.jei.common.input.keys.IJeiKeyMappingBuilder;
 import mezz.jei.common.input.keys.JeiKeyConflictContext;
 import mezz.jei.common.input.keys.JeiKeyModifier;
-import net.minecraft.client.KeyMapping;
 
 public class FabricJeiKeyMappingBuilder extends AbstractJeiKeyMappingBuilder {
 	protected final String category;
@@ -31,13 +30,25 @@ public class FabricJeiKeyMappingBuilder extends AbstractJeiKeyMappingBuilder {
 
 	@Override
 	protected IJeiKeyMappingInternal buildMouse(int mouseButton) {
-		KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.MOUSE, mouseButton, category);
+		FabricKeyMapping keyMapping = new FabricKeyMapping(
+			description,
+			InputConstants.Type.MOUSE,
+			mouseButton,
+			category,
+			context
+		);
 		return new FabricJeiKeyMapping(keyMapping, context);
 	}
 
 	@Override
 	public IJeiKeyMappingInternal buildKeyboardKey(int key) {
-		KeyMapping keyMapping = new KeyMapping(description, InputConstants.Type.KEYSYM, key, category);
+		FabricKeyMapping keyMapping = new FabricKeyMapping(
+			description,
+			InputConstants.Type.KEYSYM,
+			key,
+			category,
+			context
+		);
 		return new FabricJeiKeyMapping(keyMapping, context);
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingCategoryBuilder.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricJeiKeyMappingCategoryBuilder.java
@@ -2,6 +2,7 @@ package mezz.jei.fabric.input;
 
 import mezz.jei.common.input.keys.IJeiKeyMappingBuilder;
 import mezz.jei.common.input.keys.IJeiKeyMappingCategoryBuilder;
+import net.fabricmc.loader.api.FabricLoader;
 
 public class FabricJeiKeyMappingCategoryBuilder implements IJeiKeyMappingCategoryBuilder {
 	private final String category;
@@ -12,6 +13,10 @@ public class FabricJeiKeyMappingCategoryBuilder implements IJeiKeyMappingCategor
 
 	@Override
 	public IJeiKeyMappingBuilder createMapping(String description) {
-		return new FabricJeiKeyMappingBuilder(category, description);
+		if (FabricLoader.getInstance().isModLoaded("amecsapi")) {
+			return new AmecsJeiKeyMappingBuilder(category, description);
+		} else {
+			return new FabricJeiKeyMappingBuilder(category, description);
+		}
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/input/FabricKeyMapping.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/input/FabricKeyMapping.java
@@ -1,0 +1,86 @@
+package mezz.jei.fabric.input;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import mezz.jei.common.input.keys.JeiKeyConflictContext;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.network.chat.Component;
+
+public class FabricKeyMapping extends KeyMapping {
+	protected InputConstants.Key realKey;
+	protected final JeiKeyConflictContext context;
+
+	public FabricKeyMapping(
+		String description,
+		InputConstants.Type type,
+		int keyCode,
+		String category,
+		JeiKeyConflictContext context
+	) {
+		// Ensure the default key is set correctly (it is final).
+		super(description, type, keyCode, category);
+		this.realKey = KeyBindingHelper.getBoundKeyOf(this);
+		this.context = context;
+		// Overwrite the parent's key variable so it doesn't block other keybinds.
+		super.setKey(InputConstants.UNKNOWN);
+	}
+
+	// Override all methods that would otherwise interact with super.key so displaying
+	// and rebinding work correctly. This cannot work for the static methods that
+	// count clicks and monitor presses, but JEI doesn't use them anyway.
+
+	@Override
+	public void setKey(InputConstants.Key key) {
+		this.realKey = key;
+	}
+
+	@Override
+	public boolean same(KeyMapping binding) {
+		// Special implementation which is aware of the key conflict context.
+		if (binding instanceof FabricKeyMapping other) {
+			return realKey.equals(KeyBindingHelper.getBoundKeyOf(other)) &&
+				(context.conflicts(other.context) || other.context.conflicts(context));
+		} else {
+			// This ensures symmetry between conflicts, as regular keybinds see this one as
+			// being unbound and not conflicting.
+			return false;
+		}
+	}
+
+	@Override
+	public boolean isUnbound() {
+		return this.realKey.equals(InputConstants.UNKNOWN);
+	}
+
+	@Override
+	public boolean matches(int keyCode, int scanCode) {
+		if (keyCode != InputConstants.UNKNOWN.getValue()) {
+			return this.realKey.getType() == InputConstants.Type.KEYSYM &&
+				this.realKey.getValue() == keyCode;
+		} else {
+			return this.realKey.getType() == InputConstants.Type.SCANCODE &&
+				this.realKey.getValue() == scanCode;
+		}
+	}
+
+	@Override
+	public boolean matchesMouse(int button) {
+		return this.realKey.getType() == InputConstants.Type.MOUSE &&
+			this.realKey.getValue() == button;
+	}
+
+	@Override
+	public Component getTranslatedKeyMessage() {
+		return this.realKey.getDisplayName();
+	}
+
+	@Override
+	public boolean isDefault() {
+		return this.realKey.equals(getDefaultKey());
+	}
+
+	@Override
+	public String saveString() {
+		return this.realKey.getName();
+	}
+}

--- a/Fabric/src/main/java/mezz/jei/fabric/startup/ClientLifecycleHandler.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/startup/ClientLifecycleHandler.java
@@ -9,6 +9,7 @@ import mezz.jei.fabric.network.ConnectionToServer;
 import mezz.jei.gui.config.InternalKeyMappings;
 import mezz.jei.library.startup.JeiStarter;
 import mezz.jei.library.startup.StartData;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import org.apache.logging.log4j.LogManager;
@@ -26,7 +27,7 @@ public class ClientLifecycleHandler {
 		IConnectionToServer serverConnection = new ConnectionToServer();
 		Internal.setServerConnection(serverConnection);
 
-		InternalKeyMappings keyMappings = new InternalKeyMappings(keyMapping -> {});
+		InternalKeyMappings keyMappings = new InternalKeyMappings(KeyBindingHelper::registerKeyBinding);
 		Internal.setKeyMappings(keyMappings);
 
 		ClientNetworkHandler.registerClientPacketHandler(serverConnection);

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ fabricApiVersionRange=>=0.102.0+1.21
 
 # AMECS (Fabric only)
 amecsMinecraftVersion=1.20
-amecsVersionFabric=1.4.0+mc1.20-pre1
+amecsVersionFabric=1.5.6+mc1.20.2
 
 # Mappings
 # https://parchmentmc.org/docs/getting-started

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,6 +54,10 @@ fabricApiVersion=0.103.0+1.21.1
 fabricLoaderVersionRange=>=0.16.3
 fabricApiVersionRange=>=0.102.0+1.21
 
+# AMECS (Fabric only)
+amecsMinecraftVersion=1.20
+amecsVersionFabric=1.4.0+mc1.20-pre1
+
 # Mappings
 # https://parchmentmc.org/docs/getting-started
 parchmentMinecraftVersion=1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ fabricApiVersion=0.103.0+1.21.1
 fabricLoaderVersionRange=>=0.16.3
 fabricApiVersionRange=>=0.102.0+1.21
 
-# AMECS (Fabric only)
+# AMECS (Fabric only, for keybinds with modifiers)
 amecsMinecraftVersion=1.20
 amecsVersionFabric=1.5.6+mc1.20.2
 


### PR DESCRIPTION
Fixes that keybindings are not displayed in the Minecraft controls menu for Fabric and can thus not be rebound, but at the cost of losing modifiers (which are not supported by plain Fabric). Contains optional support for [AMECS](https://modrinth.com/mod/amecs) to automatically re-enable key modifiers.