### PR TITLE
Switch to fastutil maps in key areas of the recipe manager

### DIFF
--- a/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
@@ -152,6 +152,8 @@ public class PluginLoader {
 		RecipeRegistration recipeRegistration = new RecipeRegistration(jeiHelpers, ingredientManager, ingredientVisibility, vanillaRecipeFactory, recipeManagerInternal);
 		PluginCaller.callOnPlugins("Registering recipes", plugins, p -> p.registerRecipes(recipeRegistration));
 
+		recipeManagerInternal.compact();
+
 		return new RecipeManager(recipeManagerInternal, ingredientManager);
 	}
 

--- a/Library/src/main/java/mezz/jei/library/recipes/RecipeManagerInternal.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/RecipeManagerInternal.java
@@ -280,4 +280,8 @@ public class RecipeManagerInternal {
 		ImmutableList<IRecipeCategoryDecorator<?>> decorators = recipeCategoryDecorators.get(recipeType);
 		return (List<IRecipeCategoryDecorator<T>>) (Object) decorators;
 	}
+
+	public void compact() {
+		recipeMaps.values().forEach(RecipeMap::compact);
+	}
 }

--- a/Library/src/main/java/mezz/jei/library/recipes/collect/IngredientToRecipesMap.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/collect/IngredientToRecipesMap.java
@@ -1,16 +1,16 @@
 package mezz.jei.library.recipes.collect;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class IngredientToRecipesMap<R> {
-	private final Map<Object, List<R>> uidToRecipes = new HashMap<>();
+	private final Map<Object, ArrayList<R>> uidToRecipes = new Object2ObjectOpenHashMap<>();
 
 	public void add(R recipe, Collection<Object> ingredientUids) {
 		for (Object uid : ingredientUids) {
@@ -26,5 +26,9 @@ public class IngredientToRecipesMap<R> {
 			return Collections.emptyList();
 		}
 		return Collections.unmodifiableList(recipes);
+	}
+
+	public void compact() {
+		uidToRecipes.values().forEach(ArrayList::trimToSize);
 	}
 }

--- a/Library/src/main/java/mezz/jei/library/recipes/collect/RecipeIngredientTable.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/collect/RecipeIngredientTable.java
@@ -26,4 +26,8 @@ public class RecipeIngredientTable {
 		}
 		return ingredientToRecipesMap.get(ingredientUid);
 	}
+
+	public void compact() {
+		map.values().forEach(IngredientToRecipesMap::compact);
+	}
 }

--- a/Library/src/main/java/mezz/jei/library/recipes/collect/RecipeMap.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/collect/RecipeMap.java
@@ -1,5 +1,9 @@
 package mezz.jei.library.recipes.collect;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.IIngredientTypeWithSubtypes;
@@ -8,7 +12,6 @@ import mezz.jei.api.ingredients.subtypes.UidContext;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.runtime.IIngredientManager;
-import mezz.jei.core.collect.SetMultiMap;
 import mezz.jei.library.ingredients.IIngredientSupplier;
 import org.jetbrains.annotations.UnmodifiableView;
 
@@ -25,8 +28,8 @@ import java.util.stream.Stream;
  */
 public class RecipeMap {
 	private final RecipeIngredientTable recipeTable = new RecipeIngredientTable();
-	private final SetMultiMap<Object, RecipeType<?>> ingredientUidToCategoryMap = new SetMultiMap<>();
-	private final SetMultiMap<Object, RecipeType<?>> categoryCatalystUidToRecipeCategoryMap = new SetMultiMap<>();
+	private final Multimap<Object, RecipeType<?>> ingredientUidToCategoryMap = Multimaps.newSetMultimap(new Object2ObjectOpenHashMap<>(), ObjectOpenHashSet::new);
+	private final Multimap<Object, RecipeType<?>> categoryCatalystUidToRecipeCategoryMap = Multimaps.newSetMultimap(new Object2ObjectOpenHashMap<>(), ObjectOpenHashSet::new);
 	private final Comparator<RecipeType<?>> recipeTypeComparator;
 	private final IIngredientManager ingredientManager;
 	private final RecipeIngredientRole role;
@@ -78,6 +81,10 @@ public class RecipeMap {
 			}
 			recipeTable.add(recipe, recipeType, ingredientUids);
 		}
+	}
+
+	public void compact() {
+		recipeTable.compact();
 	}
 
 	private <T> Object getIngredientUid(ITypedIngredient<T> typedIngredient) {


### PR DESCRIPTION
This PR improves memory usage of JEI's recipe structures slightly by switching to fastutil maps in a few key places (avoiding the overhead of many `HashMap$Node` objects) and compacting the array lists stored by `uidToRecipes` after recipes are created (to avoid keeping oversized arrays in memory forever).