### PR TITLE
Optimize storage of ItemStacks

### DIFF
--- a/CommonApi/src/main/java/mezz/jei/api/ingredients/IIngredientType.java
+++ b/CommonApi/src/main/java/mezz/jei/api/ingredients/IIngredientType.java
@@ -39,8 +39,9 @@ public interface IIngredientType<T> {
 	 */
 	default Optional<T> castIngredient(@Nullable Object ingredient) {
 		Class<? extends T> ingredientClass = getIngredientClass();
-		return Optional.ofNullable(ingredient)
-			.filter(ingredientClass::isInstance)
-			.map(ingredientClass::cast);
+		if (ingredientClass.isInstance(ingredient)) {
+			return Optional.of(ingredientClass.cast(ingredient));
+		}
+		return Optional.empty();
 	}
 }

--- a/Library/src/main/java/mezz/jei/library/ingredients/IngredientManager.java
+++ b/Library/src/main/java/mezz/jei/library/ingredients/IngredientManager.java
@@ -178,11 +178,10 @@ public class IngredientManager implements IIngredientManager {
 
 	@Override
 	public <V> ITypedIngredient<V> normalizeTypedIngredient(ITypedIngredient<V> typedIngredient) {
+		ErrorUtil.checkNotNull(typedIngredient, "typedIngredient");
 		IIngredientType<V> type = typedIngredient.getType();
 		IIngredientHelper<V> ingredientHelper = getIngredientHelper(type);
-		V ingredient = typedIngredient.getIngredient();
-		V normalized = ingredientHelper.normalizeIngredient(ingredient);
-		return TypedIngredient.createUnvalidated(type, normalized);
+		return TypedIngredient.normalize(typedIngredient, ingredientHelper);
 	}
 
 	@SuppressWarnings("removal")

--- a/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/NormalizedTypedItem.java
+++ b/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/NormalizedTypedItem.java
@@ -1,0 +1,34 @@
+package mezz.jei.library.ingredients.itemStacks;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+record NormalizedTypedItem(Holder<Item> itemHolder) implements ITypedIngredient<ItemStack> {
+	@Override
+	public ItemStack getIngredient() {
+		return new ItemStack(itemHolder);
+	}
+
+	@Override
+	public Optional<ItemStack> getItemStack() {
+		return Optional.of(getIngredient());
+	}
+
+	@Override
+	public IIngredientType<ItemStack> getType() {
+		return VanillaTypes.ITEM_STACK;
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleItemStack{" +
+			"itemHolder=" + itemHolder +
+			'}';
+	}
+}

--- a/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/NormalizedTypedItemStack.java
+++ b/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/NormalizedTypedItemStack.java
@@ -1,0 +1,71 @@
+package mezz.jei.library.ingredients.itemStacks;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+public record NormalizedTypedItemStack(
+	Holder<Item> itemHolder,
+	DataComponentPatch dataComponentPatch
+) implements ITypedIngredient<ItemStack> {
+	public static ITypedIngredient<ItemStack> normalize(ITypedIngredient<ItemStack> typedIngredient) {
+		switch (typedIngredient) {
+			case NormalizedTypedItemStack normalized -> {
+				return normalized;
+			}
+			case NormalizedTypedItem normalized -> {
+				return normalized;
+			}
+			case TypedItemStack typedItemStack -> {
+				return create(typedItemStack.itemHolder(), typedItemStack.dataComponentPatch());
+			}
+			default -> {
+				ItemStack itemStack = typedIngredient.getIngredient();
+				return create(itemStack.getItemHolder(), itemStack.getComponentsPatch());
+			}
+		}
+	}
+
+	public static ITypedIngredient<ItemStack> create(Holder<Item> itemHolder, DataComponentPatch dataComponentPatch) {
+		if (dataComponentPatch.isEmpty()) {
+			return new NormalizedTypedItem(itemHolder);
+		}
+		return new NormalizedTypedItemStack(itemHolder, dataComponentPatch);
+	}
+
+	public static ITypedIngredient<ItemStack> create(ItemStack itemStack) {
+		return create(
+			itemStack.getItemHolder(),
+			itemStack.getComponentsPatch()
+		);
+	}
+
+	@Override
+	public ItemStack getIngredient() {
+		return new ItemStack(itemHolder, 1, dataComponentPatch);
+	}
+
+	@Override
+	public Optional<ItemStack> getItemStack() {
+		return Optional.of(getIngredient());
+	}
+
+	@Override
+	public IIngredientType<ItemStack> getType() {
+		return VanillaTypes.ITEM_STACK;
+	}
+
+	@Override
+	public String toString() {
+		return "NormalizedTypedItemStack{" +
+			"itemHolder=" + itemHolder +
+			", dataComponentPatch=" + dataComponentPatch +
+			'}';
+	}
+}

--- a/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/TypedItemStack.java
+++ b/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/TypedItemStack.java
@@ -1,0 +1,52 @@
+package mezz.jei.library.ingredients.itemStacks;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+public record TypedItemStack(
+	Holder<Item> itemHolder,
+	DataComponentPatch dataComponentPatch,
+	int count
+) implements ITypedIngredient<ItemStack> {
+	public static ITypedIngredient<ItemStack> create(ItemStack ingredient) {
+		if (ingredient.getCount() == 1) {
+			return NormalizedTypedItemStack.create(ingredient);
+		}
+		return new TypedItemStack(
+			ingredient.getItemHolder(),
+			ingredient.getComponentsPatch(),
+			ingredient.getCount()
+		);
+	}
+
+	@Override
+	public ItemStack getIngredient() {
+		return new ItemStack(itemHolder, count, dataComponentPatch);
+	}
+
+	@Override
+	public Optional<ItemStack> getItemStack() {
+		return Optional.of(getIngredient());
+	}
+
+	@Override
+	public IIngredientType<ItemStack> getType() {
+		return VanillaTypes.ITEM_STACK;
+	}
+
+	@Override
+	public String toString() {
+		return "TypedItemStack{" +
+			"itemHolder=" + itemHolder +
+			", dataComponentPatch=" + dataComponentPatch +
+			", count=" + count +
+			'}';
+	}
+}

--- a/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/package-info.java
+++ b/Library/src/main/java/mezz/jei/library/ingredients/itemStacks/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package mezz.jei.library.ingredients.itemStacks;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This PR tries to store less data per ItemStack.

The benefit is a bit debatable because ItemStacks need to be created frequently from this data in order to use them for rendering and other purposes.
The memory footprint is lower, but memory churn and cpu usage could be higher.
It'll need some testing to validate whether it's helping or hurting things.