### PR TITLE
[backport] Prevent recipe transfers from touching output slots

### DIFF
--- a/Common/src/main/java/mezz/jei/common/transfer/RecipeTransferUtil.java
+++ b/Common/src/main/java/mezz/jei/common/transfer/RecipeTransferUtil.java
@@ -101,9 +101,8 @@ public final class RecipeTransferUtil {
 				.toList();
 			if (!invalidRecipeIndexes.isEmpty()) {
 				LOGGER.error(
-					"Transfer handler has invalid slots for the destination of the recipe, " +
-						"the slots are not included in the list of crafting slots. " +
-						StringUtil.intsToString(invalidRecipeIndexes)
+					"Transfer request has invalid slots for the destination of the recipe,  the slots are not included in the list of crafting slots. {}",
+					StringUtil.intsToString(invalidRecipeIndexes)
 				);
 				return false;
 			}
@@ -118,11 +117,10 @@ public final class RecipeTransferUtil {
 				.toList();
 			if (!invalidInventorySlotIndexes.isEmpty()) {
 				LOGGER.error(
-					"Transfer handler has invalid source slots for the inventory stacks for the recipe, " +
-						"the slots are not included in the list of inventory slots or recipe slots. " +
-						StringUtil.intsToString(invalidInventorySlotIndexes) +
-						"\n inventory slots: " + StringUtil.intsToString(inventorySlotIndexes) +
-						"\n crafting slots: " + StringUtil.intsToString(craftingSlotIndexes)
+					"Transfer request has invalid source slots for the inventory stacks for the recipe, the slots are not included in the list of inventory slots or recipe slots. {}\n inventory slots: {}\n crafting slots: {}",
+					StringUtil.intsToString(invalidInventorySlotIndexes),
+					StringUtil.intsToString(inventorySlotIndexes),
+					StringUtil.intsToString(craftingSlotIndexes)
 				);
 				return false;
 			}
@@ -135,9 +133,8 @@ public final class RecipeTransferUtil {
 				.collect(Collectors.toSet());
 			if (!overlappingSlots.isEmpty()) {
 				LOGGER.error(
-					"Transfer handler has invalid slots, " +
-						"inventorySlots and craftingSlots should not share any slot, but both have: " +
-						StringUtil.intsToString(overlappingSlots)
+					"Transfer request has invalid slots, inventorySlots and craftingSlots should not share any slot, but both have: {}",
+					StringUtil.intsToString(overlappingSlots)
 				);
 				return false;
 			}
@@ -155,14 +152,31 @@ public final class RecipeTransferUtil {
 				.toList();
 			if (!invalidPickupSlots.isEmpty()) {
 				LOGGER.error(
-					"Transfer handler has invalid slots, " +
-						"the player is unable to pickup from them: " +
-						StringUtil.intsToString(invalidPickupSlots)
+					"Transfer request has invalid slots, the player is unable to pickup from them: {}",
+					StringUtil.intsToString(invalidPickupSlots)
 				);
 				return false;
 			}
 		}
 
+		// check that all slots are real (not output slots)
+		{
+			List<Integer> invalidFakeSlots = Stream.concat(
+					craftingSlots.stream(),
+					inventorySlots.stream()
+				)
+				.filter(Slot::isFake)
+				.map(slot -> slot.index)
+				.toList();
+			if (!invalidFakeSlots.isEmpty()) {
+				LOGGER.error(
+					"Transfer request has invalid slots, they are fake slots (recipe outputs): {}",
+					StringUtil.intsToString(invalidFakeSlots)
+				);
+				return false;
+			}
+		}
+		
 		return true;
 	}
 

--- a/Library/src/main/java/mezz/jei/library/transfer/BasicRecipeTransferHandler.java
+++ b/Library/src/main/java/mezz/jei/library/transfer/BasicRecipeTransferHandler.java
@@ -119,10 +119,8 @@ public class BasicRecipeTransferHandler<C extends AbstractContainerMenu, R> impl
 			return handlerHelper.createUserErrorForMissingSlots(message, transferOperations.missingItems);
 		}
 
-		{
-			if (!RecipeTransferUtil.validateSlots(player, transferOperations.results, craftingSlots, inventorySlots)) {
-				return handlerHelper.createInternalError();
-			}
+		if (!RecipeTransferUtil.validateSlots(player, transferOperations.results, craftingSlots, inventorySlots)) {
+			return handlerHelper.createInternalError();
 		}
 
 		if (doTransfer) {
@@ -145,7 +143,25 @@ public class BasicRecipeTransferHandler<C extends AbstractContainerMenu, R> impl
 		C container,
 		List<Slot> craftingSlots,
 		List<Slot> inventorySlots
-	) {
+	) {	
+		for (Slot slot : craftingSlots) {
+			if (slot.isFake()) {
+				LOGGER.error("Recipe Transfer helper {} does not work for container {}. " +
+						"The Recipe Transfer Helper references crafting slot index [{}] but it is a fake (output) slot, which is not allowed.",
+					transferInfo.getClass(), container.getClass(), slot.index
+				);
+				return false;
+			}
+		}
+		for (Slot slot : inventorySlots) {
+			if (slot.isFake()) {
+				LOGGER.error("Recipe Transfer helper {} does not work for container {}. " +
+						"The Recipe Transfer Helper references inventory slot index [{}] but it is a fake (output) slot, which is not allowed.",
+					transferInfo.getClass(), container.getClass(), slot.index
+				);
+				return false;
+			}
+		}
 		Collection<Integer> craftingSlotIndexes = slotIndexes(craftingSlots);
 		Collection<Integer> inventorySlotIndexes = slotIndexes(inventorySlots);
 		Collection<Integer> containerSlotIndexes = slotIndexes(container.slots);


### PR DESCRIPTION
Here is a vulnerability CVE-2024-41565 in your project and you fix it in the 1.21.x branch(https://github.com/mezz/JustEnoughItems/commit/99ff43ba1009c44c6d935e2ab8a6c9292bb12873). Maybe it need to be backported to the 1.20.4 branch?