### PR TITLE
Use reference set in Node instead of wrapping map

### DIFF
--- a/Core/src/main/java/mezz/jei/core/search/suffixtree/Node.java
+++ b/Core/src/main/java/mezz/jei/core/search/suffixtree/Node.java
@@ -19,6 +19,7 @@ import it.unimi.dsi.fastutil.chars.Char2ObjectArrayMap;
 import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
 import it.unimi.dsi.fastutil.chars.Char2ObjectMaps;
 import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import mezz.jei.core.util.SubString;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,7 +27,6 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.function.Consumer;
@@ -178,7 +178,7 @@ public class Node<T> extends SubString {
 			case 16 -> {
 				// "upgrade" data to a Set once it's getting bigger,
 				// to improve its `contains` performance.
-				Collection<T> newData = Collections.newSetFromMap(new IdentityHashMap<>());
+				Collection<T> newData = new ReferenceOpenHashSet<>(17);
 				newData.addAll(data);
 				newData.add(value);
 				data = newData;


### PR DESCRIPTION
This saves 5MB in my test pack. Given the IngredientFilter retained about 23MB total before, it's pretty substantial relative to the total size of the data structures.

Performance should be roughly equivalent since `IdentityHashMap` and `ReferenceOpenHashSet` are both using a flat, open addressing table under the hood.