### PR TITLE
Optimize AnvilRecipe storage

### DIFF
--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/VanillaRecipeFactory.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/VanillaRecipeFactory.java
@@ -33,7 +33,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		ErrorUtil.checkNotNull(uid, "uid");
 
-		return new AnvilRecipe(List.of(leftInput), rightInputs, outputs, uid);
+		return new AnvilRecipe(List.of(leftInput), List.copyOf(rightInputs), List.copyOf(outputs), uid);
 	}
 
 	@Override
@@ -42,7 +42,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotNull(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 
-		return new AnvilRecipe(List.of(leftInput), rightInputs, outputs, null);
+		return new AnvilRecipe(List.of(leftInput), List.copyOf(rightInputs), List.copyOf(outputs), null);
 	}
 
 	@Override
@@ -52,7 +52,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 		ErrorUtil.checkNotNull(uid, "uid");
 
-		return new AnvilRecipe(leftInputs, rightInputs, outputs, uid);
+		return new AnvilRecipe(List.copyOf(leftInputs), List.copyOf(rightInputs), List.copyOf(outputs), uid);
 	}
 
 	@Override
@@ -61,7 +61,7 @@ public class VanillaRecipeFactory implements IVanillaRecipeFactory {
 		ErrorUtil.checkNotNull(rightInputs, "rightInputs");
 		ErrorUtil.checkNotEmpty(outputs, "outputs");
 
-		return new AnvilRecipe(leftInputs, rightInputs, outputs, null);
+		return new AnvilRecipe(List.copyOf(leftInputs), List.copyOf(rightInputs), List.copyOf(outputs), null);
 	}
 
 	@Override

--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/AnvilRecipe.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/AnvilRecipe.java
@@ -13,12 +13,6 @@ public record AnvilRecipe(
 	List<ItemStack> outputs,
 	@Nullable ResourceLocation uid
 ) implements IJeiAnvilRecipe {
-	public AnvilRecipe(List<ItemStack> leftInputs, List<ItemStack> rightInputs, List<ItemStack> outputs, @Nullable ResourceLocation uid) {
-		this.leftInputs = List.copyOf(leftInputs);
-		this.rightInputs = List.copyOf(rightInputs);
-		this.outputs = List.copyOf(outputs);
-		this.uid = uid;
-	}
 
 	@Override
 	public List<ItemStack> getLeftInputs() {


### PR DESCRIPTION
This PR aims to heavily compact the storage of `AnvilRecipe` recipes in JEI. The gains are modest with vanilla/smaller modpacks (in my test 1.20.1 pack, it went from 4MB -> 600KB, so it was not that large to begin with) but I expect them to be much more significant with larger packs or with mods that store a lot of NBT on their ingredients, as the number of ItemStack copies made is greatly reduced.

Summary of changes:

1. Enchantment book recipes now store a transforming list that lazily copies the ingredient with the desired enchantment level when the list is accessed. I saw no significant regression to startup performance or UI performance from this change on my fairly weak system. The primary advantage of this change is that we should only be permanently storing one copy of the ingredient regardless of how many enchantment levels or unique enchantments it can have on it.
2. The singleton input ingredient list is now reused across all possible enchantment/enchantment level recipes.
3. The list of enchantment books is now used as-is if the item can be enchanted with every enchantment level (which I suspect is the common case). Fairly simple to do, and should not break anything as it is immutable, anyways.
4. Small cleanup of the repair recipe logic to avoid creating multiple singleton lists with the same element.

To implement 1, `AnvilRecipe` was modified to allow storing the given list in the record directly, rather than copying it to an immutable one, and the defensive copy was moved to the `VanillaRecipeFactory` API. This should not introduce bugs unless mods were using the internal `AnvilRecipe` constructor, and even then, would only cause issues if they were actually mutating their own list. Any mod using the public API still gets a defensive copy made.