### PR TITLE
Reduce initial size of sets for ingredientUidToCategoryMap

### DIFF
--- a/Library/src/main/java/mezz/jei/library/recipes/collect/RecipeMap.java
+++ b/Library/src/main/java/mezz/jei/library/recipes/collect/RecipeMap.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
  */
 public class RecipeMap {
 	private final RecipeIngredientTable recipeTable = new RecipeIngredientTable();
-	private final Multimap<Object, RecipeType<?>> ingredientUidToCategoryMap = Multimaps.newSetMultimap(new Object2ObjectOpenHashMap<>(), ObjectOpenHashSet::new);
+	private final Multimap<Object, RecipeType<?>> ingredientUidToCategoryMap = Multimaps.newSetMultimap(new Object2ObjectOpenHashMap<>(), () -> new ObjectOpenHashSet<>(2));
 	private final Multimap<Object, RecipeType<?>> categoryCatalystUidToRecipeCategoryMap = Multimaps.newSetMultimap(new Object2ObjectOpenHashMap<>(), ObjectOpenHashSet::new);
 	private final Comparator<RecipeType<?>> recipeTypeComparator;
 	private final IIngredientManager ingredientManager;


### PR DESCRIPTION
Follow-up to #3648. I noted that many `ObjectOpenHashSet`s were retained here with only 1 element, but had capacity for 16 or more elements, which is rather wasteful. This PR fixes that.