### PR TITLE
Avoid creating duplicate ResourceLocation objects for anvil enchantment recipes

### DIFF
--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -115,16 +115,16 @@ public final class AnvilRecipeMaker {
 		ItemStack ingredient
 	) {
 		var ingredientSingletonList = List.of(ingredient);
+		String ingredientId = EnchantedBookSubtypeInterpreter.INSTANCE.getStringName(ingredient);
+		String ingredientIdPath = ResourceLocationUtil.sanitizePath(ingredientId);
+		String id = "enchantment." + ingredientIdPath;
+		ResourceLocation uid = ResourceLocation.fromNamespaceAndPath(ModIds.MINECRAFT_ID, id);
 		return enchantmentDatas.stream()
 			.filter(data -> data.canEnchant(ingredient))
 			.map(data -> data.getEnchantedBooks(ingredient))
 			.filter(enchantedBooks -> !enchantedBooks.isEmpty())
 			.map(enchantedBooks -> {
 				List<ItemStack> outputs = getEnchantedIngredients(ingredient, enchantedBooks);
-				String ingredientId = EnchantedBookSubtypeInterpreter.INSTANCE.getStringName(ingredient);
-				String ingredientIdPath = ResourceLocationUtil.sanitizePath(ingredientId);
-				String id = "enchantment." + ingredientIdPath;
-				ResourceLocation uid = ResourceLocation.fromNamespaceAndPath(ModIds.MINECRAFT_ID, id);
 				// All lists given here are immutable, and we want to keep the transforming list from outputs,
 				// so we call the AnvilRecipe constructor directly
 				return new AnvilRecipe(ingredientSingletonList, enchantedBooks, outputs, uid);


### PR DESCRIPTION
This saves a couple more megabytes in ATM9NF.

Note: I found it strange that the UID does not include the specific enchantment and level (which would make it truly unique between the recipes). However, I opted to exploit that for further memory savings, rather than fix it to be unique, because I assume it was done this way for a reason, or has been like this for a while, and therefore no one is relying on it being unique among enchantment/level combos (only among unique input ingredients).

If the intent is for the UID to actually be unique for that exact recipe, this optimization can't be made. However, do note that on 1.20.1, the input ingredient's NBT is often stringified and used as part of the name - so this will again cause exponential growth if items with large NBT get enchanted.