### PR TITLE
add control to force potentially existing bookmark to top of list

### DIFF
--- a/Common/src/main/java/mezz/jei/common/input/IInternalKeyMappings.java
+++ b/Common/src/main/java/mezz/jei/common/input/IInternalKeyMappings.java
@@ -23,6 +23,7 @@ public interface IInternalKeyMappings extends IJeiKeyMappings {
 	IJeiKeyMapping getCloseRecipeGui();
 
 	IJeiKeyMapping getBookmark();
+	IJeiKeyMapping getForceBookmark();
 	IJeiKeyMapping getToggleBookmarkOverlay();
 
 	@Override

--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -84,6 +84,7 @@
 
   "jei.key.category.mouse.hover": "JEI (Hovering With Mouse)",
   "key.jei.bookmark": "Add/Remove Bookmark",
+  "key.jei.forceBookmark": "Replace Bookmark",
   "key.jei.showRecipe": "Show Recipe",
   "key.jei.showRecipe2": "Show Recipe",
   "key.jei.showUses": "Show Uses",

--- a/Gui/src/main/java/mezz/jei/gui/bookmarks/BookmarkList.java
+++ b/Gui/src/main/java/mezz/jei/gui/bookmarks/BookmarkList.java
@@ -90,19 +90,24 @@ public class BookmarkList implements IIngredientGridSource {
 		return this.bookmarksSet.contains(value);
 	}
 
-	public <T> boolean onElementBookmarked(IElement<T> element, boolean shouldForce) {
-		return element.getBookmark()
-			.map(this::remove)
-			.orElseGet(() -> {
-				ITypedIngredient<T> ingredient = element.getTypedIngredient();
-				IBookmark bookmark = IngredientBookmark.create(ingredient, ingredientManager);
-				return add(bookmark, shouldForce);
-			});
+	public <T> boolean onElementBookmarked(IElement<T> element, boolean shouldForceAdd) {
+		boolean didExist = element.getBookmark()
+					.map(this::remove)
+					.orElse(false);
+
+		if(shouldForceAdd || !didExist) {
+			ITypedIngredient<T> ingredient = element.getTypedIngredient();
+			IBookmark bookmark = IngredientBookmark.create(ingredient, ingredientManager);
+			return add(bookmark, shouldForceAdd);
+		}
+		return true;
 	}
 
-	public void toggleBookmark(IBookmark bookmark) {
+	public void toggleBookmark(IBookmark bookmark, boolean shouldAddBack) {
 		if (remove(bookmark)) {
-			return;
+			if(!shouldAddBack) {
+				return;
+			}
 		}
 		add(bookmark, false);
 	}

--- a/Gui/src/main/java/mezz/jei/gui/config/InternalKeyMappings.java
+++ b/Gui/src/main/java/mezz/jei/gui/config/InternalKeyMappings.java
@@ -32,6 +32,7 @@ public final class InternalKeyMappings implements IInternalKeyMappings {
 	private final IJeiKeyMapping nextPage;
 
 	private final IJeiKeyMapping bookmark;
+	private final IJeiKeyMapping forceBookmark;
 	private final IJeiKeyMapping toggleBookmarkOverlay;
 	private final IJeiKeyMapping transferRecipeBookmark;
 	private final IJeiKeyMapping maxTransferRecipeBookmark;
@@ -126,6 +127,12 @@ public final class InternalKeyMappings implements IInternalKeyMappings {
 		// Mouse Hover
 		bookmark = mouseHover.createMapping("key.jei.bookmark")
 			.setContext(JeiKeyConflictContext.JEI_GUI_HOVER)
+			.buildKeyboardKey(GLFW.GLFW_KEY_A)
+			.register(registerMethod);
+		// Mouse Hover
+		forceBookmark = mouseHover.createMapping("key.jei.forceBookmark")
+			.setContext(JeiKeyConflictContext.JEI_GUI_HOVER)
+			.setModifier(JeiKeyModifier.SHIFT)
 			.buildKeyboardKey(GLFW.GLFW_KEY_A)
 			.register(registerMethod);
 
@@ -367,6 +374,11 @@ public final class InternalKeyMappings implements IInternalKeyMappings {
 	@Override
 	public IJeiKeyMapping getBookmark() {
 		return bookmark;
+	}
+
+	@Override
+	public IJeiKeyMapping getForceBookmark() {
+		return forceBookmark;
 	}
 
 	@Override

--- a/Gui/src/main/java/mezz/jei/gui/input/handlers/BookmarkInputHandler.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/handlers/BookmarkInputHandler.java
@@ -20,18 +20,21 @@ public class BookmarkInputHandler implements IUserInputHandler {
 
 	@Override
 	public Optional<IUserInputHandler> handleUserInput(Screen screen, UserInput input, IInternalKeyMappings keyBindings) {
-		if (input.is(keyBindings.getBookmark())) {
-			return handleBookmark(input, keyBindings);
+		if (input.is(keyBindings.getForceBookmark())) {
+			return handleBookmark(input, keyBindings, true);
+		}
+		else if (input.is(keyBindings.getBookmark())) {
+			return handleBookmark(input, keyBindings, false);
 		}
 		return Optional.empty();
 	}
 
-	private Optional<IUserInputHandler> handleBookmark(UserInput input, IInternalKeyMappings keyBindings) {
+	private Optional<IUserInputHandler> handleBookmark(UserInput input, IInternalKeyMappings keyBindings, boolean shouldForce) {
 		return focusSource.getIngredientUnderMouse(input, keyBindings)
 			.findFirst()
 			.flatMap(clicked -> {
 				if (input.isSimulate() ||
-					bookmarkList.onElementBookmarked(clicked.getElement())
+					bookmarkList.onElementBookmarked(clicked.getElement(), shouldForce)
 				) {
 					IUserInputHandler handler = new SameElementInputHandler(this, clicked::isMouseOver);
 					return Optional.of(handler);

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeBookmarkButton.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeBookmarkButton.java
@@ -87,7 +87,7 @@ public class RecipeBookmarkButton extends GuiIconToggleButton {
 	protected boolean onMouseClicked(UserInput input) {
 		if (recipeBookmark != null) {
 			if (!input.isSimulate()) {
-				bookmarks.toggleBookmark(recipeBookmark);
+				bookmarks.toggleBookmark(recipeBookmark, false);
 			}
 			return true;
 		}


### PR DESCRIPTION
I am the type of player that bookmarks items, but doesn't remove them once done with that item (or the item is used through out the pack). This becomes annoying when I want to put an item near the top of the list (the setting I use), but it is already in the bookmark list.

This PR adds the "shift + a" keybind, which removes an existing bookmark, and adds it back. If the item was not already bookmarked, it is added as if the normal "a" keybind was pressed