### PR TITLE
Implement variable sized item recipe transfer handler

### DIFF
--- a/Common/src/main/java/mezz/jei/common/network/packets/PacketRecipeTransfer.java
+++ b/Common/src/main/java/mezz/jei/common/network/packets/PacketRecipeTransfer.java
@@ -27,7 +27,9 @@ public class PacketRecipeTransfer extends PlayToServerPacket<PacketRecipeTransfe
 		p -> p.maxTransfer,
 		ByteBufCodecs.BOOL,
 		p -> p.requireCompleteSets,
-		PacketRecipeTransfer::new
+			ByteBufCodecs.VAR_INT.apply(ByteBufCodecs.list()),
+			p->p.itemTransferAmounts,
+			PacketRecipeTransfer::new
 	);
 
 	public final List<TransferOperation> transferOperations;
@@ -35,36 +37,39 @@ public class PacketRecipeTransfer extends PlayToServerPacket<PacketRecipeTransfe
 	public final List<Integer> inventorySlots;
 	private final boolean maxTransfer;
 	private final boolean requireCompleteSets;
+	private final List<Integer> itemTransferAmounts;
 
 	public static PacketRecipeTransfer fromSlots(
 			List<TransferOperation> transferOperations,
 			List<Slot> craftingSlots,
 			List<Slot> inventorySlots,
 			boolean maxTransfer,
-			boolean requireCompleteSets
-	) {
+			boolean requireCompleteSets,
+			List<Integer> itemTransferAmounts) {
 		return new PacketRecipeTransfer(
 				transferOperations,
 				craftingSlots.stream().map(s -> s.index).toList(),
 				inventorySlots.stream().map(s -> s.index).toList(),
 				maxTransfer,
-				requireCompleteSets
+				requireCompleteSets,
+				itemTransferAmounts
 		);
 	}
 
 	public PacketRecipeTransfer(
-		List<TransferOperation> transferOperations,
-		List<Integer> craftingSlots,
-		List<Integer> inventorySlots,
-		boolean maxTransfer,
-		boolean requireCompleteSets
-	) {
+            List<TransferOperation> transferOperations,
+            List<Integer> craftingSlots,
+            List<Integer> inventorySlots,
+            boolean maxTransfer,
+            boolean requireCompleteSets, List<Integer> itemTransferAmounts
+    ) {
 		this.transferOperations = transferOperations;
 		this.craftingSlots = craftingSlots;
 		this.inventorySlots = inventorySlots;
 		this.maxTransfer = maxTransfer;
 		this.requireCompleteSets = requireCompleteSets;
-	}
+        this.itemTransferAmounts = itemTransferAmounts;
+    }
 
 	@Override
 	public Type<PacketRecipeTransfer> type() {
@@ -85,7 +90,8 @@ public class PacketRecipeTransfer extends PlayToServerPacket<PacketRecipeTransfe
 				craftingSlots.stream().map(container::getSlot).toList(),
 				inventorySlots.stream().map(container::getSlot).toList(),
 				maxTransfer,
-				requireCompleteSets
+				requireCompleteSets,
+				itemTransferAmounts
 		);
 	}
 

--- a/CommonApi/src/main/java/mezz/jei/api/IModPlugin.java
+++ b/CommonApi/src/main/java/mezz/jei/api/IModPlugin.java
@@ -1,6 +1,7 @@
 package mezz.jei.api;
 
 import mezz.jei.api.helpers.IPlatformFluidHelper;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import mezz.jei.api.registration.IIngredientAliasRegistration;
 import mezz.jei.api.registration.IModInfoRegistration;
 import mezz.jei.api.registration.IRuntimeRegistration;
@@ -111,7 +112,7 @@ public interface IModPlugin {
 	/**
 	 * Register recipe transfer handlers (move ingredients from the inventory into crafting GUIs).
 	 */
-	default void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
+	default void registerRecipeTransferHandlers(IRecipeTransferRegistration registration, IRecipeTransferHandlerHelper transferHandlerHelper) {
 
 	}
 

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
@@ -54,7 +54,7 @@ public interface IRecipeTransferHandler<C extends AbstractContainerMenu, R> {
 	IRecipeTransferError transferRecipe(C container, R recipe, IRecipeSlotsView recipeSlots, Player player, boolean maxTransfer, boolean doTransfer);
 
 	/**
-	 * Provide here how many items to transfer for each requested item stack
+	 * Provide here how many items to transfer for each requested item stack, typically, item amounts in the recipe
 	 * @return list of amounts for items to transfer
 	 */
 	default List<Integer> getItemTransferAmounts(R recipe)

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -51,4 +52,10 @@ public interface IRecipeTransferHandler<C extends AbstractContainerMenu, R> {
 	 */
 	@Nullable
 	IRecipeTransferError transferRecipe(C container, R recipe, IRecipeSlotsView recipeSlots, Player player, boolean maxTransfer, boolean doTransfer);
+
+	default List<Integer> getItemTransferAmounts(R recipe)
+	{
+		return List.of();
+	}
+
 }

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandler.java
@@ -53,6 +53,10 @@ public interface IRecipeTransferHandler<C extends AbstractContainerMenu, R> {
 	@Nullable
 	IRecipeTransferError transferRecipe(C container, R recipe, IRecipeSlotsView recipeSlots, Player player, boolean maxTransfer, boolean doTransfer);
 
+	/**
+	 * Provide here how many items to transfer for each requested item stack
+	 * @return list of amounts for items to transfer
+	 */
 	default List<Integer> getItemTransferAmounts(R recipe)
 	{
 		return List.of();

--- a/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandlerHelper.java
+++ b/CommonApi/src/main/java/mezz/jei/api/recipe/transfer/IRecipeTransferHandlerHelper.java
@@ -3,6 +3,7 @@ package mezz.jei.api.recipe.transfer;
 import mezz.jei.api.gui.ingredient.ICraftingGridHelper;
 import mezz.jei.api.gui.ingredient.IRecipeSlotView;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IStackHelper;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.transfer.IRecipeTransferError.Type;
 import mezz.jei.api.registration.IRecipeTransferRegistration;
@@ -102,4 +103,6 @@ public interface IRecipeTransferHandlerHelper {
 	 * @since 19.16.1
 	 */
 	Map<Integer, Ingredient> getGuiSlotIndexToIngredientMap(RecipeHolder<CraftingRecipe> recipeHolder);
+
+	IStackHelper getStackHelper();
 }

--- a/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
+++ b/Library/src/main/java/mezz/jei/library/load/PluginLoader.java
@@ -160,7 +160,7 @@ public final class PluginLoader {
 			.orElseThrow(() -> new NullPointerException("vanilla crafting category"));
 		IRecipeTransferHandlerHelper handlerHelper = new RecipeTransferHandlerHelper(stackHelper, craftingCategory);
 		RecipeTransferRegistration recipeTransferRegistration = new RecipeTransferRegistration(stackHelper, handlerHelper, jeiHelpers, connectionToServer);
-		PluginCaller.callOnPlugins("Registering recipes transfer handlers", plugins, p -> p.registerRecipeTransferHandlers(recipeTransferRegistration));
+		PluginCaller.callOnPlugins("Registering recipes transfer handlers", plugins, p -> p.registerRecipeTransferHandlers(recipeTransferRegistration, handlerHelper));
 		return recipeTransferRegistration.createRecipeTransferManager();
 	}
 

--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/VanillaPlugin.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/VanillaPlugin.java
@@ -302,7 +302,7 @@ public class VanillaPlugin implements IModPlugin {
 	}
 
 	@Override
-	public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
+	public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration, IRecipeTransferHandlerHelper transferHandlerHelper) {
 		registration.addRecipeTransferHandler(CraftingMenu.class, MenuType.CRAFTING, RecipeTypes.CRAFTING, 1, 9, 10, 36);
 		registration.addRecipeTransferHandler(CrafterMenu.class, MenuType.CRAFTER_3x3, RecipeTypes.CRAFTING, 0, 9, 9, 36);
 		registration.addRecipeTransferHandler(FurnaceMenu.class, MenuType.FURNACE, RecipeTypes.SMELTING, 0, 1, 3, 36);

--- a/Library/src/main/java/mezz/jei/library/transfer/BasicRecipeTransferHandler.java
+++ b/Library/src/main/java/mezz/jei/library/transfer/BasicRecipeTransferHandler.java
@@ -130,7 +130,8 @@ public class BasicRecipeTransferHandler<C extends AbstractContainerMenu, R> impl
 				craftingSlots,
 				inventorySlots,
 				maxTransfer,
-				requireCompleteSets
+				requireCompleteSets,
+					getItemTransferAmounts(recipe)
 			);
 			serverConnection.sendPacketToServer(packet);
 		}

--- a/Library/src/main/java/mezz/jei/library/transfer/RecipeTransferHandlerHelper.java
+++ b/Library/src/main/java/mezz/jei/library/transfer/RecipeTransferHandlerHelper.java
@@ -95,4 +95,9 @@ public class RecipeTransferHandlerHelper implements IRecipeTransferHandlerHelper
 		ImmutableSize2i recipeSize = craftingRecipeCategory.getRecipeSize(recipeHolder);
 		return CraftingGridHelper.getGuiSlotToIngredientMap(recipeHolder, recipeSize.width(), recipeSize.height());
 	}
+
+	@Override
+	public IStackHelper getStackHelper() {
+		return stackHelper;
+	}
 }


### PR DESCRIPTION
This PR makes it possible to properly implement item transfer handler for recipes that have inputs with variable item stack size inputs.
For this I added a default method to IRecipeTransferHandler, where a user can return item stack sizes for transferred items.
This method is then passed to BasicRecipeTransferHandlerServer through PacketRecipeTransfer. If the list is empty, transfer behaves as before, otherwise stack sizes are given to net.minecraft.world.inventory.Slot#safeTake, which handles item extraction.
Also I had to replace 3 hash maps with linked hash maps to preserve stack size to slot mapping.
I exposed IRecipeTransferHandlerHelper in the transfer handler registration method to allow getting IStackHelper for use in transfer handler instantiation.
I tested these changes in my mod I'm developing. I have custom recipe type that can have input items with variable size, so I decided to make this PR.