### PR TITLE
Fix translation in zh_cn.json

### DIFF
--- a/Common/src/main/resources/assets/jei/lang/zh_cn.json
+++ b/Common/src/main/resources/assets/jei/lang/zh_cn.json
@@ -7,7 +7,7 @@
   "jei.tooltip.liquid.amount": "%s mB",
   "jei.tooltip.liquid.flowing": "%s (流动中)",
   "jei.tooltip.transfer": "转移物品",
-  "jei.tooltip.recipe.tag": "接受下列任何物品：%s",
+  "jei.tooltip.recipe.tag": "接受标签中的原料：%s",
   "jei.tooltip.item.colors": "颜色：%s",
   "jei.tooltip.item.search.aliases": "搜索别名:",
   "jei.tooltip.shapeless.recipe": "无序配方",


### PR DESCRIPTION
The translation of `"jei.tooltip.recipe.tag"` (en_us: `Accepts tag: %s`) in zh_cn  is `"接受下列任何物品：%s"`, which means "Accept any of the following **items**: %s" literally. However, in the game this translation key can be used for any recipes with tagged ingredients, including items, fluids or any custom tagged ingredients. This could sometimes confuse players when they see a non-item ingredient with this tooltip. The new translation means "Accept **ingredients** in the tag: %s" which could make better understanding.

![image](https://github.com/user-attachments/assets/c0039405-2c6c-463f-9814-82ca1568c79f)
