### PR TITLE
Don't draw tooltips in exclusion areas

### DIFF
--- a/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -99,7 +99,9 @@ public class IngredientGridWithNavigation implements IShowsRecipeFocuses, IMouse
 	}
 
 	public void drawTooltips(Minecraft minecraft, int mouseX, int mouseY) {
-		this.ingredientGrid.drawTooltips(minecraft, mouseX, mouseY);
+		if (!this.guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY)) {
+			this.ingredientGrid.drawTooltips(minecraft, mouseX, mouseY);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Prevents JEI tooltips from being drawn in zones marked as exclusion zones. Prevents issues with some moveable GUI elements and JEI tooltips.