### PR TITLE
made CraftingGridHelper.getCraftingIndex better readable 

### DIFF
--- a/Library/src/main/java/mezz/jei/library/gui/helpers/CraftingGridHelper.java
+++ b/Library/src/main/java/mezz/jei/library/gui/helpers/CraftingGridHelper.java
@@ -182,31 +182,11 @@ public class CraftingGridHelper implements ICraftingGridHelper {
 	}
 
 	private static int getCraftingIndex(int i, int width, int height) {
-		int index;
-		if (width == 1) {
-			if (height == 3) {
-				index = (i * 3) + 1;
-			} else if (height == 2) {
-				index = (i * 3) + 1;
-			} else {
-				index = 4;
-			}
-		} else if (height == 1) {
-			index = i + 3;
-		} else if (width == 2) {
-			index = i;
-			if (i > 1) {
-				index++;
-				if (i > 3) {
-					index++;
-				}
-			}
-		} else if (height == 2) {
-			index = i + 3;
-		} else {
-			index = i;
-		}
-		return index;
+		int row = i / width;
+        int col = i % width;
+		int GRID_WIDTH = 3;
+
+        return row * GRID_WIDTH + col;
 	}
 
 }


### PR DESCRIPTION
technically allows arbitrary height + width of the crafting grid but ofc that helper is for vanilla crafting tables. only needs to know the input recipe width and the crafting grid width, heights get auto aligned.