### PR TITLE
Fix vanilla/JEI search bar focus conflict

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/input/handlers/TextFieldInputHandler.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/handlers/TextFieldInputHandler.java
@@ -1,11 +1,15 @@
 package mezz.jei.gui.input.handlers;
 
 import mezz.jei.common.input.IInternalKeyMappings;
+import mezz.jei.core.util.ReflectionUtil;
 import mezz.jei.core.util.TextHistory;
 import mezz.jei.gui.input.GuiTextFieldFilter;
 import mezz.jei.gui.input.IUserInputHandler;
 import mezz.jei.gui.input.UserInput;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 
 import java.util.Optional;
 
@@ -65,6 +69,7 @@ public class TextFieldInputHandler implements IUserInputHandler {
 		if (textFieldFilter.isFocused() != focused) {
 			if (!input.isSimulate()) {
 				textFieldFilter.setFocused(focused);
+				handleVanillaSearchBox(!focused);
 			}
 			return true;
 		}
@@ -75,6 +80,7 @@ public class TextFieldInputHandler implements IUserInputHandler {
 		if (!input.isSimulate()) {
 			textFieldFilter.setValue("");
 			textFieldFilter.setFocused(true);
+			handleVanillaSearchBox(false);
 		}
 		return true;
 	}
@@ -97,5 +103,19 @@ public class TextFieldInputHandler implements IUserInputHandler {
 	@Override
 	public void unfocus() {
 		textFieldFilter.setFocused(false);
+		handleVanillaSearchBox(true);
+	}
+
+	private void handleVanillaSearchBox(boolean focused) {
+		if (Minecraft.getInstance().screen instanceof CreativeModeInventoryScreen screen) {
+			ReflectionUtil reflectionUtil = new ReflectionUtil();
+			Optional<EditBox> field = reflectionUtil.getFieldWithClass(screen, EditBox.class).findFirst();
+			field.ifPresent(searchBox -> {
+				if (searchBox.isVisible()) {
+					searchBox.setCanLoseFocus(!focused);
+					searchBox.setFocused(focused);
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
Aims to fix the issue raised in #3981, making it possible to select and type into the JEI search bar even when the vanilla search tab is open. Clicking away from the JEI search bar returns focus to vanilla.

![image](https://github.com/user-attachments/assets/9eded56c-a4c7-4089-9087-6a6e6bbae59d)

This is my first attempt at contributing to a project and I tried my best to understand the process and code--I apologize if I've gone about things incorrectly or implemented inefficiently! Let me know if there is anything I can do. I appreciate your work :)