### PR TITLE
Add minimum height to RecipeGui

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -62,6 +62,7 @@ public class RecipesGui extends Screen implements IRecipesGui, IRecipeFocusSourc
 	private static final int smallButtonWidth = 13;
 	private static final int smallButtonHeight = 13;
 	private static final int minGuiWidth = 198;
+	private static final int minGuiHeight = 198;
 
 	private final IInternalKeyMappings keyBindings;
 	private final BookmarkList bookmarks;
@@ -175,12 +176,12 @@ public class RecipesGui extends Screen implements IRecipesGui, IRecipeFocusSourc
 		super.init();
 
 		final int xSize = minGuiWidth;
-		int ySize;
+		int ySize = Math.max(this.height, minGuiHeight);
 		IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
 		if (clientConfig.isCenterSearchBarEnabled()) {
-			ySize = this.height - 76;
+			ySize -= 76;
 		} else {
-			ySize = this.height - 58;
+			ySize -= 58;
 		}
 		int extraSpace = 0;
 		final int maxHeight = clientConfig.getMaxRecipeGuiHeight();


### PR DESCRIPTION
Prevents small window sizes from crashing the game. Without this change RecipeGui might try to draw a rectangle with negative dimensions, causing a crash.

This pull request is for 1.21.1, but this issue should exist on 1.21.x and perhaps older versions as well.

Fixes [issue 4033](https://github.com/mezz/JustEnoughItems/issues/4033)