### PR TITLE
Collate various potion reagents into single recipe (#4035)

### DIFF
--- a/Library/src/main/java/mezz/jei/library/util/BrewingRecipeMakerCommon.java
+++ b/Library/src/main/java/mezz/jei/library/util/BrewingRecipeMakerCommon.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class BrewingRecipeMakerCommon {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -122,7 +123,8 @@ public class BrewingRecipeMakerCommon {
 			String inputPathId = PotionSubtypeInterpreter.INSTANCE.getStringName(potionInput);
 
 			for (ItemStack potionReagent : potionReagents) {
-				ItemStack potionOutput = getOutput(potionBrewing, potionInput.copy(), potionReagent);
+				ItemStack potionInputCopy = potionInput.copy();
+				ItemStack potionOutput = getOutput(potionBrewing, potionInputCopy, potionReagent);
 				if (potionOutput.isEmpty()) {
 					continue;
 				}
@@ -143,15 +145,35 @@ public class BrewingRecipeMakerCommon {
 				String outputPathId = PotionSubtypeInterpreter.INSTANCE.getStringName(potionOutput);
 				String outputModId = outputResourceLocation.getNamespace();
 				String uidPath = ResourceLocationUtil.sanitizePath(inputPathId + ".to." + outputPathId);
+				ResourceLocation fullUid = ResourceLocation.fromNamespaceAndPath(outputModId, uidPath);
 				IJeiBrewingRecipe recipe = recipeFactory.createBrewingRecipe(
 					List.of(potionReagent),
-					potionInput.copy(),
+					potionInputCopy,
 					potionOutput,
-					ResourceLocation.fromNamespaceAndPath(outputModId, uidPath)
+				fullUid
 				);
 				if (!recipes.contains(recipe)) {
 					recipes.add(recipe);
 					newPotions.add(potionOutput);
+				} else {
+					IJeiBrewingRecipe existingRecipe = recipes.stream().filter(r -> r.equals(recipe)).findFirst().orElse(null);
+		if (existingRecipe == null) {
+			LOGGER.error("The 'existing' brewing recipe with the uid {} could not be found to merge additional reagent {}.", fullUid, itemStackHelper.getResourceLocation(potionReagent));
+			continue;
+		}
+		if (existingRecipe.getIngredients().stream().noneMatch(reagent -> ItemStack.isSameItemSameComponents(reagent, potionReagent))) {
+						IJeiBrewingRecipe replacementRecipe = recipeFactory.createBrewingRecipe(
+						Stream.concat(
+				existingRecipe.getIngredients().stream(),
+				Stream.of(potionReagent)
+			).toList(),
+						potionInputCopy,
+							potionOutput,
+							fullUid
+						);
+						recipes.remove(recipe);
+						recipes.add(replacementRecipe);
+					}
 				}
 			}
 		}

--- a/Library/src/main/java/mezz/jei/library/util/BrewingRecipeMakerCommon.java
+++ b/Library/src/main/java/mezz/jei/library/util/BrewingRecipeMakerCommon.java
@@ -150,24 +150,24 @@ public class BrewingRecipeMakerCommon {
 					List.of(potionReagent),
 					potionInputCopy,
 					potionOutput,
-				fullUid
+					fullUid
 				);
 				if (!recipes.contains(recipe)) {
 					recipes.add(recipe);
 					newPotions.add(potionOutput);
 				} else {
 					IJeiBrewingRecipe existingRecipe = recipes.stream().filter(r -> r.equals(recipe)).findFirst().orElse(null);
-		if (existingRecipe == null) {
-			LOGGER.error("The 'existing' brewing recipe with the uid {} could not be found to merge additional reagent {}.", fullUid, itemStackHelper.getResourceLocation(potionReagent));
-			continue;
-		}
-		if (existingRecipe.getIngredients().stream().noneMatch(reagent -> ItemStack.isSameItemSameComponents(reagent, potionReagent))) {
+					if (existingRecipe == null) {
+						LOGGER.error("The 'existing' brewing recipe with the uid {} could not be found to merge additional reagent {}.", fullUid, itemStackHelper.getResourceLocation(potionReagent));
+						continue;
+					}
+					if (existingRecipe.getIngredients().stream().noneMatch(reagent -> ItemStack.isSameItemSameComponents(reagent, potionReagent))) {
 						IJeiBrewingRecipe replacementRecipe = recipeFactory.createBrewingRecipe(
-						Stream.concat(
-				existingRecipe.getIngredients().stream(),
-				Stream.of(potionReagent)
-			).toList(),
-						potionInputCopy,
+							Stream.concat(
+								existingRecipe.getIngredients().stream(),
+								Stream.of(potionReagent)
+							).toList(),
+							potionInputCopy,
 							potionOutput,
 							fullUid
 						);

--- a/Library/src/main/java/mezz/jei/library/util/BrewingRecipeMakerCommon.java
+++ b/Library/src/main/java/mezz/jei/library/util/BrewingRecipeMakerCommon.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class BrewingRecipeMakerCommon {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -145,33 +144,35 @@ public class BrewingRecipeMakerCommon {
 				String outputPathId = PotionSubtypeInterpreter.INSTANCE.getStringName(potionOutput);
 				String outputModId = outputResourceLocation.getNamespace();
 				String uidPath = ResourceLocationUtil.sanitizePath(inputPathId + ".to." + outputPathId);
-				ResourceLocation fullUid = ResourceLocation.fromNamespaceAndPath(outputModId, uidPath);
 				IJeiBrewingRecipe recipe = recipeFactory.createBrewingRecipe(
 					List.of(potionReagent),
 					potionInputCopy,
 					potionOutput,
-					fullUid
+					ResourceLocation.fromNamespaceAndPath(outputModId, uidPath)
 				);
-				if (!recipes.contains(recipe)) {
+
+				IJeiBrewingRecipe existingRecipe = recipes.stream()
+					.filter(recipe::equals)
+					.findFirst()
+					.orElse(null);
+				if (existingRecipe == null) {
 					recipes.add(recipe);
 					newPotions.add(potionOutput);
 				} else {
-					IJeiBrewingRecipe existingRecipe = recipes.stream().filter(r -> r.equals(recipe)).findFirst().orElse(null);
-					if (existingRecipe == null) {
-						LOGGER.error("The 'existing' brewing recipe with the uid {} could not be found to merge additional reagent {}.", fullUid, itemStackHelper.getResourceLocation(potionReagent));
-						continue;
-					}
-					if (existingRecipe.getIngredients().stream().noneMatch(reagent -> ItemStack.isSameItemSameComponents(reagent, potionReagent))) {
+					// This is a recipe with the same uid and output as an existing recipe,
+					// but it has a different reagent.
+					// Create a recipe that combines the two.
+					IngredientSet<ItemStack> reagents = new IngredientSet<>(itemStackHelper, UidContext.Recipe);
+					reagents.addAll(existingRecipe.getIngredients());
+					reagents.add(potionReagent);
+					if (reagents.size() != existingRecipe.getIngredients().size()) {
 						IJeiBrewingRecipe replacementRecipe = recipeFactory.createBrewingRecipe(
-							Stream.concat(
-								existingRecipe.getIngredients().stream(),
-								Stream.of(potionReagent)
-							).toList(),
-							potionInputCopy,
-							potionOutput,
-							fullUid
+							List.copyOf(reagents),
+							existingRecipe.getPotionInputs(),
+							existingRecipe.getPotionOutput(),
+							existingRecipe.getUid()
 						);
-						recipes.remove(recipe);
+						recipes.remove(existingRecipe);
 						recipes.add(replacementRecipe);
 					}
 				}


### PR DESCRIPTION
This PR fixes #4035 

JeiBrewingRecipe instances created by BrewingRecipeMakerCommon are given a uid that combines purely the input potion type and the output potion type.

This uid is used in equality checks, which means that additional recipes for a potion with an existing recipe are completely ignored.

Instead of modifying the uid to include the reagent, this instead collates existing reagents and, if the reagent of the "new" recipe isn't already contained, replaces the existing recipe with a new one that includes all previous reagents.

This seemed a better option and more inline with how JEI already handles inputs that produce the same output than creating separate recipes.

There could potentially be an issue with custom implementations of IJeiBrewingRecipe, specifically those that directly subclass JeiBrewingRecipe, and do "complicated things" with ingredients, as those would be replaced with a standard JeiBrewingRecipe. I'm not sure if it's an edge case that can occur to require direct checking. All other implementations would fail JeiBrewingRecipe's equality check.

Finally, my only remaining concern with this solution is `BrewingRecipeUtil::addRecipe` which is manually called by `JeiBrewingRecipe`'s class initializer. As it appears to be set-backed, I don't think the additional creation of a new JeiBrewingRecipe would have any impact on it.

Separate to JEI's code base, there is the potential for mods who have noticed this bug and have implemented their own solution to fix it by registering additional recipes. I'm unaware of any mods that do this, however.

EDIT: There appears to be formatting issues with this commit. When I was publishing to local maven to test in Roots 4, the `build` refused to run unless I executed `:applySpotless`. I didn't see a code style file in order to be able to fix it myself.