### PR TITLE
Hook into fabric recipe sync.

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItems.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItems.java
@@ -12,11 +12,15 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.recipe.v1.sync.RecipeSynchronization;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-
-import java.util.Objects;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class JustEnoughItems implements ModInitializer {
+	private static final Logger LOGGER = LogManager.getLogger();
+
 	@Override
 	public void onInitialize() {
 		IServerConfig serverConfig = ServerConfig.getInstance();
@@ -28,10 +32,16 @@ public class JustEnoughItems implements ModInitializer {
 		var registered = Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, resourceLocation, recipeSerializer);
 		RecipeSerializers.register(() -> registered);
 
-		// Run through vanilla recipe serializaers and sync them
-		for (var serializer : BuiltInRegistries.RECIPE_SERIALIZER.keySet()) {
-			if (serializer.getNamespace().equals(ResourceLocation.DEFAULT_NAMESPACE)) {
-				RecipeSynchronization.synchronizeRecipeSerializer(Objects.requireNonNull(BuiltInRegistries.RECIPE_SERIALIZER.getValue(serializer)));
+		// Run through vanilla recipe serializers and sync them
+		for (var entry : BuiltInRegistries.RECIPE_SERIALIZER.entrySet()) {
+			ResourceKey<RecipeSerializer<?>> resourceKey = entry.getKey();
+			if (resourceKey.location().getNamespace().equals(ModIds.MINECRAFT_ID)) {
+				RecipeSerializer<?> serializer = entry.getValue();
+				try {
+					RecipeSynchronization.synchronizeRecipeSerializer(serializer);
+				} catch (RuntimeException e) {
+					LOGGER.warn("Failed to synchronize recipe serializer {}", resourceKey, e);
+				}
 			}
 		}
 	}

--- a/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItems.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItems.java
@@ -9,9 +9,12 @@ import mezz.jei.fabric.network.ServerNetworkHandler;
 import mezz.jei.library.plugins.vanilla.crafting.JeiShapedRecipe;
 import mezz.jei.library.recipes.RecipeSerializers;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.recipe.v1.sync.RecipeSynchronization;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+
+import java.util.Objects;
 
 public class JustEnoughItems implements ModInitializer {
 	@Override
@@ -24,5 +27,13 @@ public class JustEnoughItems implements ModInitializer {
 		var recipeSerializer = new JeiShapedRecipe.Serializer();
 		var registered = Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, resourceLocation, recipeSerializer);
 		RecipeSerializers.register(() -> registered);
+		RecipeSynchronization.synchronizeRecipeSerializer(recipeSerializer);
+
+		// Run through vanilla recipe serializaers and sync them
+		for (var serializer : BuiltInRegistries.RECIPE_SERIALIZER.keySet()) {
+			if (serializer.getNamespace().equals(ResourceLocation.DEFAULT_NAMESPACE)) {
+				RecipeSynchronization.synchronizeRecipeSerializer(Objects.requireNonNull(BuiltInRegistries.RECIPE_SERIALIZER.getValue(serializer)));
+			}
+		}
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItems.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItems.java
@@ -27,7 +27,6 @@ public class JustEnoughItems implements ModInitializer {
 		var recipeSerializer = new JeiShapedRecipe.Serializer();
 		var registered = Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, resourceLocation, recipeSerializer);
 		RecipeSerializers.register(() -> registered);
-		RecipeSynchronization.synchronizeRecipeSerializer(recipeSerializer);
 
 		// Run through vanilla recipe serializaers and sync them
 		for (var serializer : BuiltInRegistries.RECIPE_SERIALIZER.keySet()) {

--- a/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItemsClient.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItemsClient.java
@@ -11,10 +11,12 @@ import mezz.jei.fabric.plugins.fabric.FabricGuiPlugin;
 import mezz.jei.fabric.startup.ClientLifecycleHandler;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent;
 import net.fabricmc.fabric.api.resource.v1.ResourceLoader;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.minecraft.world.item.crafting.RecipeMap;
 
 @SuppressWarnings("unused")
 public class JustEnoughItemsClient implements ClientModInitializer {
@@ -22,6 +24,11 @@ public class JustEnoughItemsClient implements ClientModInitializer {
 	public void onInitializeClient() {
 		Translator.setLocaleSupplier(new MinecraftLocaleSupplier());
 		ClientLifecycleHandler clientLifecycleHandler = new ClientLifecycleHandler();
+
+		ClientRecipeSynchronizedEvent.EVENT.register((minecraft, synchronizedRecipes) -> {
+            Internal.setClientSyncedRecipes(RecipeMap.create(synchronizedRecipes.recipes()));
+			JeiLifecycleEvents.AFTER_RECIPE_SYNC.invoker().run();
+		});
 
 		JeiLifecycleEvents.REGISTER_RESOURCE_RELOAD_LISTENER.register((resourceManager, textureManager) -> {
 			Textures textures = Internal.getTextures();

--- a/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItemsClient.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/JustEnoughItemsClient.java
@@ -26,7 +26,7 @@ public class JustEnoughItemsClient implements ClientModInitializer {
 		ClientLifecycleHandler clientLifecycleHandler = new ClientLifecycleHandler();
 
 		ClientRecipeSynchronizedEvent.EVENT.register((minecraft, synchronizedRecipes) -> {
-            Internal.setClientSyncedRecipes(RecipeMap.create(synchronizedRecipes.recipes()));
+			Internal.setClientSyncedRecipes(RecipeMap.create(synchronizedRecipes.recipes()));
 			JeiLifecycleEvents.AFTER_RECIPE_SYNC.invoker().run();
 		});
 

--- a/Fabric/src/main/java/mezz/jei/fabric/mixin/ClientPacketListenerMixin.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/mixin/ClientPacketListenerMixin.java
@@ -3,7 +3,6 @@ package mezz.jei.fabric.mixin;
 import mezz.jei.fabric.events.JeiLifecycleEvents;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
-import net.minecraft.network.protocol.game.ClientboundUpdateRecipesPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,11 +10,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPacketListener.class)
 public class ClientPacketListenerMixin {
-	@Inject(method = "handleUpdateRecipes", at = @At("RETURN"))
-	private void handleUpdateRecipes(ClientboundUpdateRecipesPacket packet, CallbackInfo ci) {
-		JeiLifecycleEvents.AFTER_RECIPE_SYNC.invoker().run();
-	}
-
 	@Inject(
 		method = "handleLogin(Lnet/minecraft/network/protocol/game/ClientboundLoginPacket;)V",
 		at = @At(

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ neogradle.subsystems.conventions.runs.create-default-run-per-type=false
 # Fabric
 # https://fabricmc.net/develop/
 fabricLoaderVersion=0.17.3
-fabricApiVersion=0.135.0+1.21.10
+fabricApiVersion=0.137.0+1.21.10
 fabricLoaderVersionRange=>=0.17.0
 fabricApiVersionRange=>=0.133.14+1.21.9
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ neogradle.subsystems.conventions.runs.create-default-run-per-type=false
 fabricLoaderVersion=0.17.3
 fabricApiVersion=0.137.0+1.21.10
 fabricLoaderVersionRange=>=0.17.0
-fabricApiVersionRange=>=0.133.14+1.21.9
+fabricApiVersionRange=>=0.137.0+1.21.10
 
 # Mappings
 # https://parchmentmc.org/docs/getting-started


### PR DESCRIPTION
With https://github.com/FabricMC/fabric/pull/4926 being merged and released as Fabric API 0.137.0+1.21.10, JEI can now release updated version on Fabric.

Naturally the mod is needed on server to works (same as neoforge) to enable required recipes.

Changes are pretty simple, since fabric also just syncs Recipe objects.

Solves Fabric side of #4040