### PR TITLE
Fix incorrect burn time for blast furnace and smoker. small bug issue #4275

### DIFF
--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/cooking/fuel/AbstractFuelCategory.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/cooking/fuel/AbstractFuelCategory.java
@@ -65,7 +65,7 @@ public abstract class AbstractFuelCategory extends AbstractRecipeCategory<IJeiFu
 		builder.addAnimatedRecipeFlame(burnTime)
 			.setPosition(1, 0);
 
-		Component smeltCountText = createSmeltCountText(burnTime);
+        Component smeltCountText = createSmeltCountText(recipe.getBurnTime());
 		builder.addText(smeltCountText, getWidth() - 20, getHeight())
 			.setPosition(20, 0)
 			.setTextAlignment(HorizontalAlignment.CENTER)


### PR DESCRIPTION
[Fixes #4275](https://github.com/mezz/JustEnoughItems/issues/4275)

The burnDivisor (used to speed up the flame animation for Blast Furnace and Smoker) was also being applied to the burn time passed to createSmeltCountText. This caused the displayed smelt count to be halved (Coal showing "Smelts 4 items" instead of 8 in a Blast Furnace).

The fix passes recipe.getBurnTime() (the original, undivided burn time) to createSmeltCountText, since fuel burns at the same rate in all furnace types, only cooking speed differs.






![Image 3-24-26 at 4 58 PM (2)](https://github.com/user-attachments/assets/ba64b7af-dd33-46e5-893f-d4c3bd8b5af8)
![Image 3-24-26 at 4 58 PM (1)](https://github.com/user-attachments/assets/716ddcd4-a280-4866-8f9b-fdef5519bd0e)
![Image 3-24-26 at 4 58 PM](https://github.com/user-attachments/assets/ffe40bd9-09af-48bd-af4c-98c41c0f773b)