### PR TITLE
[26.1] Polish translation update

### DIFF
--- a/Common/src/main/resources/assets/jei/lang/pl_pl.json
+++ b/Common/src/main/resources/assets/jei/lang/pl_pl.json
@@ -95,6 +95,7 @@
   "key.jei.showUses2": "Pokaż zastosowania",
   "key.jei.transferRecipeBookmark": "Stwórz recepturę z zakładek (jedną)",
   "key.jei.maxTransferRecipeBookmark": "Stwórz recepturę z zakładek (wiele)",
+  "key.jei.quickMove": "Szybko przenieś przedmiot widmo",
 
   "key.category.jei.search": "JEI (filtr wyszukiwania)",
   "key.jei.clearSearchBar": "Wyczyść filtr wyszukiwania",
@@ -133,8 +134,8 @@
   "jei.config.client.search.creativeTabSearchMode.description": "Tryb wyszukiwania po nazwach kart z trybu kreatywnego (prefiks: %).",
   "jei.config.client.search.colorSearchMode": "^Kolor",
   "jei.config.client.search.colorSearchMode.description": "Tryb wyszukiwania po kolorach (prefiks: ^).",
-  "jei.config.client.search.identifierSearchMode": "&LokalizacjaZasobu",
-  "jei.config.client.search.identifierSearchMode.description": "Tryb wyszukiwania po lokalizacjach zasobów (prefiks: &).",
+  "jei.config.client.search.identifierSearchMode": "&Identyfikator",
+  "jei.config.client.search.identifierSearchMode.description": "Tryb wyszukiwania po identyfikatorach (prefiks: &).",
   "jei.config.client.search.searchAdvancedTooltips": "Wyszukiwanie w zaawansowanych tooltipach",
   "jei.config.client.advanced": "Zaawansowane",
   "jei.config.client.advanced.description": "Zaawansowane opcje konfiguracyjne do zmiany sposobu, w jaki funkcjonuje JEI.",


### PR DESCRIPTION
In this pull request, I updated the Polish translation to include the new text string introduced in commit 0639eebf3085b480e4a71ebc9fcbdba87de502a1, as well as the "Resource Location" → "Identifier" terminology changes from PR #4224, which were only merged for 1.21.11 and never made it into 26.1 or 26.2, leaving these two recent versions slightly behind in this regard.