### PR TITLE
Fix 9th slot of the hotbar can not be recognized for Smithing Table recipe transfer

### DIFF
--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/VanillaPlugin.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/VanillaPlugin.java
@@ -340,7 +340,7 @@ public class VanillaPlugin implements IModPlugin {
 		registration.addRecipeTransferHandler(BlastFurnaceMenu.class, MenuType.BLAST_FURNACE, RecipeTypes.BLASTING_FUEL, 1, 1, 3, 36);
 		registration.addRecipeTransferHandler(BrewingStandMenu.class, MenuType.BREWING_STAND, RecipeTypes.BREWING, 0, 4, 5, 36);
 		registration.addRecipeTransferHandler(AnvilMenu.class, MenuType.ANVIL, RecipeTypes.ANVIL, 0, 2, 3, 36);
-		registration.addRecipeTransferHandler(SmithingMenu.class, MenuType.SMITHING, RecipeTypes.SMITHING, 0, 3, 3, 36);
+		registration.addRecipeTransferHandler(SmithingMenu.class, MenuType.SMITHING, RecipeTypes.SMITHING, 0, 3, 4, 36);
 
 		IRecipeTransferHandlerHelper transferHelper = registration.getTransferHelper();
 		PlayerRecipeTransferHandler recipeTransferHandler = new PlayerRecipeTransferHandler(transferHelper);


### PR DESCRIPTION
Fixed an issue where the 9th slot of the hotbar could not be recognized when using recipe transfer for the Smithing Table. Fixed and compiled tested in 1.20.1. Other versions also have this issue but have not been tested.