### PR TITLE
[1.21.1] Fix mod-name formatting detection

### DIFF
--- a/Library/build.gradle.kts
+++ b/Library/build.gradle.kts
@@ -33,6 +33,7 @@ dependencyProjects.forEach {
 
 neoForge {
     neoFormVersion = "$minecraftVersion-$neoformTimestamp"
+    addModdingDependenciesTo(sourceSets.test.get())
 }
 
 sourceSets {

--- a/Library/src/main/java/mezz/jei/library/config/ModIdFormatConfig.java
+++ b/Library/src/main/java/mezz/jei/library/config/ModIdFormatConfig.java
@@ -11,10 +11,9 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -47,50 +46,12 @@ public class ModIdFormatConfig implements IModIdFormatConfig {
 
 	private String getOverride() {
 		if (cachedOverride == null) {
-			cachedOverride = detectModNameTooltipFormatting();
+			IPlatformItemStackHelper itemStackHelper = Services.PLATFORM.getItemStackHelper();
+			Minecraft minecraft = Minecraft.getInstance();
+			LocalPlayer player = minecraft.player;
+			cachedOverride = detectModNameTooltipFormatting(itemStackHelper, player);
 		}
 		return cachedOverride;
-	}
-
-	/*
-	 * Converts styles added directly to a Component back into legacy formatting codes.
-	 * Component#getString() does not preserve these styles, so this is needed when another
-	 * mod adds a styled mod-name line without legacy formatting codes.
-	 */
-	private static String getLegacyFormattingFromStyle(Style style) {
-		StringBuilder formatting = new StringBuilder();
-
-		if (style.getColor() != null) {
-			Integer color = style.getColor().getValue();
-			for (ChatFormatting chatFormatting : ChatFormatting.values()) {
-				if (
-					chatFormatting.isColor() &&
-					chatFormatting.getColor() != null &&
-					chatFormatting.getColor().equals(color)
-				) {
-					formatting.append(chatFormatting);
-					break;
-				}
-			}
-		}
-
-		if (style.isBold()) {
-			formatting.append(ChatFormatting.BOLD);
-		}
-		if (style.isItalic()) {
-			formatting.append(ChatFormatting.ITALIC);
-		}
-		if (style.isUnderlined()) {
-			formatting.append(ChatFormatting.UNDERLINE);
-		}
-		if (style.isStrikethrough()) {
-			formatting.append(ChatFormatting.STRIKETHROUGH);
-		}
-		if (style.isObfuscated()) {
-			formatting.append(ChatFormatting.OBFUSCATED);
-		}
-
-		return formatting.toString();
 	}
 
 	@Override
@@ -107,10 +68,11 @@ public class ModIdFormatConfig implements IModIdFormatConfig {
 		return !getOverride().isEmpty();
 	}
 
-	private String detectModNameTooltipFormatting() {
-		IPlatformItemStackHelper itemStackHelper = Services.PLATFORM.getItemStackHelper();
-		Minecraft minecraft = Minecraft.getInstance();
-		LocalPlayer player = minecraft.player;
+	public static String detectModNameTooltipFormatting(IPlatformItemStackHelper itemStackHelper) {
+		return detectModNameTooltipFormatting(itemStackHelper, null);
+	}
+
+	public static String detectModNameTooltipFormatting(IPlatformItemStackHelper itemStackHelper, @Nullable Player player) {
 		List<Component> tooltip = itemStackHelper.getTestTooltip(player, new ItemStack(Items.APPLE));
 		if (tooltip.size() <= 1) {
 			return "";
@@ -122,15 +84,7 @@ public class ModIdFormatConfig implements IModIdFormatConfig {
 			if (lineString.contains(ModIds.MINECRAFT_NAME)) {
 				String withoutFormatting = ChatFormatting.stripFormatting(lineString);
 				if (withoutFormatting.contains(ModIds.MINECRAFT_NAME)) {
-					String detectedFormat = StringUtils.replaceOnce(lineString, ModIds.MINECRAFT_NAME, MOD_NAME_FORMAT_CODE);
-					if (detectedFormat.equals(MOD_NAME_FORMAT_CODE)) {
-						String legacyFormat = getLegacyFormattingFromStyle(line.getStyle());
-						if (!legacyFormat.isEmpty()) {
-							return legacyFormat + MOD_NAME_FORMAT_CODE;
-						}
-					}
-
-					return detectedFormat;
+					return StyledTextHelper.replaceFirst(line, ModIds.MINECRAFT_NAME, MOD_NAME_FORMAT_CODE);
 				}
 			}
 		}

--- a/Library/src/main/java/mezz/jei/library/config/ModIdFormatConfig.java
+++ b/Library/src/main/java/mezz/jei/library/config/ModIdFormatConfig.java
@@ -11,6 +11,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,47 @@ public class ModIdFormatConfig implements IModIdFormatConfig {
 		return cachedOverride;
 	}
 
+	/*
+	 * Converts styles added directly to a Component back into legacy formatting codes.
+	 * Component#getString() does not preserve these styles, so this is needed when another
+	 * mod adds a styled mod-name line without legacy formatting codes.
+	 */
+	private static String getLegacyFormattingFromStyle(Style style) {
+		StringBuilder formatting = new StringBuilder();
+
+		if (style.getColor() != null) {
+			Integer color = style.getColor().getValue();
+			for (ChatFormatting chatFormatting : ChatFormatting.values()) {
+				if (
+					chatFormatting.isColor() &&
+					chatFormatting.getColor() != null &&
+					chatFormatting.getColor().equals(color)
+				) {
+					formatting.append(chatFormatting);
+					break;
+				}
+			}
+		}
+
+		if (style.isBold()) {
+			formatting.append(ChatFormatting.BOLD);
+		}
+		if (style.isItalic()) {
+			formatting.append(ChatFormatting.ITALIC);
+		}
+		if (style.isUnderlined()) {
+			formatting.append(ChatFormatting.UNDERLINE);
+		}
+		if (style.isStrikethrough()) {
+			formatting.append(ChatFormatting.STRIKETHROUGH);
+		}
+		if (style.isObfuscated()) {
+			formatting.append(ChatFormatting.OBFUSCATED);
+		}
+
+		return formatting.toString();
+	}
+
 	@Override
 	public final String getModNameFormat() {
 		String override = getOverride();
@@ -80,7 +122,15 @@ public class ModIdFormatConfig implements IModIdFormatConfig {
 			if (lineString.contains(ModIds.MINECRAFT_NAME)) {
 				String withoutFormatting = ChatFormatting.stripFormatting(lineString);
 				if (withoutFormatting.contains(ModIds.MINECRAFT_NAME)) {
-					return StringUtils.replaceOnce(lineString, ModIds.MINECRAFT_NAME, MOD_NAME_FORMAT_CODE);
+					String detectedFormat = StringUtils.replaceOnce(lineString, ModIds.MINECRAFT_NAME, MOD_NAME_FORMAT_CODE);
+					if (detectedFormat.equals(MOD_NAME_FORMAT_CODE)) {
+						String legacyFormat = getLegacyFormattingFromStyle(line.getStyle());
+						if (!legacyFormat.isEmpty()) {
+							return legacyFormat + MOD_NAME_FORMAT_CODE;
+						}
+					}
+
+					return detectedFormat;
 				}
 			}
 		}

--- a/Library/src/main/java/mezz/jei/library/config/StyledTextHelper.java
+++ b/Library/src/main/java/mezz/jei/library/config/StyledTextHelper.java
@@ -1,0 +1,249 @@
+package mezz.jei.library.config;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public final class StyledTextHelper {
+	private StyledTextHelper() {
+
+	}
+
+	public static String replaceFirst(Component text, String target, String replacement) {
+		List<StyledTextSegment> segments = getStyledTextSegments(text);
+		return getTextRange(segments, target)
+			.map(textRange -> replaceFirst(segments, textRange, replacement))
+			.orElse("");
+	}
+
+	/*
+	 * Converts styles added directly to a Component back into legacy formatting codes.
+	 * Component#getString() does not preserve these styles, so this is needed when another
+	 * mod adds styled text without legacy formatting codes.
+	 */
+	public static String getLegacyFormattingFromStyle(Style style) {
+		StringBuilder formatting = new StringBuilder();
+
+		TextColor color = style.getColor();
+		if (color != null) {
+			ChatFormatting colorFormatting = getChatFormattingFromTextColor(color);
+			if (colorFormatting != null) {
+				formatting.append(colorFormatting);
+			}
+		}
+
+		if (style.isBold()) {
+			formatting.append(ChatFormatting.BOLD);
+		}
+		if (style.isItalic()) {
+			formatting.append(ChatFormatting.ITALIC);
+		}
+		if (style.isUnderlined()) {
+			formatting.append(ChatFormatting.UNDERLINE);
+		}
+		if (style.isStrikethrough()) {
+			formatting.append(ChatFormatting.STRIKETHROUGH);
+		}
+		if (style.isObfuscated()) {
+			formatting.append(ChatFormatting.OBFUSCATED);
+		}
+
+		return formatting.toString();
+	}
+
+	public static @Nullable ChatFormatting getChatFormattingFromTextColor(TextColor color) {
+		for (ChatFormatting chatFormatting : ChatFormatting.values()) {
+			if (chatFormatting.isColor()) {
+				TextColor textColor = TextColor.fromLegacyFormat(chatFormatting);
+				if (textColor != null && textColor.equals(color)) {
+					return chatFormatting;
+				}
+			}
+		}
+		return null;
+	}
+
+	public static List<StyledTextSegment> getStyledTextSegments(Component text) {
+		List<StyledTextSegment> segments = new ArrayList<>();
+		int[] textLength = {0};
+		text.visit((style, rawText) -> {
+			String plainText = ChatFormatting.stripFormatting(rawText);
+			if (!plainText.isEmpty()) {
+				int start = textLength[0];
+				textLength[0] += plainText.length();
+				segments.add(new StyledTextSegment(start, textLength[0], rawText, plainText, style));
+			}
+			return Optional.empty();
+		}, Style.EMPTY);
+		return segments;
+	}
+
+	public static Optional<TextRange> getTextRange(List<StyledTextSegment> segments, String target) {
+		String text = segments.stream()
+			.map(StyledTextSegment::plainText)
+			.collect(Collectors.joining());
+		int targetStart = text.indexOf(target);
+		if (targetStart < 0) {
+			return Optional.empty();
+		}
+		return Optional.of(new TextRange(targetStart, targetStart + target.length()));
+	}
+
+	public static String replaceFirst(List<StyledTextSegment> segments, TextRange targetRange, String replacement) {
+		boolean targetStyleConsistent = isTargetStyleConsistent(segments, targetRange);
+
+		StringBuilder formattedText = new StringBuilder();
+		boolean addedReplacement = false;
+		for (StyledTextSegment segment : segments) {
+			addedReplacement = appendSegmentWithReplacement(
+				formattedText,
+				segment,
+				targetRange,
+				replacement,
+				targetStyleConsistent,
+				addedReplacement
+			);
+		}
+		return formattedText.toString();
+	}
+
+	public static boolean appendSegmentWithReplacement(
+		StringBuilder formattedText,
+		StyledTextSegment segment,
+		TextRange targetRange,
+		String replacement,
+		boolean targetStyleConsistent,
+		boolean addedReplacement
+	) {
+		if (!segment.intersects(targetRange)) {
+			formattedText.append(formatSegmentText(segment, segment.start(), segment.end()));
+			return addedReplacement;
+		}
+
+		if (segment.start() < targetRange.start()) {
+			formattedText.append(formatSegmentText(segment, segment.start(), targetRange.start()));
+		}
+
+		if (!addedReplacement) {
+			formattedText.append(formatReplacement(segment, targetRange, replacement, targetStyleConsistent));
+			addedReplacement = true;
+		}
+
+		if (segment.end() > targetRange.end()) {
+			formattedText.append(formatSegmentText(segment, targetRange.end(), segment.end()));
+		}
+
+		return addedReplacement;
+	}
+
+	public static String formatReplacement(StyledTextSegment segment, TextRange targetRange, String replacement, boolean targetStyleConsistent) {
+		if (!targetStyleConsistent) {
+			return replacement;
+		}
+
+		int overlapStart = Math.max(segment.start(), targetRange.start());
+		int overlapEnd = Math.min(segment.end(), targetRange.end());
+		boolean includeStyle = segment.start() >= targetRange.start();
+		return formatSegmentReplacement(segment, overlapStart, overlapEnd, replacement, includeStyle);
+	}
+
+	public static boolean isTargetStyleConsistent(List<StyledTextSegment> segments, TextRange targetRange) {
+		@Nullable
+		Style targetStyle = null;
+		for (StyledTextSegment segment : segments) {
+			if (!segment.intersects(targetRange)) {
+				continue;
+			}
+
+			Style segmentStyle = segment.style();
+			if (targetStyle == null) {
+				targetStyle = segmentStyle;
+			} else if (!targetStyle.equals(segmentStyle)) {
+				return false;
+			}
+		}
+		return targetStyle != null;
+	}
+
+	public static String formatSegmentText(StyledTextSegment segment, int start, int end) {
+		String rawText = getRawTextRange(segment.rawText(), start - segment.start(), end - segment.start());
+		return applyStyleToText(segment.style(), rawText);
+	}
+
+	public static String formatSegmentReplacement(StyledTextSegment segment, int start, int end, String replacement, boolean includeStyle) {
+		String rawText = getRawTextRange(segment.rawText(), start - segment.start(), end - segment.start());
+		if (includeStyle) {
+			rawText = applyStyleToText(segment.style(), rawText);
+		}
+		String plainText = ChatFormatting.stripFormatting(rawText);
+		if (plainText.isEmpty()) {
+			return replacement;
+		}
+		return StringUtils.replaceOnce(rawText, plainText, replacement);
+	}
+
+	public static String applyStyleToText(Style style, String text) {
+		String formatting = getLegacyFormattingFromStyle(style);
+		if (formatting.isEmpty() || text.isEmpty()) {
+			return text;
+		}
+
+		int index = 0;
+		while (index + 1 < text.length() && text.charAt(index) == ChatFormatting.PREFIX_CODE) {
+			index += 2;
+		}
+		return text.substring(0, index) + formatting + text.substring(index);
+	}
+
+	public static String getRawTextRange(String rawText, int start, int end) {
+		StringBuilder rawTextRange = new StringBuilder();
+		StringBuilder activeFormatting = new StringBuilder();
+		boolean addedActiveFormatting = false;
+		int plainIndex = 0;
+
+		for (int i = 0; i < rawText.length(); i++) {
+			char c = rawText.charAt(i);
+			if (c == ChatFormatting.PREFIX_CODE && i + 1 < rawText.length()) {
+				String formatting = rawText.substring(i, i + 2);
+				if (plainIndex < start) {
+					activeFormatting.append(formatting);
+				} else if (plainIndex < end) {
+					rawTextRange.append(formatting);
+				}
+				i++;
+				continue;
+			}
+
+			if (plainIndex >= start && plainIndex < end) {
+				if (!addedActiveFormatting) {
+					rawTextRange.insert(0, activeFormatting);
+					addedActiveFormatting = true;
+				}
+				rawTextRange.append(c);
+			}
+			plainIndex++;
+		}
+
+		return rawTextRange.toString();
+	}
+
+	public record StyledTextSegment(int start, int end, String rawText, String plainText, Style style) {
+		public boolean intersects(TextRange range) {
+			return range.intersects(this.start, this.end);
+		}
+	}
+
+	public record TextRange(int start, int end) {
+		public boolean intersects(int start, int end) {
+			return this.start < end && this.end > start;
+		}
+	}
+}

--- a/Library/src/test/java/mezz/jei/test/ModIdFormatConfigTest.java
+++ b/Library/src/test/java/mezz/jei/test/ModIdFormatConfigTest.java
@@ -1,0 +1,253 @@
+package mezz.jei.test;
+
+import mezz.jei.api.constants.ModIds;
+import mezz.jei.common.platform.IPlatformItemStackHelper;
+import mezz.jei.library.config.ModIdFormatConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.SharedConstants;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+
+public class ModIdFormatConfigTest {
+	@BeforeAll
+	public static void setup() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithNoModName() {
+		// Setup: the tooltip has only the item name and no mod-name line.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple")
+		);
+
+		// Operation: try to detect mod-name formatting even though there is no mod name.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: no override is detected when the mod name is absent.
+		Assertions.assertEquals("", result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingIgnoresItemNameLine() {
+		// Setup: the first tooltip line contains the Minecraft name, but there is no mod-name line.
+		List<Component> tooltip = List.of(
+			Component.literal(ModIds.MINECRAFT_NAME)
+		);
+
+		// Operation: try to detect formatting from a tooltip whose first line contains the mod name.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the detector ignores the first tooltip line.
+		Assertions.assertEquals("", result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingUsesLaterModNameLine() {
+		// Setup: a non-mod-name tooltip line appears before the styled mod-name line.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.literal("Food"),
+			Component.literal(ModIds.MINECRAFT_NAME).withStyle(ChatFormatting.BLUE)
+		);
+
+		// Operation: detect formatting after skipping unrelated tooltip lines.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the later mod-name line is used.
+		String expected = ChatFormatting.BLUE + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithLegacyFormatting() {
+		// Setup: the mod-name line uses legacy formatting codes.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.literal(ChatFormatting.BLUE + ModIds.MINECRAFT_NAME)
+		);
+
+		// Operation: detect formatting when the mod name is styled with legacy codes.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the legacy color code is preserved before the mod-name placeholder.
+		String expected = ChatFormatting.BLUE + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithStyledComponent() {
+		// Setup: the mod-name line uses component style instead of legacy formatting codes.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.literal(ModIds.MINECRAFT_NAME)
+				.withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC)
+		);
+
+		// Operation: detect formatting when the mod name is styled through the component.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the component style is converted to legacy codes before the placeholder.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithLegacyAndStyledComponent() {
+		// Setup: the mod-name line combines legacy color with direct component style.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.literal(ChatFormatting.BLUE + ModIds.MINECRAFT_NAME)
+				.withStyle(ChatFormatting.ITALIC)
+		);
+
+		// Operation: detect formatting when legacy codes and component style both apply.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: both legacy and component styles are preserved before the placeholder.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingIgnoresStyleOutsideModName() {
+		// Setup: the prefix and mod name use different component styles.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.empty()
+				.append(Component.literal("Mod: ").withStyle(ChatFormatting.RED))
+				.append(Component.literal(ModIds.MINECRAFT_NAME).withStyle(ChatFormatting.BLUE))
+		);
+
+		// Operation: detect formatting when non-mod-name text has its own style.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the prefix and mod-name styles are preserved.
+		String expected = ChatFormatting.RED.toString() + "Mod: " + ChatFormatting.BLUE + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithStyleOnPrefixAndModNameSegment() {
+		// Setup: part of the prefix is red and the rest of the line, including the mod name, is blue.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.empty()
+				.append(Component.literal("Mod").withStyle(ChatFormatting.RED))
+				.append(Component.literal("name: " + ModIds.MINECRAFT_NAME).withStyle(ChatFormatting.BLUE))
+		);
+
+		// Operation: detect formatting when prefix text shares a component with the mod name.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the prefix and mod-name segment styles are preserved.
+		String expected = ChatFormatting.RED.toString() + "Mod" + ChatFormatting.BLUE + "name: " + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithModNameSplitAcrossBlueComponents() {
+		// Setup: the mod name is split across two separate blue components.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.empty()
+				.append(Component.literal("Mine").withStyle(ChatFormatting.BLUE))
+				.append(Component.literal("craft").withStyle(ChatFormatting.BLUE))
+		);
+
+		// Operation: detect formatting when the split mod-name components have matching color.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: the shared blue style is applied to the placeholder.
+		String expected = ChatFormatting.BLUE + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithModNameSplitAcrossStyledComponents() {
+		// Setup: the mod name is split across components with the same style.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.empty()
+				.append(Component.literal("Mine").withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC))
+				.append(Component.literal("craft").withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC))
+		);
+
+		// Operation: detect formatting when the mod name spans multiple styled components.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: matching styles across all mod-name parts are applied to the placeholder.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingWithInconsistentModNameStyling() {
+		// Setup: the mod name is split across components with different styles.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.empty()
+				.append(Component.literal("Mine").withStyle(ChatFormatting.BLUE))
+				.append(Component.literal("craft").withStyle(ChatFormatting.ITALIC))
+		);
+
+		// Operation: detect formatting when different styles apply to parts of the mod name.
+		String result = detectModNameTooltipFormatting(tooltip);
+
+		// Assertions: inconsistent mod-name styling is not collapsed into one override style.
+		Assertions.assertEquals(ModIdFormatConfig.MOD_NAME_FORMAT_CODE, result);
+	}
+
+	@Test
+	public void testDetectModNameTooltipFormattingUsesPlatformTooltip() {
+		// Setup: the platform item stack helper returns a tooltip with a styled mod-name line.
+		List<Component> tooltip = List.of(
+			Component.literal("Apple"),
+			Component.literal(ModIds.MINECRAFT_NAME)
+				.withStyle(ChatFormatting.BLUE)
+		);
+
+		// Operation: detect formatting through ModIdFormatConfig's platform-helper entry point.
+		String result = ModIdFormatConfig.detectModNameTooltipFormatting(new TestItemStackHelper(tooltip));
+
+		// Assertions: the platform tooltip is delegated to the formatting detector.
+		String expected = ChatFormatting.BLUE + ModIdFormatConfig.MOD_NAME_FORMAT_CODE;
+		Assertions.assertEquals(expected, result);
+	}
+
+	private static String detectModNameTooltipFormatting(List<Component> tooltip) {
+		return ModIdFormatConfig.detectModNameTooltipFormatting(new TestItemStackHelper(tooltip));
+	}
+
+	private record TestItemStackHelper(List<Component> tooltip) implements IPlatformItemStackHelper {
+		@Override
+		public int getBurnTime(ItemStack itemStack) {
+			return 0;
+		}
+
+		@Override
+		public boolean isBookEnchantable(ItemStack stack, ItemStack book) {
+			return false;
+		}
+
+		@Override
+		public Optional<String> getCreatorModId(ItemStack stack) {
+			return Optional.empty();
+		}
+
+		@Override
+		public List<Component> getTestTooltip(@Nullable Player player, ItemStack itemStack) {
+			return tooltip;
+		}
+	}
+}

--- a/Library/src/test/java/mezz/jei/test/StyledTextHelperTest.java
+++ b/Library/src/test/java/mezz/jei/test/StyledTextHelperTest.java
@@ -1,0 +1,535 @@
+package mezz.jei.test;
+
+import mezz.jei.library.config.StyledTextHelper;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+public class StyledTextHelperTest {
+	private static final String TARGET = "Target";
+	private static final String TARGET_START = "Tar";
+	private static final String TARGET_END = "get";
+	private static final String REPLACEMENT = "<replacement>";
+	private static final String LABEL = "Label: ";
+
+	@Test
+	public void testReplaceFirstWithNoMatch() {
+		// Setup: the component has formatting but does not contain the target text.
+		Component text = Component.literal("No matching text")
+			.withStyle(ChatFormatting.BLUE);
+
+		// Operation: try to replace a target that is not present.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: no formatted text is produced.
+		Assertions.assertEquals("", result);
+	}
+
+	@Test
+	public void testReplaceFirstWithLegacyFormatting() {
+		// Setup: the target text uses legacy formatting codes.
+		Component text = Component.literal(ChatFormatting.BLUE + TARGET);
+
+		// Operation: replace the target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: the legacy color code is preserved before the replacement.
+		Assertions.assertEquals(ChatFormatting.BLUE + REPLACEMENT, result);
+	}
+
+	@Test
+	public void testGetChatFormattingFromTextColorWithLegacyColor() {
+		// Setup: a TextColor was created from a legacy formatting color.
+		TextColor color = TextColor.fromLegacyFormat(ChatFormatting.BLUE);
+		Assertions.assertNotNull(color);
+
+		// Operation: convert the TextColor back to a ChatFormatting value.
+		ChatFormatting result = StyledTextHelper.getChatFormattingFromTextColor(color);
+
+		// Assertions: the matching legacy color is returned.
+		Assertions.assertEquals(ChatFormatting.BLUE, result);
+	}
+
+	@Test
+	public void testGetChatFormattingFromTextColorWithNonLegacyColor() {
+		// Setup: a TextColor uses an arbitrary RGB value with no legacy equivalent.
+		TextColor color = TextColor.fromRgb(0x12_34_56);
+
+		// Operation: try to convert the TextColor back to a ChatFormatting value.
+		ChatFormatting result = StyledTextHelper.getChatFormattingFromTextColor(color);
+
+		// Assertions: unsupported colors are not converted.
+		Assertions.assertNull(result);
+	}
+
+	@Test
+	public void testGetStyledTextSegments() {
+		// Setup: a component has two styled text segments.
+		Component text = Component.empty()
+			.append(Component.literal(LABEL).withStyle(ChatFormatting.RED))
+			.append(Component.literal(TARGET).withStyle(ChatFormatting.BLUE));
+
+		// Operation: split the component into styled text segments.
+		List<StyledTextHelper.StyledTextSegment> result = StyledTextHelper.getStyledTextSegments(text);
+
+		// Assertions: each segment keeps its range, raw text, plain text, and style.
+		Assertions.assertEquals(2, result.size());
+		StyledTextHelper.StyledTextSegment prefix = result.getFirst();
+		Assertions.assertEquals(0, prefix.start());
+		Assertions.assertEquals(LABEL.length(), prefix.end());
+		Assertions.assertEquals(LABEL, prefix.rawText());
+		Assertions.assertEquals(LABEL, prefix.plainText());
+		Assertions.assertEquals(ChatFormatting.RED.toString(), StyledTextHelper.getLegacyFormattingFromStyle(prefix.style()));
+
+		StyledTextHelper.StyledTextSegment target = result.get(1);
+		Assertions.assertEquals(LABEL.length(), target.start());
+		Assertions.assertEquals(LABEL.length() + TARGET.length(), target.end());
+		Assertions.assertEquals(TARGET, target.rawText());
+		Assertions.assertEquals(TARGET, target.plainText());
+		Assertions.assertEquals(ChatFormatting.BLUE.toString(), StyledTextHelper.getLegacyFormattingFromStyle(target.style()));
+	}
+
+	@Test
+	public void testGetStyledTextSegmentsStripsLegacyFormattingForPlainTextRange() {
+		// Setup: a component segment contains legacy formatting codes in its raw text.
+		Component text = Component.literal(ChatFormatting.BLUE + TARGET);
+
+		// Operation: split the component into styled text segments.
+		List<StyledTextHelper.StyledTextSegment> result = StyledTextHelper.getStyledTextSegments(text);
+
+		// Assertions: raw text keeps legacy codes, while plain text and ranges do not count them.
+		StyledTextHelper.StyledTextSegment segment = result.getFirst();
+		Assertions.assertEquals(ChatFormatting.BLUE + TARGET, segment.rawText());
+		Assertions.assertEquals(TARGET, segment.plainText());
+		Assertions.assertEquals(0, segment.start());
+		Assertions.assertEquals(TARGET.length(), segment.end());
+	}
+
+	@Test
+	public void testGetTextRangeFindsTargetAcrossSegments() {
+		// Setup: the target text is split across two styled segments.
+		List<StyledTextHelper.StyledTextSegment> segments = StyledTextHelper.getStyledTextSegments(
+			Component.empty()
+				.append(Component.literal(TARGET_START).withStyle(ChatFormatting.BLUE))
+				.append(Component.literal(TARGET_END).withStyle(ChatFormatting.BLUE))
+		);
+
+		// Operation: find the target text range in the joined plain text.
+		Optional<StyledTextHelper.TextRange> result = StyledTextHelper.getTextRange(segments, TARGET);
+
+		// Assertions: the target range covers the joined segment text.
+		Assertions.assertTrue(result.isPresent());
+		Assertions.assertEquals(new StyledTextHelper.TextRange(0, TARGET.length()), result.get());
+	}
+
+	@Test
+	public void testGetTextRangeReturnsEmptyForMissingTarget() {
+		// Setup: the segments do not contain the target text.
+		List<StyledTextHelper.StyledTextSegment> segments = StyledTextHelper.getStyledTextSegments(
+			Component.literal("No matching text")
+		);
+
+		// Operation: try to find the missing target text range.
+		Optional<StyledTextHelper.TextRange> result = StyledTextHelper.getTextRange(segments, TARGET);
+
+		// Assertions: no range is returned.
+		Assertions.assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void testTextRangeIntersects() {
+		// Setup: a text range covers the middle of a plain-text line.
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(5, 10);
+
+		// Operation: compare the range against before, overlapping, and after ranges.
+		boolean before = range.intersects(0, 5);
+		boolean overlappingStart = range.intersects(0, 6);
+		boolean inside = range.intersects(6, 9);
+		boolean overlappingEnd = range.intersects(9, 12);
+		boolean after = range.intersects(10, 12);
+
+		// Assertions: only ranges that share at least one character intersect.
+		Assertions.assertFalse(before);
+		Assertions.assertTrue(overlappingStart);
+		Assertions.assertTrue(inside);
+		Assertions.assertTrue(overlappingEnd);
+		Assertions.assertFalse(after);
+	}
+
+	@Test
+	public void testStyledTextSegmentIntersects() {
+		// Setup: a styled segment covers the middle of a plain-text line.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(5, 10, "abcde", "abcde", Style.EMPTY);
+
+		// Operation: compare the segment against before, overlapping, and after target ranges.
+		boolean before = segment.intersects(new StyledTextHelper.TextRange(0, 5));
+		boolean overlapping = segment.intersects(new StyledTextHelper.TextRange(4, 6));
+		boolean after = segment.intersects(new StyledTextHelper.TextRange(10, 12));
+
+		// Assertions: the segment delegates intersection checks to the range.
+		Assertions.assertFalse(before);
+		Assertions.assertTrue(overlapping);
+		Assertions.assertFalse(after);
+	}
+
+	@Test
+	public void testReplaceFirstWithComponentStyle() {
+		// Setup: the target text uses component style instead of legacy formatting codes.
+		Component text = Component.literal(TARGET)
+			.withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC);
+
+		// Operation: replace the target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: the component style is converted to legacy codes before the replacement.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithAllComponentStyleFlags() {
+		// Setup: the target text uses every legacy-compatible component style flag.
+		Component text = Component.literal(TARGET)
+			.withStyle(ChatFormatting.GREEN, ChatFormatting.BOLD, ChatFormatting.ITALIC, ChatFormatting.UNDERLINE, ChatFormatting.STRIKETHROUGH, ChatFormatting.OBFUSCATED);
+
+		// Operation: replace the styled target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: color and all style flags are preserved in stable order.
+		String expected = ChatFormatting.GREEN.toString() +
+			ChatFormatting.BOLD +
+			ChatFormatting.ITALIC +
+			ChatFormatting.UNDERLINE +
+			ChatFormatting.STRIKETHROUGH +
+			ChatFormatting.OBFUSCATED +
+			REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithNonLegacyTextColor() {
+		// Setup: the target text uses an RGB component color that has no legacy color code.
+		Component text = Component.literal(TARGET)
+			.withColor(0x12_34_56);
+
+		// Operation: replace the styled target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: the unsupported color is omitted, but replacement still occurs.
+		Assertions.assertEquals(REPLACEMENT, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithLegacyAndComponentStyle() {
+		// Setup: the target text combines legacy color with direct component style.
+		Component text = Component.literal(ChatFormatting.BLUE + TARGET)
+			.withStyle(ChatFormatting.ITALIC);
+
+		// Operation: replace the styled target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: both legacy and component styles are preserved before the replacement.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstPreservesStyleOutsideTarget() {
+		// Setup: the prefix and target use different component styles.
+		Component text = Component.empty()
+			.append(Component.literal(LABEL).withStyle(ChatFormatting.RED))
+			.append(Component.literal(TARGET).withStyle(ChatFormatting.BLUE));
+
+		// Operation: replace the target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: the prefix and target styles are preserved.
+		String expected = ChatFormatting.RED + LABEL + ChatFormatting.BLUE + REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithStyleOnPrefixAndTargetSegment() {
+		// Setup: part of the prefix is red and the rest of the line, including the target, is blue.
+		Component text = Component.empty()
+			.append(Component.literal("Pre").withStyle(ChatFormatting.RED))
+			.append(Component.literal("fix: " + TARGET).withStyle(ChatFormatting.BLUE));
+
+		// Operation: replace the target when prefix text shares a component with it.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: the prefix and target segment styles are preserved.
+		String expected = ChatFormatting.RED + "Pre" + ChatFormatting.BLUE + "fix: " + REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithTargetSplitAcrossMatchingComponents() {
+		// Setup: the target is split across two components with matching styles.
+		Component text = Component.empty()
+			.append(Component.literal(TARGET_START).withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC))
+			.append(Component.literal(TARGET_END).withStyle(ChatFormatting.BLUE, ChatFormatting.ITALIC));
+
+		// Operation: replace the split target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: matching styles across all target parts are applied to the replacement.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithTargetSplitAcrossDifferentStyles() {
+		// Setup: the target is split across components with different styles.
+		Component text = Component.empty()
+			.append(Component.literal(TARGET_START).withStyle(ChatFormatting.BLUE))
+			.append(Component.literal(TARGET_END).withStyle(ChatFormatting.ITALIC));
+
+		// Operation: replace the split target text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: inconsistent target styling is not collapsed into one replacement style.
+		Assertions.assertEquals(REPLACEMENT, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithSegmentsAndRange() {
+		// Setup: styled text segments and an explicit target range identify the target text.
+		List<StyledTextHelper.StyledTextSegment> segments = StyledTextHelper.getStyledTextSegments(
+			Component.literal(LABEL + TARGET).withStyle(ChatFormatting.BLUE)
+		);
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(LABEL.length(), LABEL.length() + TARGET.length());
+
+		// Operation: replace the explicit target range.
+		String result = StyledTextHelper.replaceFirst(segments, range, REPLACEMENT);
+
+		// Assertions: surrounding text and target style are preserved.
+		String expected = ChatFormatting.BLUE + LABEL + REPLACEMENT;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testAppendSegmentWithReplacementForNonIntersectingSegment() {
+		// Setup: the segment is before the target range.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, LABEL.length(), LABEL, LABEL, Style.EMPTY.applyFormat(ChatFormatting.RED));
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(LABEL.length(), LABEL.length() + TARGET.length());
+		StringBuilder formattedText = new StringBuilder();
+
+		// Operation: append the segment while replacement has not been added.
+		boolean addedReplacement = StyledTextHelper.appendSegmentWithReplacement(formattedText, segment, range, REPLACEMENT, true, false);
+
+		// Assertions: the segment text is appended and the replacement flag is unchanged.
+		Assertions.assertFalse(addedReplacement);
+		Assertions.assertEquals(ChatFormatting.RED + LABEL, formattedText.toString());
+	}
+
+	@Test
+	public void testAppendSegmentWithReplacementForIntersectingSegment() {
+		// Setup: the segment contains the target range.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, TARGET.length(), TARGET, TARGET, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(0, TARGET.length());
+		StringBuilder formattedText = new StringBuilder();
+
+		// Operation: append the segment and replacement.
+		boolean addedReplacement = StyledTextHelper.appendSegmentWithReplacement(formattedText, segment, range, REPLACEMENT, true, false);
+
+		// Assertions: the replacement is appended with segment style and the replacement flag is set.
+		Assertions.assertTrue(addedReplacement);
+		Assertions.assertEquals(ChatFormatting.BLUE + REPLACEMENT, formattedText.toString());
+	}
+
+	@Test
+	public void testAppendSegmentWithReplacementDoesNotAddReplacementTwice() {
+		// Setup: the segment intersects a range whose replacement was already added.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(TARGET_START.length(), TARGET.length(), TARGET_END, TARGET_END, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(0, TARGET.length());
+		StringBuilder formattedText = new StringBuilder(REPLACEMENT);
+
+		// Operation: append the second intersecting segment after replacement has already been added.
+		boolean addedReplacement = StyledTextHelper.appendSegmentWithReplacement(formattedText, segment, range, REPLACEMENT, true, true);
+
+		// Assertions: no duplicate replacement is appended.
+		Assertions.assertTrue(addedReplacement);
+		Assertions.assertEquals(REPLACEMENT, formattedText.toString());
+	}
+
+	@Test
+	public void testFormatReplacementWithConsistentStyle() {
+		// Setup: a styled segment contains the whole target range.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, TARGET.length(), TARGET, TARGET, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(0, TARGET.length());
+
+		// Operation: format a replacement for a consistently styled target.
+		String result = StyledTextHelper.formatReplacement(segment, range, REPLACEMENT, true);
+
+		// Assertions: the replacement keeps the segment style.
+		Assertions.assertEquals(ChatFormatting.BLUE + REPLACEMENT, result);
+	}
+
+	@Test
+	public void testFormatReplacementWithoutConsistentStyle() {
+		// Setup: a styled segment contains part of an inconsistently styled target range.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, TARGET_START.length(), TARGET_START, TARGET_START, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+		StyledTextHelper.TextRange range = new StyledTextHelper.TextRange(0, TARGET.length());
+
+		// Operation: format a replacement for an inconsistently styled target.
+		String result = StyledTextHelper.formatReplacement(segment, range, REPLACEMENT, false);
+
+		// Assertions: no segment style is applied to the replacement.
+		Assertions.assertEquals(REPLACEMENT, result);
+	}
+
+	@Test
+	public void testIsTargetStyleConsistentWithMatchingStyles() {
+		// Setup: the target is split across components with matching styles.
+		List<StyledTextHelper.StyledTextSegment> segments = StyledTextHelper.getStyledTextSegments(
+			Component.empty()
+				.append(Component.literal(TARGET_START).withStyle(ChatFormatting.BLUE))
+				.append(Component.literal(TARGET_END).withStyle(ChatFormatting.BLUE))
+		);
+
+		// Operation: check whether the target range has one consistent style.
+		boolean result = StyledTextHelper.isTargetStyleConsistent(segments, new StyledTextHelper.TextRange(0, TARGET.length()));
+
+		// Assertions: matching styles are considered consistent.
+		Assertions.assertTrue(result);
+	}
+
+	@Test
+	public void testIsTargetStyleConsistentWithDifferentStyles() {
+		// Setup: the target is split across components with different styles.
+		List<StyledTextHelper.StyledTextSegment> segments = StyledTextHelper.getStyledTextSegments(
+			Component.empty()
+				.append(Component.literal(TARGET_START).withStyle(ChatFormatting.BLUE))
+				.append(Component.literal(TARGET_END).withStyle(ChatFormatting.ITALIC))
+		);
+
+		// Operation: check whether the target range has one consistent style.
+		boolean result = StyledTextHelper.isTargetStyleConsistent(segments, new StyledTextHelper.TextRange(0, TARGET.length()));
+
+		// Assertions: different styles are not considered consistent.
+		Assertions.assertFalse(result);
+	}
+
+	@Test
+	public void testFormatSegmentText() {
+		// Setup: a styled segment has a prefix and target text.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, LABEL.length() + TARGET.length(), LABEL + TARGET, LABEL + TARGET, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+
+		// Operation: format only the prefix range from the segment.
+		String result = StyledTextHelper.formatSegmentText(segment, 0, LABEL.length());
+
+		// Assertions: the segment style is applied to the selected text.
+		Assertions.assertEquals(ChatFormatting.BLUE + LABEL, result);
+	}
+
+	@Test
+	public void testFormatSegmentReplacementWithIncludedStyle() {
+		// Setup: a styled segment contains the target text.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, TARGET.length(), TARGET, TARGET, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+
+		// Operation: format a replacement and include the segment style.
+		String result = StyledTextHelper.formatSegmentReplacement(segment, 0, TARGET.length(), REPLACEMENT, true);
+
+		// Assertions: the segment style is applied to the replacement.
+		Assertions.assertEquals(ChatFormatting.BLUE + REPLACEMENT, result);
+	}
+
+	@Test
+	public void testFormatSegmentReplacementWithoutIncludedStyle() {
+		// Setup: a styled segment contains the target text.
+		StyledTextHelper.StyledTextSegment segment = new StyledTextHelper.StyledTextSegment(0, TARGET.length(), TARGET, TARGET, Style.EMPTY.applyFormat(ChatFormatting.BLUE));
+
+		// Operation: format a replacement without including the segment style.
+		String result = StyledTextHelper.formatSegmentReplacement(segment, 0, TARGET.length(), REPLACEMENT, false);
+
+		// Assertions: the replacement is returned without segment style.
+		Assertions.assertEquals(REPLACEMENT, result);
+	}
+
+	@Test
+	public void testReplaceFirstWithStyledSuffixAfterTarget() {
+		// Setup: the target component has styled suffix text after the target.
+		Component text = Component.literal(TARGET + " suffix")
+			.withStyle(ChatFormatting.BLUE);
+
+		// Operation: replace the target while preserving suffix text.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: the styled suffix is preserved after the replacement.
+		String expected = ChatFormatting.BLUE + REPLACEMENT + ChatFormatting.BLUE + " suffix";
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testReplaceFirstOnlyReplacesFirstTarget() {
+		// Setup: the same target appears twice with one component style.
+		Component text = Component.literal(TARGET + " " + TARGET)
+			.withStyle(ChatFormatting.BLUE);
+
+		// Operation: replace the first target.
+		String result = StyledTextHelper.replaceFirst(text, TARGET, REPLACEMENT);
+
+		// Assertions: only the first target is replaced and the second target is preserved.
+		String expected = ChatFormatting.BLUE + REPLACEMENT + ChatFormatting.BLUE + " " + TARGET;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testGetRawTextRangePreservesActiveLegacyFormatting() {
+		// Setup: legacy formatting changes before the requested plain-text range.
+		String rawText = ChatFormatting.RED + LABEL + ChatFormatting.BLUE + TARGET;
+
+		// Operation: slice out the target text from the raw legacy-formatted text.
+		String result = StyledTextHelper.getRawTextRange(rawText, LABEL.length(), LABEL.length() + TARGET.length());
+
+		// Assertions: active legacy formatting is carried into the sliced range.
+		String expected = ChatFormatting.RED.toString() + ChatFormatting.BLUE + TARGET;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testGetRawTextRangePreservesFormattingInsideRange() {
+		// Setup: legacy formatting changes inside the requested plain-text range.
+		String rawText = LABEL + ChatFormatting.BLUE + TARGET;
+
+		// Operation: slice a range containing both plain text and a legacy formatting change.
+		String result = StyledTextHelper.getRawTextRange(rawText, 0, LABEL.length() + TARGET.length());
+
+		// Assertions: formatting inside the range is preserved in place.
+		String expected = LABEL + ChatFormatting.BLUE + TARGET;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testApplyStyleToTextInsertsComponentStyleAfterExistingLegacyCodes() {
+		// Setup: text already starts with a legacy color code and the component style adds italic.
+		String text = ChatFormatting.BLUE + TARGET;
+		Style style = Style.EMPTY.applyFormat(ChatFormatting.ITALIC);
+
+		// Operation: apply the component style to the legacy-formatted text.
+		String result = StyledTextHelper.applyStyleToText(style, text);
+
+		// Assertions: the component style is inserted after existing leading legacy codes.
+		String expected = ChatFormatting.BLUE.toString() + ChatFormatting.ITALIC + TARGET;
+		Assertions.assertEquals(expected, result);
+	}
+
+	@Test
+	public void testGetLegacyFormattingFromStyleWithEmptyStyle() {
+		// Setup: the style has no legacy-compatible formatting.
+		Style style = Style.EMPTY;
+
+		// Operation: convert the empty style to legacy formatting.
+		String result = StyledTextHelper.getLegacyFormattingFromStyle(style);
+
+		// Assertions: no formatting codes are produced.
+		Assertions.assertEquals("", result);
+	}
+}

--- a/Library/src/test/java/mezz/jei/test/package-info.java
+++ b/Library/src/test/java/mezz/jei/test/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package mezz.jei.test;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Fix mod-name formatting detection when another mod adds a styled Component tooltip line.

Previously, JEI detected existing mod-name tooltip formatting using Component#getString(). This preserves legacy formatting codes in the text, but does not preserve styles applied directly to the Component. As a result, when another mod added a styled mod-name line without legacy formatting codes, JEI detected the override as plain %MODNAME%. Item tooltips still looked correct because the other mod added the item mod name, but JEI-rendered non-item ingredient tooltips, such as fluids, used the plain override.

This change recovers legacy formatting from the Component style when the detected format would otherwise be plain %MODNAME%.

Fixes https://github.com/mezz/JustEnoughItems/issues/4245 , https://github.com/Snownee/Jade/issues/545