### PR TITLE
Query vanilla's repairable component for calculating builtin anvil repair recipes

### DIFF
--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/AnvilRecipeMaker.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/anvil/AnvilRecipeMaker.java
@@ -1,5 +1,6 @@
 package mezz.jei.library.plugins.vanilla.anvil;
 
+import java.util.Collections;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.recipe.vanilla.IJeiAnvilRecipe;
@@ -13,11 +14,11 @@ import mezz.jei.library.plugins.vanilla.ingredients.subtypes.EnchantedBookSubtyp
 import mezz.jei.library.util.ResourceLocationUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
-import net.minecraft.tags.ItemTags;
-import net.minecraft.tags.TagKey;
 import net.minecraft.util.context.ContextMap;
 import net.minecraft.world.entity.EntityEquipment;
 import net.minecraft.world.entity.player.Inventory;
@@ -28,11 +29,11 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.item.crafting.display.SlotDisplay;
 import net.minecraft.world.item.crafting.display.SlotDisplayContext;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
+import net.minecraft.world.item.enchantment.Repairable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.Nullable;
@@ -150,143 +151,28 @@ public final class AnvilRecipeMaker {
 			.toList();
 	}
 
-	private static class RepairData {
-		private final SlotDisplay repairIngredient;
-		private final List<ItemStack> repairables;
-
-		public RepairData(TagKey<Item> repairTag, ItemStack... repairables) {
-			this.repairIngredient = new SlotDisplay.TagSlotDisplay(repairTag);
-			this.repairables = List.of(repairables);
-		}
-
-		public RepairData(SlotDisplay repairIngredient, ItemStack... repairables) {
-			this.repairIngredient = repairIngredient;
-			this.repairables = List.of(repairables);
-		}
-
-		public SlotDisplay getRepairIngredient() {
-			return repairIngredient;
-		}
-
-		public List<ItemStack> getRepairables() {
-			return repairables;
-		}
-	}
-
-	private static Stream<RepairData> getRepairData() {
-		return Stream.of(
-			new RepairData(ItemTags.WOODEN_TOOL_MATERIALS,
-				new ItemStack(Items.WOODEN_SWORD),
-				new ItemStack(Items.WOODEN_PICKAXE),
-				new ItemStack(Items.WOODEN_AXE),
-				new ItemStack(Items.WOODEN_SHOVEL),
-				new ItemStack(Items.WOODEN_HOE)
-			),
-			new RepairData(ItemTags.PLANKS,
-				new ItemStack(Items.SHIELD)
-			),
-			new RepairData(ItemTags.STONE_TOOL_MATERIALS,
-				new ItemStack(Items.STONE_SWORD),
-				new ItemStack(Items.STONE_PICKAXE),
-				new ItemStack(Items.STONE_AXE),
-				new ItemStack(Items.STONE_SHOVEL),
-				new ItemStack(Items.STONE_HOE)
-			),
-			new RepairData(ItemTags.REPAIRS_LEATHER_ARMOR,
-				new ItemStack(Items.LEATHER_HELMET),
-				new ItemStack(Items.LEATHER_CHESTPLATE),
-				new ItemStack(Items.LEATHER_LEGGINGS),
-				new ItemStack(Items.LEATHER_BOOTS)
-			),
-			new RepairData(ItemTags.IRON_TOOL_MATERIALS,
-				new ItemStack(Items.IRON_SWORD),
-				new ItemStack(Items.IRON_PICKAXE),
-				new ItemStack(Items.IRON_AXE),
-				new ItemStack(Items.IRON_SHOVEL),
-				new ItemStack(Items.IRON_HOE)
-			),
-			new RepairData(ItemTags.REPAIRS_IRON_ARMOR,
-				new ItemStack(Items.IRON_HELMET),
-				new ItemStack(Items.IRON_CHESTPLATE),
-				new ItemStack(Items.IRON_LEGGINGS),
-				new ItemStack(Items.IRON_BOOTS)
-			),
-			new RepairData(ItemTags.REPAIRS_CHAIN_ARMOR,
-				new ItemStack(Items.CHAINMAIL_HELMET),
-				new ItemStack(Items.CHAINMAIL_CHESTPLATE),
-				new ItemStack(Items.CHAINMAIL_LEGGINGS),
-				new ItemStack(Items.CHAINMAIL_BOOTS)
-			),
-			new RepairData(ItemTags.GOLD_TOOL_MATERIALS,
-				new ItemStack(Items.GOLDEN_SWORD),
-				new ItemStack(Items.GOLDEN_PICKAXE),
-				new ItemStack(Items.GOLDEN_AXE),
-				new ItemStack(Items.GOLDEN_SHOVEL),
-				new ItemStack(Items.GOLDEN_HOE)
-			),
-			new RepairData(ItemTags.REPAIRS_GOLD_ARMOR,
-				new ItemStack(Items.GOLDEN_HELMET),
-				new ItemStack(Items.GOLDEN_CHESTPLATE),
-				new ItemStack(Items.GOLDEN_LEGGINGS),
-				new ItemStack(Items.GOLDEN_BOOTS)
-			),
-			new RepairData(ItemTags.DIAMOND_TOOL_MATERIALS,
-				new ItemStack(Items.DIAMOND_SWORD),
-				new ItemStack(Items.DIAMOND_PICKAXE),
-				new ItemStack(Items.DIAMOND_AXE),
-				new ItemStack(Items.DIAMOND_SHOVEL),
-				new ItemStack(Items.DIAMOND_HOE)
-			),
-			new RepairData(ItemTags.REPAIRS_DIAMOND_ARMOR,
-				new ItemStack(Items.DIAMOND_HELMET),
-				new ItemStack(Items.DIAMOND_CHESTPLATE),
-				new ItemStack(Items.DIAMOND_LEGGINGS),
-				new ItemStack(Items.DIAMOND_BOOTS)
-			),
-			new RepairData(ItemTags.NETHERITE_TOOL_MATERIALS,
-				new ItemStack(Items.NETHERITE_SWORD),
-				new ItemStack(Items.NETHERITE_AXE),
-				new ItemStack(Items.NETHERITE_HOE),
-				new ItemStack(Items.NETHERITE_SHOVEL),
-				new ItemStack(Items.NETHERITE_PICKAXE)
-			),
-			new RepairData(ItemTags.REPAIRS_NETHERITE_ARMOR,
-				new ItemStack(Items.NETHERITE_BOOTS),
-				new ItemStack(Items.NETHERITE_HELMET),
-				new ItemStack(Items.NETHERITE_LEGGINGS),
-				new ItemStack(Items.NETHERITE_CHESTPLATE)
-			),
-			new RepairData(Ingredient.of(Items.PHANTOM_MEMBRANE).display(),
-				new ItemStack(Items.ELYTRA)
-			),
-			new RepairData(ItemTags.REPAIRS_TURTLE_HELMET,
-				new ItemStack(Items.TURTLE_HELMET)
-			)
-		);
-	}
-
 	private static Stream<IJeiAnvilRecipe> getRepairRecipes(
 		IVanillaRecipeFactory vanillaRecipeFactory,
 		IIngredientHelper<ItemStack> ingredientHelper
 	) {
-		return getRepairData()
-			.flatMap(repairData -> getRepairRecipes(repairData, vanillaRecipeFactory, ingredientHelper));
-	}
-
-	private static Stream<IJeiAnvilRecipe> getRepairRecipes(
-		RepairData repairData,
-		IVanillaRecipeFactory vanillaRecipeFactory,
-		IIngredientHelper<ItemStack> ingredientHelper
-	) {
-		SlotDisplay repairIngredient = repairData.getRepairIngredient();
-		List<ItemStack> repairables = repairData.getRepairables();
-
 		Minecraft minecraft = Minecraft.getInstance();
 		ContextMap contextmap = SlotDisplayContext.fromLevel(Objects.requireNonNull(minecraft.level));
-		List<ItemStack> repairMaterials = repairIngredient.resolveForStacks(contextmap);
-
-		return repairables.stream()
-			.mapMulti((itemStack, consumer) -> {
+		record RepairData(Holder.Reference<Item> item, List<ItemStack> repairMaterials) {
+		}
+		return RegistryUtil.getRegistry(Registries.ITEM).listElements()
+			.map(item -> {
+				Repairable repairable = item.components().get(DataComponents.REPAIRABLE);
+				if (repairable == null) {
+					return null;
+				}
+				HolderSet<Item> items = repairable.items();
+				if (items.size() == 0) {//Is unlikely to be the case, but better safe than sorry
+					return new RepairData(item, Collections.emptyList());
+				}
+				return new RepairData(item, Ingredient.of(items).display().resolveForStacks(contextmap));
+			}).filter(Objects::nonNull)
+			.mapMulti((repairData, consumer) -> {
+				ItemStack itemStack = new ItemStack(repairData.item());
 				String uid = EnchantedBookSubtypeInterpreter.INSTANCE.getStringName(itemStack);
 				String ingredientIdPath = ResourceLocationUtil.sanitizePath(uid);
 				String itemModId = ingredientHelper.getIdentifier(itemStack).getNamespace();
@@ -306,6 +192,7 @@ public final class AnvilRecipeMaker {
 				);
 				consumer.accept(repairWithSame);
 
+				List<ItemStack> repairMaterials = repairData.repairMaterials();
 				if (!repairMaterials.isEmpty()) {
 					ItemStack damagedFully = itemStack.copy();
 					damagedFully.setDamageValue(damagedFully.getMaxDamage());


### PR DESCRIPTION
Makes it easier for mods to not have to define anvil repair recipes by default for "simple" repairable items. Also adds missing repair recipes for the following vanilla items:
- Wolf Armor
- Copper Shovel
- Copper Pickaxe
- Copper Axe
- Copper Hoe
- Copper Sword
- Copper Spear
- Copper Helmet
- Copper Chestplate
- Copper Leggings
- Copper Boots
- Wooden Spear
- Stone Spear
- Iron Spear
- Golden Spear
- Diamond Spear
- Netherite Spear
- Mace