### PR TITLE
Client-side recipe fallback + fix empty-recipe GUI crash

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/startup/ClientLifecycleHandler.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/startup/ClientLifecycleHandler.java
@@ -12,6 +12,7 @@ import mezz.jei.library.startup.StartData;
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import org.apache.logging.log4j.LogManager;
@@ -54,8 +55,17 @@ public class ClientLifecycleHandler {
 			ScreenEvents.AFTER_INIT.register((minecraft, screen, scaledWidth, scaledHeight) -> {
 				if (!running) {
 					if (screen instanceof AbstractContainerScreen && minecraft.player != null) {
-						LOGGER.error("A Screen is opening but JEI hasn't started yet because the recipe sync event didn't happen.");
+						// Client-side recipe patch: the server never synced recipes to JEI
+						// (e.g. an older server reached through ViaVersion). Load the client's
+						// own vanilla recipes so recipes can still be browsed, then start JEI.
+						LOGGER.info("JEI: recipe sync event did not happen; loading recipes from client-side data.");
+						loadClientSideRecipesIfMissing();
 						startJei();
+						// JEI's per-screen input handlers register on screen BEFORE_INIT, which
+						// already fired for this screen before JEI started. Re-initialize the
+						// current screen (deferred, to avoid reentrancy) so those handlers attach
+						// and mouse/keyboard input works on the already-open screen.
+						reinitScreenForInput(minecraft, screen);
 					}
 				}
 			});
@@ -75,6 +85,21 @@ public class ClientLifecycleHandler {
 				startJei();
 			}
 		};
+	}
+
+	private void loadClientSideRecipesIfMissing() {
+		if (Internal.getClientSyncedRecipes().values().isEmpty()) {
+			ClientRecipeLoader.loadClientSideRecipes()
+				.ifPresent(Internal::setClientSyncedRecipes);
+		}
+	}
+
+	private void reinitScreenForInput(Minecraft minecraft, Screen screen) {
+		minecraft.execute(() -> {
+			if (minecraft.screen == screen) {
+				screen.init(minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
+			}
+		});
 	}
 
 	private void startJei() {

--- a/Fabric/src/main/java/mezz/jei/fabric/startup/ClientRecipeLoader.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/startup/ClientRecipeLoader.java
@@ -1,0 +1,92 @@
+package mezz.jei.fabric.startup;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.VanillaPackResources;
+import net.minecraft.server.packs.repository.ServerPacksSource;
+import net.minecraft.server.packs.resources.MultiPackResourceManager;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Client-side recipe patch.
+ * <p>
+ * Since Minecraft 1.21.2 recipes live server-side and reach JEI through Fabric's
+ * {@code ClientRecipeSynchronizedEvent}. On servers that do not send that sync
+ * (e.g. older servers reached through ViaVersion), JEI would otherwise have no
+ * recipes at all. This loads the client's own built-in (vanilla) recipe files so
+ * recipes can still be browsed, using the connected server's registries for
+ * deserialization.
+ */
+public final class ClientRecipeLoader {
+	private static final Logger LOGGER = LogManager.getLogger();
+	private static final String RECIPE_DIR = "recipe";
+	private static final String JSON_SUFFIX = ".json";
+
+	private ClientRecipeLoader() {}
+
+	public static Optional<RecipeMap> loadClientSideRecipes() {
+		Minecraft minecraft = Minecraft.getInstance();
+		ClientPacketListener connection = minecraft.getConnection();
+		if (connection == null) {
+			return Optional.empty();
+		}
+		RegistryAccess.Frozen registryAccess = connection.registryAccess();
+		RegistryOps<JsonElement> ops = registryAccess.createSerializationContext(JsonOps.INSTANCE);
+
+		VanillaPackResources vanillaPack = ServerPacksSource.createVanillaPackSource();
+		List<RecipeHolder<?>> holders = new ArrayList<>();
+		int failed = 0;
+		try (MultiPackResourceManager resourceManager =
+				 new MultiPackResourceManager(PackType.SERVER_DATA, List.of(vanillaPack))) {
+			Map<Identifier, Resource> resources =
+				resourceManager.listResources(RECIPE_DIR, id -> id.getPath().endsWith(JSON_SUFFIX));
+			for (Map.Entry<Identifier, Resource> entry : resources.entrySet()) {
+				Identifier fileId = entry.getKey();
+				String path = fileId.getPath();
+				// "recipe/foo/bar.json" -> "foo/bar"
+				String recipePath = path.substring(RECIPE_DIR.length() + 1, path.length() - JSON_SUFFIX.length());
+				ResourceKey<Recipe<?>> key = ResourceKey.create(Registries.RECIPE, fileId.withPath(recipePath));
+				try (Reader reader = entry.getValue().openAsReader()) {
+					JsonElement json = JsonParser.parseReader(reader);
+					Recipe<?> recipe = Recipe.CODEC.parse(ops, json).getOrThrow();
+					holders.add(makeHolder(key, recipe));
+				} catch (Exception e) {
+					failed++;
+				}
+			}
+		} catch (Exception e) {
+			LOGGER.error("JEI client-side recipe loading failed", e);
+			return Optional.empty();
+		}
+
+		if (holders.isEmpty()) {
+			return Optional.empty();
+		}
+		LOGGER.info("JEI loaded {} recipes from client-side data ({} skipped)", holders.size(), failed);
+		return Optional.of(RecipeMap.create(holders));
+	}
+
+	private static <T extends Recipe<?>> RecipeHolder<T> makeHolder(ResourceKey<Recipe<?>> key, T recipe) {
+		return new RecipeHolder<>(key, recipe);
+	}
+}

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeGuiLogic.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeGuiLogic.java
@@ -308,6 +308,12 @@ public class RecipeGuiLogic implements IRecipeGuiLogic {
 
 	@Override
 	public boolean hasMultiplePages() {
+		// Client-side recipe patch: when no recipes are available (e.g. connected to a
+		// server that does not sync recipes to JEI), there are no recipe categories.
+		// Avoid indexing into the empty category list, which crashes JEI GUI startup.
+		if (state.getRecipeCategories().isEmpty()) {
+			return false;
+		}
 		List<?> recipes = state.getFocusedRecipes().getRecipes();
 		return recipes.size() > state.getRecipesPerPage();
 	}

--- a/Gui/src/main/java/mezz/jei/gui/recipes/lookups/IngredientLookupState.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/lookups/IngredientLookupState.java
@@ -117,6 +117,10 @@ public class IngredientLookupState implements ILookupState {
 	}
 
 	public int recipeCount() {
+		// Client-side recipe patch: guard against an empty category list (no synced recipes).
+		if (recipeCategories.isEmpty()) {
+			return 0;
+		}
 		return getFocusedRecipes().getRecipes().size();
 	}
 


### PR DESCRIPTION
# PR: Client-side recipe fallback + empty-recipe crash fix (26.1)

Branch: `clientside-recipe-fallback` (2 commits, off `26.1`)

## Motivation
Since Minecraft 1.21.2 recipes are server-authoritative and reach JEI through
Fabric's `ClientRecipeSynchronizedEvent`. On servers that never send it — most
notably older-version servers reached through **ViaVersion** — JEI receives no
recipes. Two problems follow:

1. **Crash:** opening a container makes JEI start with zero recipe categories.
   Building the recipe GUI indexes into the empty category list
   (`IngredientLookupState.getFocusedRecipes` → `recipeCategories.get(0)`),
   throwing `ArrayIndexOutOfBoundsException` during GUI startup — which aborts
   the whole runtime registration, so even the item-list overlay disappears.
2. **No recipes:** even without the crash, there is nothing to browse.

## Changes
**Commit 1 — crash fix (safe, standalone):**
- `RecipeGuiLogic.hasMultiplePages()` and `IngredientLookupState.recipeCount()`
  return early when the recipe-category list is empty.

**Commit 2 — client-side recipe fallback (opt-in behavior, Fabric only):**
- New `ClientRecipeLoader`: when the sync event did not happen, load the client's
  own built-in vanilla recipe files (`data/*/recipe/*.json`) via a `SERVER_DATA`
  `MultiPackResourceManager`, deserialize with the connected server's registries
  (`connection.registryAccess().createSerializationContext(JsonOps.INSTANCE)`),
  and feed them to JEI as client-synced recipes.
- `ClientLifecycleHandler`: in the existing container-open fallback, load
  client-side recipes if none are present, then re-initialize the already-open
  screen so JEI's per-screen input handlers (registered on `BEFORE_INIT`) attach.

## Notes / open questions for maintainers
- Commit 1 is a pure defensive fix and is useful regardless of the rest.
- Commit 2 intentionally re-introduces client-side recipe reading as a *fallback
  only* (server-synced recipes still take precedence via `AFTER_RECIPE_SYNC`).
  If reading client recipes on non-syncing servers is undesirable by design, it
  could be gated behind a config option, or Commit 1 could be merged alone.
- Only vanilla client recipes are loaded currently; modded data packs are not
  included in the fallback resource manager.
