### PR TITLE
[Feature] Add option to disable toast notification reflow

### DIFF
--- a/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
@@ -22,6 +22,7 @@ public final class ClientConfig implements IClientConfig {
 	// appearance
 	private final Supplier<Boolean> centerSearchBarEnabled;
 	private final Supplier<Integer> maxRecipeGuiHeight;
+	private final Supplier<Boolean> toastReflowEnabled;
 
 	// cheat_mode
 	private final Supplier<GiveMode> giveMode;
@@ -50,7 +51,6 @@ public final class ClientConfig implements IClientConfig {
 	private final Supplier<Boolean> lookupBlockTagsEnabled;
 	private final Supplier<Boolean> showTagRecipesEnabled;
 	private final Supplier<Boolean> showCreativeTabNamesEnabled;
-    private final Supplier<Boolean> toastReflowEnabled;
 
 	// input
 	private final Supplier<Integer> dragDelayMs;
@@ -77,6 +77,7 @@ public final class ClientConfig implements IClientConfig {
 			minRecipeGuiHeight,
 			Integer.MAX_VALUE
 		);
+		toastReflowEnabled = appearance.addBoolean("toastReflowEnabled", true);
 
 		IConfigCategoryBuilder cheating = schema.addCategory("cheating");
 		giveMode = cheating.addEnum("giveMode", GiveMode.defaultGiveMode);
@@ -99,7 +100,6 @@ public final class ClientConfig implements IClientConfig {
 		tagContentTooltipEnabled = tooltips.addBoolean("tagContentTooltipEnabled", true);
 		hideSingleTagContentTooltipEnabled = tooltips.addBoolean("hideSingleTagContentTooltipEnabled", true);
 		ingredientsSummaryEnabled = tooltips.addBoolean("enableRecipesGuiIngredientsSummary", false);
-        toastReflowEnabled = appearance.addBoolean("toastReflowEnabled", true);
 
 		IConfigCategoryBuilder performance = schema.addCategory("performance");
 		lowMemorySlowSearchEnabled = performance.addBoolean("lowMemorySlowSearchEnabled", false);
@@ -335,8 +335,8 @@ public final class ClientConfig implements IClientConfig {
 		return showCreativeTabNamesEnabled.get();
 	}
 
-    @Override
-    public boolean isToastReflowEnabled() {
-        return toastReflowEnabled.get();
-    }
+	@Override
+	public boolean isToastReflowEnabled() {
+		return toastReflowEnabled.get();
+	}
 }

--- a/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
@@ -50,6 +50,7 @@ public final class ClientConfig implements IClientConfig {
 	private final Supplier<Boolean> lookupBlockTagsEnabled;
 	private final Supplier<Boolean> showTagRecipesEnabled;
 	private final Supplier<Boolean> showCreativeTabNamesEnabled;
+    private final Supplier<Boolean> toastReflowEnabled;
 
 	// input
 	private final Supplier<Integer> dragDelayMs;
@@ -98,6 +99,7 @@ public final class ClientConfig implements IClientConfig {
 		tagContentTooltipEnabled = tooltips.addBoolean("tagContentTooltipEnabled", true);
 		hideSingleTagContentTooltipEnabled = tooltips.addBoolean("hideSingleTagContentTooltipEnabled", true);
 		ingredientsSummaryEnabled = tooltips.addBoolean("enableRecipesGuiIngredientsSummary", false);
+        toastReflowEnabled = appearance.addBoolean("toastReflowEnabled", true);
 
 		IConfigCategoryBuilder performance = schema.addCategory("performance");
 		lowMemorySlowSearchEnabled = performance.addBoolean("lowMemorySlowSearchEnabled", false);
@@ -332,4 +334,9 @@ public final class ClientConfig implements IClientConfig {
 	public boolean isShowCreativeTabNamesEnabled() {
 		return showCreativeTabNamesEnabled.get();
 	}
+
+    @Override
+    public boolean isToastReflowEnabled() {
+        return toastReflowEnabled.get();
+    }
 }

--- a/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
@@ -71,4 +71,6 @@ public interface IClientConfig {
 	boolean isShowTagRecipesEnabled();
 
 	boolean isShowCreativeTabNamesEnabled();
+
+    boolean isToastReflowEnabled();
 }

--- a/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
@@ -72,5 +72,5 @@ public interface IClientConfig {
 
 	boolean isShowCreativeTabNamesEnabled();
 
-    boolean isToastReflowEnabled();
+	boolean isToastReflowEnabled();
 }

--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -39,6 +39,8 @@
   "jei.tooltip.recipe.sort.bookmarks.first.disabled": "Show bookmarked recipes first (disabled).",
   "jei.tooltip.recipe.sort.craftable.first.enabled": "Show craftable recipes first (enabled).",
   "jei.tooltip.recipe.sort.craftable.first.disabled": "Show craftable recipes first (disabled).",
+  "jei.config.client.appearance.toastReflowEnabled": "Toast Reflow",
+  "jei.config.client.appearance.toastReflowEnabled.description": "Moves toast notifications to avoid overlapping with the JEI interface.",
 
   "_comment": "Error Tooltips",
   "jei.tooltip.error.recipe.transfer.missing": "Missing Items",

--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -40,7 +40,7 @@
   "jei.tooltip.recipe.sort.craftable.first.enabled": "Show craftable recipes first (enabled).",
   "jei.tooltip.recipe.sort.craftable.first.disabled": "Show craftable recipes first (disabled).",
   "jei.config.client.appearance.toastReflowEnabled": "Toast Reflow",
-  "jei.config.client.appearance.toastReflowEnabled.description": "Moves toast notifications to avoid overlapping with the JEI interface.",
+  "jei.config.client.appearance.toastReflowEnabled.description": "Reserves space for toast notifications so they do not overlap the JEI interface.",
 
   "_comment": "Error Tooltips",
   "jei.tooltip.error.recipe.transfer.missing": "Missing Items",

--- a/Fabric/src/main/java/mezz/jei/fabric/platform/ScreenHelper.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/platform/ScreenHelper.java
@@ -72,11 +72,11 @@ public class ScreenHelper implements IPlatformScreenHelper {
 
 	@Override
 	public ImmutableRect2i getToastsArea() {
-        IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
-        if (!clientConfig.isToastReflowEnabled()) {
-            return ImmutableRect2i.EMPTY;
-        }
-        Minecraft minecraft = Minecraft.getInstance();
+		IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
+		if (!clientConfig.isToastReflowEnabled()) {
+			return ImmutableRect2i.EMPTY;
+		}
+		Minecraft minecraft = Minecraft.getInstance();
 		ToastManager toastManager = minecraft.gui.toastManager();
 		List<ToastManager.ToastInstance<?>> visible = toastManager.visibleToasts;
 		if (visible.isEmpty()) {

--- a/Fabric/src/main/java/mezz/jei/fabric/platform/ScreenHelper.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/platform/ScreenHelper.java
@@ -1,6 +1,8 @@
 package mezz.jei.fabric.platform;
 
 import com.mojang.blaze3d.platform.Window;
+import mezz.jei.common.Internal;
+import mezz.jei.common.config.IClientConfig;
 import mezz.jei.common.platform.IPlatformScreenHelper;
 import mezz.jei.common.util.ImmutableRect2i;
 import net.minecraft.client.Minecraft;
@@ -70,7 +72,11 @@ public class ScreenHelper implements IPlatformScreenHelper {
 
 	@Override
 	public ImmutableRect2i getToastsArea() {
-		Minecraft minecraft = Minecraft.getInstance();
+        IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
+        if (!clientConfig.isToastReflowEnabled()) {
+            return ImmutableRect2i.EMPTY;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
 		ToastManager toastManager = minecraft.gui.toastManager();
 		List<ToastManager.ToastInstance<?>> visible = toastManager.visibleToasts;
 		if (visible.isEmpty()) {

--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/gui/ToastGuiHandler.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/gui/ToastGuiHandler.java
@@ -13,20 +13,20 @@ import java.util.List;
 
 public class ToastGuiHandler implements IGlobalGuiHandler {
 
-    @Override
-    public Collection<Rect2i> getGuiExtraAreas() {
-        IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
+	@Override
+	public Collection<Rect2i> getGuiExtraAreas() {
+		IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
 
-        if (!clientConfig.isToastReflowEnabled()) {
-            return List.of();
-        }
+		if (!clientConfig.isToastReflowEnabled()) {
+			return List.of();
+		}
 
-        IPlatformScreenHelper screenHelper = Services.PLATFORM.getScreenHelper();
-        ImmutableRect2i toastsArea = screenHelper.getToastsArea();
+		IPlatformScreenHelper screenHelper = Services.PLATFORM.getScreenHelper();
+		ImmutableRect2i toastsArea = screenHelper.getToastsArea();
 
-        if (toastsArea.isEmpty()) {
-            return List.of();
-        }
-        return List.of(toastsArea.toMutable());
-    }
+		if (toastsArea.isEmpty()) {
+			return List.of();
+		}
+		return List.of(toastsArea.toMutable());
+	}
 }

--- a/Library/src/main/java/mezz/jei/library/plugins/vanilla/gui/ToastGuiHandler.java
+++ b/Library/src/main/java/mezz/jei/library/plugins/vanilla/gui/ToastGuiHandler.java
@@ -1,6 +1,8 @@
 package mezz.jei.library.plugins.vanilla.gui;
 
 import mezz.jei.api.gui.handlers.IGlobalGuiHandler;
+import mezz.jei.common.Internal;
+import mezz.jei.common.config.IClientConfig;
 import mezz.jei.common.platform.IPlatformScreenHelper;
 import mezz.jei.common.platform.Services;
 import mezz.jei.common.util.ImmutableRect2i;
@@ -10,13 +12,21 @@ import java.util.Collection;
 import java.util.List;
 
 public class ToastGuiHandler implements IGlobalGuiHandler {
-	@Override
-	public Collection<Rect2i> getGuiExtraAreas() {
-		IPlatformScreenHelper screenHelper = Services.PLATFORM.getScreenHelper();
-		ImmutableRect2i toastsArea = screenHelper.getToastsArea();
-		if (toastsArea.isEmpty()) {
-			return List.of();
-		}
-		return List.of(toastsArea.toMutable());
-	}
+
+    @Override
+    public Collection<Rect2i> getGuiExtraAreas() {
+        IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
+
+        if (!clientConfig.isToastReflowEnabled()) {
+            return List.of();
+        }
+
+        IPlatformScreenHelper screenHelper = Services.PLATFORM.getScreenHelper();
+        ImmutableRect2i toastsArea = screenHelper.getToastsArea();
+
+        if (toastsArea.isEmpty()) {
+            return List.of();
+        }
+        return List.of(toastsArea.toMutable());
+    }
 }

--- a/NeoForge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
+++ b/NeoForge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
@@ -149,6 +149,11 @@ public class TestClientConfig implements IClientConfig {
 	}
 
 	@Override
+	public boolean isToastReflowEnabled() {
+		return true;
+	}
+
+	@Override
 	public int getMaxRecipeGuiHeight() {
 		return 500;
 	}


### PR DESCRIPTION
**Summary:**
Added a new configuration option `toastReflowEnabled` to allow players to disable the automatic reflow of the JEI interface when toast notifications appear.

**Reasoning:**
By default, JEI shifts its item index to avoid overlapping with incoming toast notifications. When multiple toasts appear simultaneously this shifting can be visually disruptive. This change gives users the option to disable this behavior entirely.

**Important Note:**
When `toastReflowEnabled` is set to `false`, the JEI index will remain stationary, restoring the classic overlapping behavior requested by users. The toast notifications will overlap with the JEI interface, giving players full control over their preferred UI layout.
Closes #4186