### PR TITLE
Bookmark keybinding improvements

### DIFF
--- a/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
@@ -31,6 +31,7 @@ public final class ClientConfig implements IClientConfig {
 
 	// bookmarks
 	private final Supplier<Boolean> addBookmarksToFrontEnabled;
+	private final Supplier<Boolean> bookmarkOutputAsRecipe;
 	private final Supplier<List<BookmarkTooltipFeature>> bookmarkTooltipFeatures;
 	private final Supplier<Boolean> holdShiftToShowBookmarkTooltipFeaturesEnabled;
 	private final Supplier<Boolean> dragToRearrangeBookmarksEnabled;
@@ -87,6 +88,7 @@ public final class ClientConfig implements IClientConfig {
 
 		IConfigCategoryBuilder bookmarks = schema.addCategory("bookmarks");
 		addBookmarksToFrontEnabled = bookmarks.addBoolean("addBookmarksToFrontEnabled", false);
+		bookmarkOutputAsRecipe = bookmarks.addBoolean("bookmarkOutputAsRecipe", true);
 		dragToRearrangeBookmarksEnabled = bookmarks.addBoolean("dragToRearrangeBookmarksEnabled", true);
 
 		IConfigCategoryBuilder tooltips = schema.addCategory("tooltips");
@@ -193,6 +195,11 @@ public final class ClientConfig implements IClientConfig {
 	@Override
 	public boolean isAddingBookmarksToFrontEnabled() {
 		return addBookmarksToFrontEnabled.get();
+	}
+
+	@Override
+	public boolean isBookmarkOutputAsRecipeEnabled() {
+		return bookmarkOutputAsRecipe.get();
 	}
 
 	@Override

--- a/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
@@ -20,6 +20,8 @@ public interface IClientConfig {
 
 	boolean isAddingBookmarksToFrontEnabled();
 
+	boolean isBookmarkOutputAsRecipeEnabled();
+
 	boolean isLookupFluidContentsEnabled();
 
 	boolean isLookupBlockTagsEnabled();

--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -154,6 +154,8 @@
   "jei.config.client.bookmarks.description": "Config options related to Bookmarking ingredients and recipes.",
   "jei.config.client.bookmarks.addBookmarksToFrontEnabled": "Add Bookmarks to Front",
   "jei.config.client.bookmarks.addBookmarksToFrontEnabled.description": "When true, add new bookmarks to the front of the list. When false, add them to the end.",
+  "jei.config.client.bookmarks.bookmarkOutputAsRecipe": "Bookmark Output as Recipe",
+  "jei.config.client.bookmarks.bookmarkOutputAsRecipe.description": "When true, pressing the bookmark key on a recipe's output will bookmark the recipe instead of the ingredient.",
   "jei.config.client.bookmarks.dragToRearrangeBookmarksEnabled": "Drag To Rearrange Bookmarks",
   "jei.config.client.bookmarks.dragToRearrangeBookmarksEnabled.description": "Enable dragging bookmarks to rearrange them in the list.",
 

--- a/Common/src/main/resources/assets/jei/lang/zh_cn.json
+++ b/Common/src/main/resources/assets/jei/lang/zh_cn.json
@@ -149,6 +149,8 @@
   "jei.config.client.bookmarks.description": "与书签原料和配方相关的配置选项。",
   "jei.config.client.bookmarks.addBookmarksToFrontEnabled": "置顶添加书签",
   "jei.config.client.bookmarks.addBookmarksToFrontEnabled.description": "设为true时，将新书签添加到列表顶端。设为false时，将新书签添加到列表末尾。",
+  "jei.config.client.bookmarks.bookmarkOutputAsRecipe": "将产物收藏为配方书签",
+  "jei.config.client.bookmarks.bookmarkOutputAsRecipe.description": "启用后，在配方产物上按书签键会收藏该配方，而不是该原料。",
   "jei.config.client.bookmarks.dragToRearrangeBookmarksEnabled": "拖拽以重新排列书签",
   "jei.config.client.bookmarks.dragToRearrangeBookmarksEnabled.description": "启用后，可拖拽书签以重新排列其在列表中顺序。",
 

--- a/CommonApi/src/main/java/mezz/jei/api/runtime/IRecipesGui.java
+++ b/CommonApi/src/main/java/mezz/jei/api/runtime/IRecipesGui.java
@@ -1,6 +1,5 @@
 package mezz.jei.api.runtime;
 
-import mezz.jei.api.gui.IRecipeLayoutDrawable;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IFocusFactory;
@@ -68,14 +67,4 @@ public interface IRecipesGui {
 	 * @since 19.20.0
 	 */
 	Optional<Screen> getParentScreen();
-
-	/**
-	 * Get the recipe layout currently under the mouse.
-	 *
-	 * If the {@link IRecipesGui} is not open or the mouse is not over a recipe layout,
-	 * this will return {@link Optional#empty()}.
-	 */
-	default Optional<IRecipeLayoutDrawable<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
-		return Optional.empty();
-	}
 }

--- a/CommonApi/src/main/java/mezz/jei/api/runtime/IRecipesGui.java
+++ b/CommonApi/src/main/java/mezz/jei/api/runtime/IRecipesGui.java
@@ -1,5 +1,6 @@
 package mezz.jei.api.runtime;
 
+import mezz.jei.api.gui.IRecipeLayoutDrawable;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IFocusFactory;
@@ -67,4 +68,14 @@ public interface IRecipesGui {
 	 * @since 19.20.0
 	 */
 	Optional<Screen> getParentScreen();
+
+	/**
+	 * Get the recipe layout currently under the mouse.
+	 *
+	 * If the {@link IRecipesGui} is not open or the mouse is not over a recipe layout,
+	 * this will return {@link Optional#empty()}.
+	 */
+	default Optional<IRecipeLayoutDrawable<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
+		return Optional.empty();
+	}
 }

--- a/Gui/src/main/java/mezz/jei/gui/input/handlers/BookmarkInputHandler.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/handlers/BookmarkInputHandler.java
@@ -4,8 +4,6 @@ import mezz.jei.api.gui.IRecipeLayoutDrawable;
 import mezz.jei.api.gui.handlers.IGuiProperties;
 import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
 import mezz.jei.api.recipe.RecipeIngredientRole;
-import mezz.jei.api.runtime.IIngredientManager;
-import mezz.jei.api.runtime.IRecipesGui;
 import mezz.jei.common.config.IClientConfig;
 import mezz.jei.common.input.IInternalKeyMappings;
 import mezz.jei.gui.bookmarks.BookmarkList;
@@ -14,6 +12,8 @@ import mezz.jei.gui.input.CombinedRecipeFocusSource;
 import mezz.jei.gui.input.IUserInputHandler;
 import mezz.jei.gui.input.UserInput;
 import mezz.jei.gui.overlay.bookmarks.BookmarkOverlay;
+import mezz.jei.gui.recipes.IRecipeLayoutWithButtons;
+import mezz.jei.gui.recipes.RecipesGui;
 import net.minecraft.client.gui.screens.Screen;
 
 import java.util.Optional;
@@ -23,15 +23,19 @@ public class BookmarkInputHandler implements IUserInputHandler {
 	private final BookmarkList bookmarkList;
 	private final BookmarkOverlay bookmarkOverlay;
 	private final IClientConfig clientConfig;
-	private final IIngredientManager ingredientManager;
-	private final IRecipesGui recipesGui;
+	private final RecipesGui recipesGui;
 
-	public BookmarkInputHandler(CombinedRecipeFocusSource focusSource, BookmarkList bookmarkList, BookmarkOverlay bookmarkOverlay, IClientConfig clientConfig, IIngredientManager ingredientManager, IRecipesGui recipesGui) {
+	public BookmarkInputHandler(
+		CombinedRecipeFocusSource focusSource,
+		BookmarkList bookmarkList,
+		BookmarkOverlay bookmarkOverlay,
+		IClientConfig clientConfig,
+		RecipesGui recipesGui
+	) {
 		this.focusSource = focusSource;
 		this.bookmarkList = bookmarkList;
 		this.bookmarkOverlay = bookmarkOverlay;
 		this.clientConfig = clientConfig;
-		this.ingredientManager = ingredientManager;
 		this.recipesGui = recipesGui;
 	}
 
@@ -50,22 +54,20 @@ public class BookmarkInputHandler implements IUserInputHandler {
 	private Optional<IUserInputHandler> handleRecipeBookmark(UserInput input) {
 		double mouseX = input.getMouseX();
 		double mouseY = input.getMouseY();
-		Optional<IRecipeLayoutDrawable<?>> recipeLayout = recipesGui.getRecipeLayoutUnderMouse(mouseX, mouseY);
-		if (recipeLayout.isEmpty()) {
+		Optional<IRecipeLayoutWithButtons<?>> layoutWithButtons = recipesGui.getRecipeLayoutUnderMouse(mouseX, mouseY);
+		if (layoutWithButtons.isEmpty()) {
 			return Optional.empty();
 		}
 
-		IRecipeLayoutDrawable<?> layout = recipeLayout.get();
-		Optional<RecipeSlotUnderMouse> slotUnderMouse = layout.getSlotUnderMouse(mouseX, mouseY);
-		if (slotUnderMouse.isPresent()) {
-			RecipeIngredientRole role = slotUnderMouse.get().slot().getRole();
-			if (role != RecipeIngredientRole.OUTPUT || !clientConfig.isBookmarkOutputAsRecipeEnabled()) {
-				return Optional.empty();
-			}
+		IRecipeLayoutWithButtons<?> recipeLayoutWithButtons = layoutWithButtons.get();
+		RecipeBookmark<?, ?> recipeBookmark = recipeLayoutWithButtons.getRecipeBookmark();
+		if (recipeBookmark == null) {
+			return Optional.empty();
 		}
 
-		RecipeBookmark<?, ?> recipeBookmark = RecipeBookmark.create(layout, ingredientManager);
-		if (recipeBookmark == null) {
+		IRecipeLayoutDrawable<?> layout = recipeLayoutWithButtons.getRecipeLayout();
+		Optional<RecipeSlotUnderMouse> slotUnderMouse = layout.getSlotUnderMouse(mouseX, mouseY);
+		if (!shouldBookmarkRecipe(slotUnderMouse, clientConfig.isBookmarkOutputAsRecipeEnabled())) {
 			return Optional.empty();
 		}
 
@@ -73,6 +75,16 @@ public class BookmarkInputHandler implements IUserInputHandler {
 			bookmarkList.toggleBookmark(recipeBookmark);
 		}
 		return Optional.of(new SameElementInputHandler(this, layout::isMouseOver));
+	}
+
+	static boolean shouldBookmarkRecipe(Optional<RecipeSlotUnderMouse> slotUnderMouse, boolean bookmarkOutputAsRecipeEnabled) {
+		return slotUnderMouse
+			.map(slot -> shouldBookmarkRecipe(slot.slot().getRole(), bookmarkOutputAsRecipeEnabled))
+			.orElse(true);
+	}
+
+	static boolean shouldBookmarkRecipe(RecipeIngredientRole role, boolean bookmarkOutputAsRecipeEnabled) {
+		return role == RecipeIngredientRole.OUTPUT && bookmarkOutputAsRecipeEnabled;
 	}
 
 	private Optional<IUserInputHandler> handleIngredientBookmark(UserInput input, IInternalKeyMappings keyBindings) {

--- a/Gui/src/main/java/mezz/jei/gui/input/handlers/BookmarkInputHandler.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/handlers/BookmarkInputHandler.java
@@ -1,8 +1,15 @@
 package mezz.jei.gui.input.handlers;
 
+import mezz.jei.api.gui.IRecipeLayoutDrawable;
 import mezz.jei.api.gui.handlers.IGuiProperties;
+import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.runtime.IRecipesGui;
+import mezz.jei.common.config.IClientConfig;
 import mezz.jei.common.input.IInternalKeyMappings;
 import mezz.jei.gui.bookmarks.BookmarkList;
+import mezz.jei.gui.bookmarks.RecipeBookmark;
 import mezz.jei.gui.input.CombinedRecipeFocusSource;
 import mezz.jei.gui.input.IUserInputHandler;
 import mezz.jei.gui.input.UserInput;
@@ -15,22 +22,60 @@ public class BookmarkInputHandler implements IUserInputHandler {
 	private final CombinedRecipeFocusSource focusSource;
 	private final BookmarkList bookmarkList;
 	private final BookmarkOverlay bookmarkOverlay;
+	private final IClientConfig clientConfig;
+	private final IIngredientManager ingredientManager;
+	private final IRecipesGui recipesGui;
 
-	public BookmarkInputHandler(CombinedRecipeFocusSource focusSource, BookmarkList bookmarkList, BookmarkOverlay bookmarkOverlay) {
+	public BookmarkInputHandler(CombinedRecipeFocusSource focusSource, BookmarkList bookmarkList, BookmarkOverlay bookmarkOverlay, IClientConfig clientConfig, IIngredientManager ingredientManager, IRecipesGui recipesGui) {
 		this.focusSource = focusSource;
 		this.bookmarkList = bookmarkList;
 		this.bookmarkOverlay = bookmarkOverlay;
+		this.clientConfig = clientConfig;
+		this.ingredientManager = ingredientManager;
+		this.recipesGui = recipesGui;
 	}
 
 	@Override
 	public Optional<IUserInputHandler> handleUserInput(Screen screen, IGuiProperties guiProperties, UserInput input, IInternalKeyMappings keyBindings) {
 		if (input.is(keyBindings.getBookmark())) {
-			return handleBookmark(input, keyBindings);
+			Optional<IUserInputHandler> recipeHandler = handleRecipeBookmark(input);
+			if (recipeHandler.isPresent()) {
+				return recipeHandler;
+			}
+			return handleIngredientBookmark(input, keyBindings);
 		}
 		return Optional.empty();
 	}
 
-	private Optional<IUserInputHandler> handleBookmark(UserInput input, IInternalKeyMappings keyBindings) {
+	private Optional<IUserInputHandler> handleRecipeBookmark(UserInput input) {
+		double mouseX = input.getMouseX();
+		double mouseY = input.getMouseY();
+		Optional<IRecipeLayoutDrawable<?>> recipeLayout = recipesGui.getRecipeLayoutUnderMouse(mouseX, mouseY);
+		if (recipeLayout.isEmpty()) {
+			return Optional.empty();
+		}
+
+		IRecipeLayoutDrawable<?> layout = recipeLayout.get();
+		Optional<RecipeSlotUnderMouse> slotUnderMouse = layout.getSlotUnderMouse(mouseX, mouseY);
+		if (slotUnderMouse.isPresent()) {
+			RecipeIngredientRole role = slotUnderMouse.get().slot().getRole();
+			if (role != RecipeIngredientRole.OUTPUT || !clientConfig.isBookmarkOutputAsRecipeEnabled()) {
+				return Optional.empty();
+			}
+		}
+
+		RecipeBookmark<?, ?> recipeBookmark = RecipeBookmark.create(layout, ingredientManager);
+		if (recipeBookmark == null) {
+			return Optional.empty();
+		}
+
+		if (!input.isSimulate()) {
+			bookmarkList.toggleBookmark(recipeBookmark);
+		}
+		return Optional.of(new SameElementInputHandler(this, layout::isMouseOver));
+	}
+
+	private Optional<IUserInputHandler> handleIngredientBookmark(UserInput input, IInternalKeyMappings keyBindings) {
 		return focusSource.getIngredientUnderMouse(input, keyBindings)
 			.findFirst()
 			.flatMap(clicked -> {

--- a/Gui/src/main/java/mezz/jei/gui/recipes/IRecipeLayoutWithButtons.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/IRecipeLayoutWithButtons.java
@@ -1,8 +1,10 @@
 package mezz.jei.gui.recipes;
 
 import mezz.jei.api.gui.IRecipeLayoutDrawable;
+import mezz.jei.gui.bookmarks.RecipeBookmark;
 import mezz.jei.gui.input.IUserInputHandler;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import org.jspecify.annotations.Nullable;
 
 public interface IRecipeLayoutWithButtons<R> {
 	void draw(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks);
@@ -16,6 +18,9 @@ public interface IRecipeLayoutWithButtons<R> {
 	void tick();
 
 	IRecipeLayoutDrawable<R> getRecipeLayout();
+
+	@Nullable
+	RecipeBookmark<?, ?> getRecipeBookmark();
 
 	void drawTooltips(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY);
 

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeGuiLayouts.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeGuiLayouts.java
@@ -109,11 +109,11 @@ public class RecipeGuiLayouts {
 			.flatMap(Optional::stream);
 	}
 
-	public Optional<IRecipeLayoutDrawable<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
+	public Optional<IRecipeLayoutWithButtons<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
 		for (IRecipeLayoutWithButtons<?> recipeLayoutWithButtons : recipeLayoutsWithButtons) {
 			IRecipeLayoutDrawable<?> recipeLayout = recipeLayoutWithButtons.getRecipeLayout();
 			if (recipeLayout.isMouseOver(mouseX, mouseY)) {
-				return Optional.of(recipeLayout);
+				return Optional.of(recipeLayoutWithButtons);
 			}
 		}
 		return Optional.empty();

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeGuiLayouts.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeGuiLayouts.java
@@ -109,6 +109,16 @@ public class RecipeGuiLayouts {
 			.flatMap(Optional::stream);
 	}
 
+	public Optional<IRecipeLayoutDrawable<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
+		for (IRecipeLayoutWithButtons<?> recipeLayoutWithButtons : recipeLayoutsWithButtons) {
+			IRecipeLayoutDrawable<?> recipeLayout = recipeLayoutWithButtons.getRecipeLayout();
+			if (recipeLayout.isMouseOver(mouseX, mouseY)) {
+				return Optional.of(recipeLayout);
+			}
+		}
+		return Optional.empty();
+	}
+
 	private static Optional<IClickableIngredientInternal<?>> getClickedIngredient(RecipeSlotUnderMouse slotUnderMouse) {
 		return slotUnderMouse.slot().getDisplayedIngredient()
 			.map(displayedIngredient -> {

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeLayoutWithButtons.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeLayoutWithButtons.java
@@ -51,20 +51,23 @@ public final class RecipeLayoutWithButtons<R> implements IRecipeLayoutWithButton
 			}
 		}
 
-		return new RecipeLayoutWithButtons<>(recipeLayoutDrawable, transferButton, buttons);
+		return new RecipeLayoutWithButtons<>(recipeLayoutDrawable, transferButton, recipeBookmark, buttons);
 	}
 
 	private final IRecipeLayoutDrawable<R> recipeLayout;
 	private final RecipeTransferButtonController transferButton;
+	private final @Nullable RecipeBookmark<?, ?> recipeBookmark;
 	private final List<IconButton> buttons;
 
 	private RecipeLayoutWithButtons(
 		IRecipeLayoutDrawable<R> recipeLayout,
 		RecipeTransferButtonController transferButton,
+		@Nullable RecipeBookmark<?, ?> recipeBookmark,
 		List<IconButton> buttons
 	) {
 		this.recipeLayout = recipeLayout;
 		this.transferButton = transferButton;
+		this.recipeBookmark = recipeBookmark;
 		this.buttons = buttons;
 	}
 
@@ -153,6 +156,11 @@ public final class RecipeLayoutWithButtons<R> implements IRecipeLayoutWithButton
 	@Override
 	public IRecipeLayoutDrawable<R> getRecipeLayout() {
 		return recipeLayout;
+	}
+
+	@Override
+	public @Nullable RecipeBookmark<?, ?> getRecipeBookmark() {
+		return recipeBookmark;
 	}
 
 	@Override

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeLayoutWithButtonsErrored.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeLayoutWithButtonsErrored.java
@@ -6,12 +6,14 @@ import mezz.jei.api.gui.handlers.IGuiProperties;
 import mezz.jei.common.Internal;
 import mezz.jei.common.gui.RecipeLayoutDrawableErrored;
 import mezz.jei.common.input.IInternalKeyMappings;
+import mezz.jei.gui.bookmarks.RecipeBookmark;
 import mezz.jei.gui.input.IUserInputHandler;
 import mezz.jei.gui.input.UserInput;
 import mezz.jei.gui.input.handlers.CombinedInputHandler;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.Rect2i;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -65,6 +67,11 @@ public final class RecipeLayoutWithButtonsErrored<R> implements IRecipeLayoutWit
 	@Override
 	public IRecipeLayoutDrawable<R> getRecipeLayout() {
 		return errorLayout;
+	}
+
+	@Override
+	public @Nullable RecipeBookmark<?, ?> getRecipeBookmark() {
+		return null;
 	}
 
 	@Override

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -564,8 +564,7 @@ public class RecipesGui extends Screen implements IRecipesGui, IRecipeFocusSourc
 			.findFirst();
 	}
 
-	@Override
-	public Optional<IRecipeLayoutDrawable<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
+	public Optional<IRecipeLayoutWithButtons<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
 		if (!isOpen()) {
 			return Optional.empty();
 		}

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -564,6 +564,14 @@ public class RecipesGui extends Screen implements IRecipesGui, IRecipeFocusSourc
 			.findFirst();
 	}
 
+	@Override
+	public Optional<IRecipeLayoutDrawable<?>> getRecipeLayoutUnderMouse(double mouseX, double mouseY) {
+		if (!isOpen()) {
+			return Optional.empty();
+		}
+		return layouts.getRecipeLayoutUnderMouse(mouseX, mouseY);
+	}
+
 	public void back() {
 		logic.back();
 	}

--- a/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
+++ b/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
@@ -237,7 +237,7 @@ public class JeiGuiStarter {
 			ingredientListOverlay.createInputHandler(),
 			bookmarkOverlay.createInputHandler(),
 			new FocusInputHandler(recipeFocusSource, recipesGui, focusUtil, clientConfig, ingredientManager, toggleState, serverConnection),
-			new BookmarkInputHandler(recipeFocusSource, bookmarkList, bookmarkOverlay),
+			new BookmarkInputHandler(recipeFocusSource, bookmarkList, bookmarkOverlay, clientConfig, ingredientManager, recipesGui),
 			new GlobalInputHandler(toggleState),
 			new GuiAreaInputHandler(screenHelper, recipesGui, focusFactory)
 		);

--- a/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
+++ b/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
@@ -237,7 +237,7 @@ public class JeiGuiStarter {
 			ingredientListOverlay.createInputHandler(),
 			bookmarkOverlay.createInputHandler(),
 			new FocusInputHandler(recipeFocusSource, recipesGui, focusUtil, clientConfig, ingredientManager, toggleState, serverConnection),
-			new BookmarkInputHandler(recipeFocusSource, bookmarkList, bookmarkOverlay, clientConfig, ingredientManager, recipesGui),
+			new BookmarkInputHandler(recipeFocusSource, bookmarkList, bookmarkOverlay, clientConfig, recipesGui),
 			new GlobalInputHandler(toggleState),
 			new GuiAreaInputHandler(screenHelper, recipesGui, focusFactory)
 		);

--- a/NeoForge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
+++ b/NeoForge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
@@ -44,6 +44,11 @@ public class TestClientConfig implements IClientConfig {
 	}
 
 	@Override
+	public boolean isBookmarkOutputAsRecipeEnabled() {
+		return true;
+	}
+
+	@Override
 	public boolean isLookupFluidContentsEnabled() {
 		return false;
 	}


### PR DESCRIPTION
Allow the use of shortcut keys for the recipe layout, typically key A, to add a recipe as a bookmark. At the same time, the output of the recipe is allowed to be treated as the recipe bookmark itself and added to the bookmark list, while also providing configurable options.

I set this configuration to default on, mainly considering that most users typically do not bookmark individual recipe outputs but rather the recipe itself. Although it modifies the long-standing habit of JEI, I believe this aligns with user preferences, as multiple users have given me feedback that they wish for this.