### PR TITLE
Fix ingredient grid anchor reset on overlay close

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollController.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollController.java
@@ -209,6 +209,11 @@ public final class IngredientGridScrollController {
 			ingredientGrid.size()
 		);
 		updateGridFromScrollState(ingredientList);
+		if (!isSmoothScrolling()) {
+			this.ingredientGrid.getVisibleElements()
+				.findFirst()
+				.ifPresent(this::setScrollAnchorElement);
+		}
 		return true;
 	}
 

--- a/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollController.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollController.java
@@ -49,6 +49,7 @@ public final class IngredientGridScrollController {
 			visibleIngredientCount
 		);
 		updateGridFromScrollState(ingredientList);
+		rememberFirstVisibleElementAsScrollAnchor();
 	}
 
 	public void updateLayoutKeepingScrollAnchorVisible(@Nullable IElement<?> scrollAnchorElement) {
@@ -209,12 +210,16 @@ public final class IngredientGridScrollController {
 			ingredientGrid.size()
 		);
 		updateGridFromScrollState(ingredientList);
+		rememberFirstVisibleElementAsScrollAnchor();
+		return true;
+	}
+
+	private void rememberFirstVisibleElementAsScrollAnchor() {
 		if (!isSmoothScrolling()) {
 			this.ingredientGrid.getVisibleElements()
 				.findFirst()
 				.ifPresent(this::setScrollAnchorElement);
 		}
-		return true;
 	}
 
 	private void updateGridFromScrollState(List<IElement<?>> ingredientList) {

--- a/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollState.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollState.java
@@ -34,17 +34,21 @@ public final class IngredientGridScrollState {
 		int rowHeight
 	) {
 		int anchorIndex = IngredientGridPageState.findIndexOfIngredientElement(scrollAnchorElement, ingredientList);
-		float anchorPositionY = getStoredScrollAnchorPositionY(scrollAnchorElement);
-		this.scrollOffsetY = getScrollOffsetYKeepingAnchorVisible(
-			anchorIndex,
-			ingredientList.size(),
-			columns,
-			visibleRows,
-			visibleIngredientCount,
-			anchorPositionY,
-			smoothScrolling,
-			rowHeight
-		);
+		if (anchorIndex < 0) {
+			this.scrollOffsetY = getValidScrollOffsetY(this.scrollOffsetY, ingredientList.size(), columns, visibleRows, visibleIngredientCount);
+		} else {
+			float anchorPositionY = getStoredScrollAnchorPositionY(scrollAnchorElement);
+			this.scrollOffsetY = getScrollOffsetYKeepingAnchorVisible(
+				anchorIndex,
+				ingredientList.size(),
+				columns,
+				visibleRows,
+				visibleIngredientCount,
+				anchorPositionY,
+				smoothScrolling,
+				rowHeight
+			);
+		}
 	}
 
 	@Nullable

--- a/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollState.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollState.java
@@ -36,19 +36,20 @@ public final class IngredientGridScrollState {
 		int anchorIndex = IngredientGridPageState.findIndexOfIngredientElement(scrollAnchorElement, ingredientList);
 		if (anchorIndex < 0) {
 			this.scrollOffsetY = getValidScrollOffsetY(this.scrollOffsetY, ingredientList.size(), columns, visibleRows, visibleIngredientCount);
-		} else {
-			float anchorPositionY = getStoredScrollAnchorPositionY(scrollAnchorElement);
-			this.scrollOffsetY = getScrollOffsetYKeepingAnchorVisible(
-				anchorIndex,
-				ingredientList.size(),
-				columns,
-				visibleRows,
-				visibleIngredientCount,
-				anchorPositionY,
-				smoothScrolling,
-				rowHeight
-			);
+			return;
 		}
+
+		float anchorPositionY = getStoredScrollAnchorPositionY(scrollAnchorElement);
+		this.scrollOffsetY = getScrollOffsetYKeepingAnchorVisible(
+			anchorIndex,
+			ingredientList.size(),
+			columns,
+			visibleRows,
+			visibleIngredientCount,
+			anchorPositionY,
+			smoothScrolling,
+			rowHeight
+		);
 	}
 
 	@Nullable

--- a/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationController.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationController.java
@@ -94,13 +94,10 @@ public class IngredientGridWithNavigationController implements IPaged, IUserInpu
 
 	@Nullable
 	public IElement<?> getPageAnchorElement() {
-		IElement<?> pageAnchorElement;
 		if (usesScrollbar()) {
-			pageAnchorElement = this.scrollController.getScrollAnchorElement();
-		} else {
-			List<IElement<?>> ingredientList = ingredientSource.getElements();
-			pageAnchorElement = this.pageState.getPageAnchorElement(ingredientList);
+			return this.scrollController.getScrollAnchorElement();
 		}
+		IElement<?> pageAnchorElement = this.pageState.getPageAnchorElement(ingredientSource.getElements());
 		if (pageAnchorElement != null) {
 			return pageAnchorElement;
 		}
@@ -121,7 +118,20 @@ public class IngredientGridWithNavigationController implements IPaged, IUserInpu
 			int renderFirstItemIndex = this.pageState.updateForPageNavigation(firstItemIndex, ingredientList.size(), ingredientGrid.size());
 			this.ingredientGrid.set(renderFirstItemIndex, ingredientList);
 		}
+		if (!isSmoothScrolling()) {
+			this.ingredientGrid.getVisibleElements()
+				.findFirst()
+				.ifPresent(this::setAnchorElement);
+		}
 		this.onLayoutChanged.run();
+	}
+
+	private void setAnchorElement(IElement<?> element) {
+		if (usesScrollbar()) {
+			this.scrollController.setScrollAnchorElement(element);
+		} else {
+			this.pageState.setPageAnchorElement(element);
+		}
 	}
 
 	@Override
@@ -261,6 +271,11 @@ public class IngredientGridWithNavigationController implements IPaged, IUserInpu
 	private boolean usesScrollbar() {
 		return this.gridConfig.getNavigationMode()
 			.usesScrollbar();
+	}
+
+	private boolean isSmoothScrolling() {
+		return this.gridConfig.getNavigationMode()
+			.usesSmoothScrolling();
 	}
 
 	public boolean canScroll() {

--- a/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationController.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationController.java
@@ -117,21 +117,15 @@ public class IngredientGridWithNavigationController implements IPaged, IUserInpu
 			List<IElement<?>> ingredientList = ingredientSource.getElements();
 			int renderFirstItemIndex = this.pageState.updateForPageNavigation(firstItemIndex, ingredientList.size(), ingredientGrid.size());
 			this.ingredientGrid.set(renderFirstItemIndex, ingredientList);
-		}
-		if (!isSmoothScrolling()) {
-			this.ingredientGrid.getVisibleElements()
-				.findFirst()
-				.ifPresent(this::setAnchorElement);
+			rememberFirstVisibleElementAsPageAnchor();
 		}
 		this.onLayoutChanged.run();
 	}
 
-	private void setAnchorElement(IElement<?> element) {
-		if (usesScrollbar()) {
-			this.scrollController.setScrollAnchorElement(element);
-		} else {
-			this.pageState.setPageAnchorElement(element);
-		}
+	private void rememberFirstVisibleElementAsPageAnchor() {
+		this.ingredientGrid.getVisibleElements()
+			.findFirst()
+			.ifPresent(this.pageState::setPageAnchorElement);
 	}
 
 	@Override
@@ -271,11 +265,6 @@ public class IngredientGridWithNavigationController implements IPaged, IUserInpu
 	private boolean usesScrollbar() {
 		return this.gridConfig.getNavigationMode()
 			.usesScrollbar();
-	}
-
-	private boolean isSmoothScrolling() {
-		return this.gridConfig.getNavigationMode()
-			.usesSmoothScrolling();
 	}
 
 	public boolean canScroll() {

--- a/Gui/src/test/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollStateTest.java
+++ b/Gui/src/test/java/mezz/jei/gui/overlay/ingredients/IngredientGridScrollStateTest.java
@@ -1,6 +1,13 @@
 package mezz.jei.gui.overlay.ingredients;
 
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.gui.overlay.elements.IElement;
+import mezz.jei.gui.overlay.elements.IngredientElement;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static mezz.jei.gui.overlay.ingredients.IngredientGridScrollState.getFirstItemIndexForScrollOffset;
 import static mezz.jei.gui.overlay.ingredients.IngredientGridScrollState.getFirstRowForSmoothScrollPixelOffset;
@@ -13,6 +20,8 @@ import static mezz.jei.gui.overlay.ingredients.IngredientGridScrollState.getVali
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IngredientGridScrollStateTest {
+	private static final IIngredientType<Integer> INTEGER_TYPE = () -> Integer.class;
+
 	@Test
 	public void hiddenRowsAreTotalRowsMinusVisibleRows() {
 		// Setup: 100 ingredients in a nine-column grid take 12 rows, and six rows are visible.
@@ -159,6 +168,32 @@ public class IngredientGridScrollStateTest {
 	}
 
 	@Test
+	public void missingAnchorPreservesScrollOffsetWhenLayoutStillScrolls() {
+		// Setup: the overlay was closed after the user scrolled down, so there is no visible element to use
+		// as an anchor when the overlay opens again.
+		int itemCount = 100;
+		int columns = 10;
+		int visibleRows = 5;
+		int visibleIngredientCount = 50;
+		IngredientGridScrollState scrollState = new IngredientGridScrollState();
+		scrollState.updateForScrollOffset(0.5f, itemCount, columns, visibleRows, visibleIngredientCount);
+
+		// Operation: update the layout without an anchor while the grid is still scrollable.
+		scrollState.updateKeepingScrollAnchorVisible(
+			null,
+			createElements(itemCount),
+			columns,
+			visibleRows,
+			visibleIngredientCount,
+			false,
+			IngredientGridLayout.INGREDIENT_HEIGHT
+		);
+
+		// Assertions: the reopen/layout pass keeps the current scroll position instead of resetting to top.
+		assertEquals(0.5f, scrollState.getScrollOffsetY());
+	}
+
+	@Test
 	public void scrollOffsetKeepingAnchorVisibleClampsAtBottom() {
 		// Setup: the anchor is in the last row, where its requested relative position cannot be preserved.
 		int itemCount = 1000;
@@ -196,5 +231,25 @@ public class IngredientGridScrollStateTest {
 
 		// Assertions: there is no meaningful scroll offset without columns.
 		assertEquals(0, firstItemIndex);
+	}
+
+	private static List<IElement<?>> createElements(int itemCount) {
+		List<IElement<?>> elements = new ArrayList<>();
+		for (int i = 0; i < itemCount; i++) {
+			elements.add(new IngredientElement<>(new TestTypedIngredient(i)));
+		}
+		return List.copyOf(elements);
+	}
+
+	private record TestTypedIngredient(Integer ingredient) implements ITypedIngredient<Integer> {
+		@Override
+		public IIngredientType<Integer> getType() {
+			return INTEGER_TYPE;
+		}
+
+		@Override
+		public Integer getIngredient() {
+			return ingredient;
+		}
 	}
 }

--- a/NeoForge/src/test/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationControllerTest.java
+++ b/NeoForge/src/test/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationControllerTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IngredientGridWithNavigationControllerTest {
@@ -193,6 +194,28 @@ public class IngredientGridWithNavigationControllerTest {
 	}
 
 	@Test
+	public void pagedModeKeepsNavigatedPageWhenOverlayReopensWithoutVisibleElements() {
+		// Setup: the user navigates to the second page, then the overlay closes so the grid no longer exposes
+		// visible elements as a fallback anchor.
+		Fixture fixture = Fixture.create(3, 7, true);
+		fixture.controller.updateLayoutToFirstPage();
+		assertTrue(fixture.controller.nextPage());
+		fixture.grid.hideVisibleElements();
+		fixture.clearLayoutChanges();
+
+		// Operation: reopen the overlay using the controller's page anchor.
+		IElement<?> pageAnchor = fixture.controller.getPageAnchorElement();
+		fixture.controller.updateLayoutKeepingPageAnchorVisible(pageAnchor);
+
+		// Assertions: the controller remembered the first element on the navigated-to page before the overlay
+		// closed, so reopening does not reset to the first page.
+		assertSame(fixture.source.getElements().get(3), pageAnchor);
+		assertEquals(1, fixture.layoutChanges);
+		assertEquals(3, fixture.grid.firstItemIndex);
+		assertEquals(1, fixture.controller.getPageNumber());
+	}
+
+	@Test
 	public void zeroScrollDeltaIsNotConsumed() {
 		// Setup: the mouse is over a grid with multiple pages.
 		Fixture fixture = Fixture.create(3, 7, true);
@@ -223,6 +246,29 @@ public class IngredientGridWithNavigationControllerTest {
 		assertEquals(1, fixture.layoutChanges);
 		assertEquals(1, fixture.controller.getPageNumber());
 		assertEquals(3, fixture.grid.firstItemIndex);
+		assertEquals(0, fixture.grid.scrollOffsetY);
+	}
+
+	@Test
+	public void scrollingModeKeepsScrolledRowWhenOverlayReopensWithoutVisibleElements() {
+		// Setup: the user scrolls down one row, then the overlay closes so the grid no longer exposes visible
+		// elements as a fallback anchor.
+		Fixture fixture = Fixture.create(3, 7, true, IngredientGridNavigationMode.SCROLLING);
+		fixture.controller.updateLayoutToFirstPage();
+		fixture.controller.setScrollOffsetY(0.5f);
+		fixture.grid.hideVisibleElements();
+		fixture.clearLayoutChanges();
+
+		// Operation: reopen the overlay using the controller's page anchor.
+		IElement<?> pageAnchor = fixture.controller.getPageAnchorElement();
+		fixture.controller.updateLayoutKeepingPageAnchorVisible(pageAnchor);
+
+		// Assertions: the scrollbar controller remembered the first visible element at the scrolled row before
+		// the overlay closed, so reopening does not reset to the top.
+		assertSame(fixture.source.getElements().get(3), pageAnchor);
+		assertEquals(1, fixture.layoutChanges);
+		assertEquals(3, fixture.grid.firstItemIndex);
+		assertEquals(1, fixture.controller.getPageNumber());
 		assertEquals(0, fixture.grid.scrollOffsetY);
 	}
 
@@ -489,6 +535,8 @@ public class IngredientGridWithNavigationControllerTest {
 		private int visibleSlotCount;
 		private int firstItemIndex;
 		private int scrollOffsetY;
+		private List<IElement<?>> visibleElements = List.of();
+		private boolean exposeVisibleElements = true;
 
 		private TestNavigationGrid(int slotCount) {
 			this(slotCount, 1);
@@ -508,6 +556,10 @@ public class IngredientGridWithNavigationControllerTest {
 
 		private void setVisibleSlotCount(int visibleSlotCount) {
 			this.visibleSlotCount = visibleSlotCount;
+		}
+
+		private void hideVisibleElements() {
+			this.exposeVisibleElements = false;
 		}
 
 		@Override
@@ -539,11 +591,17 @@ public class IngredientGridWithNavigationControllerTest {
 		public void set(int firstItemIndex, int scrollOffsetY, List<IElement<?>> ingredientList) {
 			this.firstItemIndex = firstItemIndex;
 			this.scrollOffsetY = scrollOffsetY;
+			int startIndex = Math.clamp(firstItemIndex, 0, ingredientList.size());
+			int endIndex = Math.min(startIndex + this.visibleSlotCount, ingredientList.size());
+			this.visibleElements = List.copyOf(ingredientList.subList(startIndex, endIndex));
 		}
 
 		@Override
 		public Stream<IElement<?>> getVisibleElements() {
-			return Stream.of();
+			if (!exposeVisibleElements) {
+				return Stream.empty();
+			}
+			return visibleElements.stream();
 		}
 
 		@Override

--- a/NeoForge/src/test/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationControllerTest.java
+++ b/NeoForge/src/test/java/mezz/jei/gui/overlay/ingredients/IngredientGridWithNavigationControllerTest.java
@@ -52,7 +52,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IngredientGridWithNavigationControllerTest {
@@ -194,22 +193,19 @@ public class IngredientGridWithNavigationControllerTest {
 	}
 
 	@Test
-	public void pagedModeKeepsNavigatedPageWhenOverlayReopensWithoutVisibleElements() {
+	public void pagedModeKeepsNavigatedPageWhenOverlayReopens() {
 		// Setup: the user navigates to the second page, then the overlay closes so the grid no longer exposes
 		// visible elements as a fallback anchor.
 		Fixture fixture = Fixture.create(3, 7, true);
 		fixture.controller.updateLayoutToFirstPage();
 		assertTrue(fixture.controller.nextPage());
-		fixture.grid.hideVisibleElements();
-		fixture.clearLayoutChanges();
+		fixture.closeOverlay();
 
 		// Operation: reopen the overlay using the controller's page anchor.
-		IElement<?> pageAnchor = fixture.controller.getPageAnchorElement();
-		fixture.controller.updateLayoutKeepingPageAnchorVisible(pageAnchor);
+		fixture.reopenOverlay();
 
 		// Assertions: the controller remembered the first element on the navigated-to page before the overlay
 		// closed, so reopening does not reset to the first page.
-		assertSame(fixture.source.getElements().get(3), pageAnchor);
 		assertEquals(1, fixture.layoutChanges);
 		assertEquals(3, fixture.grid.firstItemIndex);
 		assertEquals(1, fixture.controller.getPageNumber());
@@ -250,25 +246,24 @@ public class IngredientGridWithNavigationControllerTest {
 	}
 
 	@Test
-	public void scrollingModeKeepsScrolledRowWhenOverlayReopensWithoutVisibleElements() {
-		// Setup: the user scrolls down one row, then the overlay closes so the grid no longer exposes visible
-		// elements as a fallback anchor.
-		Fixture fixture = Fixture.create(3, 7, true, IngredientGridNavigationMode.SCROLLING);
+	public void scrollingModeKeepsScrolledRowWhenOverlayReopensAfterGridSizeChanges() {
+		// Setup: the user scrolls down to the fourth row, then the overlay closes so the grid no longer exposes
+		// visible elements as a fallback anchor.
+		Fixture fixture = Fixture.create(3, 3, 30, true, IngredientGridNavigationMode.SCROLLING);
 		fixture.controller.updateLayoutToFirstPage();
-		fixture.controller.setScrollOffsetY(0.5f);
-		fixture.grid.hideVisibleElements();
-		fixture.clearLayoutChanges();
+		int hiddenRows = IngredientGridScrollState.getHiddenRows(30, 3, 3);
+		fixture.controller.setScrollOffsetY(3 / (float) hiddenRows);
+		fixture.closeOverlay();
 
-		// Operation: reopen the overlay using the controller's page anchor.
-		IElement<?> pageAnchor = fixture.controller.getPageAnchorElement();
-		fixture.controller.updateLayoutKeepingPageAnchorVisible(pageAnchor);
+		// Operation: reopen the overlay after its grid size changes.
+		fixture.grid.setGridSize(3, 5);
+		fixture.reopenOverlay();
 
 		// Assertions: the scrollbar controller remembered the first visible element at the scrolled row before
-		// the overlay closed, so reopening does not reset to the top.
-		assertSame(fixture.source.getElements().get(3), pageAnchor);
+		// the overlay closed, so reopening does not reset or drift to another row.
 		assertEquals(1, fixture.layoutChanges);
-		assertEquals(3, fixture.grid.firstItemIndex);
-		assertEquals(1, fixture.controller.getPageNumber());
+		assertEquals(9, fixture.grid.firstItemIndex);
+		assertEquals(3, fixture.controller.getPageNumber());
 		assertEquals(0, fixture.grid.scrollOffsetY);
 	}
 
@@ -472,6 +467,15 @@ public class IngredientGridWithNavigationControllerTest {
 		void clearLayoutChanges() {
 			this.layoutChanges = 0;
 		}
+
+		void closeOverlay() {
+			this.grid.clearVisibleElements();
+			clearLayoutChanges();
+		}
+
+		void reopenOverlay() {
+			this.controller.updateLayoutKeepingPageAnchorVisible(this.controller.getPageAnchorElement());
+		}
 	}
 
 	private record TestGridConfig(IngredientGridNavigationMode navigationMode) implements IIngredientGridConfig {
@@ -536,7 +540,6 @@ public class IngredientGridWithNavigationControllerTest {
 		private int firstItemIndex;
 		private int scrollOffsetY;
 		private List<IElement<?>> visibleElements = List.of();
-		private boolean exposeVisibleElements = true;
 
 		private TestNavigationGrid(int slotCount) {
 			this(slotCount, 1);
@@ -558,8 +561,8 @@ public class IngredientGridWithNavigationControllerTest {
 			this.visibleSlotCount = visibleSlotCount;
 		}
 
-		private void hideVisibleElements() {
-			this.exposeVisibleElements = false;
+		private void clearVisibleElements() {
+			this.visibleElements = List.of();
 		}
 
 		@Override
@@ -598,9 +601,6 @@ public class IngredientGridWithNavigationControllerTest {
 
 		@Override
 		public Stream<IElement<?>> getVisibleElements() {
-			if (!exposeVisibleElements) {
-				return Stream.empty();
-			}
 			return visibleElements.stream();
 		}
 


### PR DESCRIPTION
see this gif:
<img width="735" height="415" alt="202607206235810_small" src="https://github.com/user-attachments/assets/ef3652d6-5611-4431-aaf8-d163d7ead03a" />

Based on the commit history, I suspect this [commit](https://github.com/mezz/JustEnoughItems/commit/7d1237fffe3e64c90ac60efeef2b7469b236bb11) caused the issue.