### PR TITLE
Fix: call `super.extractRenderState`

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipesGui.java
@@ -310,6 +310,8 @@ public class RecipesGui extends Screen implements IRecipesGui, IRecipeFocusSourc
 
 	@Override
 	public void extractRenderState(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks) {
+		super.extractRenderState(guiGraphics, mouseX, mouseY, partialTicks);
+		
 		guiGraphics.fill(
 			previousRecipeCategory.getX() + previousRecipeCategory.getWidth(),
 			previousRecipeCategory.getY(),


### PR DESCRIPTION
Unlike the 26.2 version, JEI's Recipe GUI for 26.1 does not call `super.extractRenderState`, which led to hard to diagnose compatibility issues with mods that expect vanilla `Screen` methods to be called, like the [method that renders vanilla renderables](https://mcsrc.dev/1/26.1.2/net/minecraft/client/gui/screens/Screen#L126-128).