### PR TITLE
Backport 26.2 ingredient grid anchor system to 1.20.1

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/input/DelegatingClickableIngredientInternal.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/DelegatingClickableIngredientInternal.java
@@ -1,0 +1,49 @@
+package mezz.jei.gui.input;
+
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.runtime.IRecipesGui;
+import mezz.jei.gui.overlay.elements.IElement;
+import mezz.jei.gui.util.FocusUtil;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+public class DelegatingClickableIngredientInternal<T> implements IClickableIngredientInternal<T> {
+	private final IClickableIngredientInternal<T> delegate;
+
+	public DelegatingClickableIngredientInternal(IClickableIngredientInternal<T> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public ITypedIngredient<T> getTypedIngredient() {
+		return delegate.getTypedIngredient();
+	}
+
+	@Override
+	public IElement<T> getElement() {
+		return delegate.getElement();
+	}
+
+	@Override
+	public boolean isMouseOver(double mouseX, double mouseY) {
+		return delegate.isMouseOver(mouseX, mouseY);
+	}
+
+	@Override
+	public ItemStack getCheatItemStack(IIngredientManager ingredientManager) {
+		return delegate.getCheatItemStack(ingredientManager);
+	}
+
+	@Override
+	public boolean canClickToFocus() {
+		return delegate.canClickToFocus();
+	}
+
+	@Override
+	public void show(IRecipesGui recipesGui, FocusUtil focusUtil, List<RecipeIngredientRole> roles) {
+		delegate.show(recipesGui, focusUtil, roles);
+	}
+}

--- a/Gui/src/main/java/mezz/jei/gui/input/IClickableIngredientInternal.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/IClickableIngredientInternal.java
@@ -1,9 +1,14 @@
 package mezz.jei.gui.input;
 
 import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.runtime.IRecipesGui;
 import mezz.jei.gui.overlay.elements.IElement;
+import mezz.jei.gui.util.FocusUtil;
 import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
 
 
 public interface IClickableIngredientInternal<T> {
@@ -31,4 +36,11 @@ public interface IClickableIngredientInternal<T> {
 	 * in order to let players navigate recipes.
 	 */
 	boolean canClickToFocus();
+
+	/**
+	 * Open recipes or usages for this ingredient.
+	 */
+	default void show(IRecipesGui recipesGui, FocusUtil focusUtil, List<RecipeIngredientRole> roles) {
+		getElement().show(recipesGui, focusUtil, roles);
+	}
 }

--- a/Gui/src/main/java/mezz/jei/gui/input/handlers/FocusInputHandler.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/handlers/FocusInputHandler.java
@@ -103,8 +103,7 @@ public class FocusInputHandler implements IUserInputHandler {
 			.findFirst()
 			.map(clicked -> {
 				if (!input.isSimulate()) {
-					IElement<?> element = clicked.getElement();
-					element.show(recipesGui, focusUtil, roles);
+					clicked.show(recipesGui, focusUtil, roles);
 				}
 				return new SameElementInputHandler(this, clicked::isMouseOver);
 			});

--- a/Gui/src/main/java/mezz/jei/gui/overlay/IngredientGridPageState.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/IngredientGridPageState.java
@@ -1,0 +1,102 @@
+package mezz.jei.gui.overlay;
+
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.common.util.MathUtil;
+import mezz.jei.gui.overlay.elements.IElement;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+final class IngredientGridPageState {
+	/**
+	 * The normalized first item index for the page currently being rendered.
+	 * Requested item indexes and anchor indexes are rounded down to their containing page before being stored here.
+	 */
+	private int firstItemIndex = 0;
+	/**
+	 * An explicit element to keep visible when the ingredient list or grid bounds change.
+	 * When this is missing or stale, the caller should fall back to the first visible element.
+	 */
+	@Nullable
+	private IElement<?> pageAnchorElement;
+
+	public int getFirstItemIndex() {
+		return firstItemIndex;
+	}
+
+	public int updateForPageNavigation(int firstItemIndex, int itemCount, int itemsPerPage) {
+		this.pageAnchorElement = null;
+		this.firstItemIndex = getFirstItemIndexForValidPage(firstItemIndex, itemCount, itemsPerPage);
+		return this.firstItemIndex;
+	}
+
+	public int updateKeepingPageAnchorVisible(@Nullable IElement<?> pageAnchorElement, List<IElement<?>> ingredientList, int itemsPerPage) {
+		int anchorIndex = findIndexOfIngredientElement(pageAnchorElement, ingredientList);
+		this.firstItemIndex = getFirstItemIndexForValidPage(anchorIndex, ingredientList.size(), itemsPerPage);
+		return this.firstItemIndex;
+	}
+
+	public @Nullable IElement<?> getPageAnchorElement(List<IElement<?>> ingredientList) {
+		if (this.pageAnchorElement != null) {
+			if (findIndexOfIngredientElement(this.pageAnchorElement, ingredientList) >= 0) {
+				return this.pageAnchorElement;
+			}
+			this.pageAnchorElement = null;
+		}
+		return null;
+	}
+
+	public void setPageAnchorElement(IElement<?> pageAnchorElement) {
+		this.pageAnchorElement = pageAnchorElement;
+	}
+
+	static int findIndexOfIngredientElement(@Nullable IElement<?> element, List<IElement<?>> ingredientList) {
+		if (element == null) {
+			return -1;
+		}
+		for (int i = 0; i < ingredientList.size(); i++) {
+			if (isSameIngredientElement(ingredientList.get(i), element)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	static boolean isSameIngredientElement(IElement<?> first, IElement<?> second) {
+		if (first == second) {
+			return true;
+		}
+
+		ITypedIngredient<?> firstIngredient = first.getTypedIngredient();
+		ITypedIngredient<?> secondIngredient = second.getTypedIngredient();
+		return firstIngredient == secondIngredient ||
+			(firstIngredient.getType().equals(secondIngredient.getType()) &&
+				firstIngredient.getIngredient() == secondIngredient.getIngredient());
+	}
+
+	static int getFirstItemIndexForValidPage(int firstItemIndex, int itemCount, int itemsPerPage) {
+		if (itemCount == 0 || itemsPerPage == 0) {
+			return 0;
+		}
+		int requestedPageStart = (Math.max(0, firstItemIndex) / itemsPerPage) * itemsPerPage;
+		int lastPageIndex = ((itemCount - 1) / itemsPerPage) * itemsPerPage;
+		return Math.min(requestedPageStart, lastPageIndex);
+	}
+
+	static int getPageCount(int itemCount, int itemsPerPage) {
+		if (itemsPerPage == 0) {
+			return 1;
+		}
+		int pageCount = MathUtil.divideCeil(itemCount, itemsPerPage);
+		pageCount = Math.max(1, pageCount);
+		return pageCount;
+	}
+
+	static int getPageNumberForFirstItemIndex(int firstItemIndex, int itemsPerPage, int itemCount) {
+		int firstIndex = getFirstItemIndexForValidPage(firstItemIndex, itemCount, itemsPerPage);
+		if (itemsPerPage == 0) {
+			return 0;
+		}
+		return firstIndex / itemsPerPage;
+	}
+}

--- a/Gui/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/IngredientGridWithNavigation.java
@@ -1,7 +1,9 @@
 package mezz.jei.gui.overlay;
 
 import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.runtime.IRecipesGui;
 import mezz.jei.api.runtime.IScreenHelper;
 import mezz.jei.common.config.IClientConfig;
 import mezz.jei.common.config.IClientToggleState;
@@ -14,6 +16,7 @@ import mezz.jei.common.util.ImmutableRect2i;
 import mezz.jei.common.util.MathUtil;
 import mezz.jei.gui.PageNavigation;
 import mezz.jei.gui.ghost.GhostIngredientDragManager;
+import mezz.jei.gui.input.DelegatingClickableIngredientInternal;
 import mezz.jei.gui.input.IClickableIngredientInternal;
 import mezz.jei.gui.input.IDragHandler;
 import mezz.jei.gui.input.IDraggableIngredientInternal;
@@ -27,6 +30,7 @@ import mezz.jei.gui.input.handlers.SameElementInputHandler;
 import mezz.jei.gui.overlay.elements.IElement;
 import mezz.jei.gui.recipes.RecipesGui;
 import mezz.jei.gui.util.CommandUtil;
+import mezz.jei.gui.util.FocusUtil;
 import mezz.jei.gui.util.MaximalRectangle;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
@@ -51,7 +55,7 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 	private static final int BORDER_PADDING = 5;
 	private static final int INNER_PADDING = 2;
 
-	private int firstItemIndex = 0;
+	private final IngredientGridPageState pageState = new IngredientGridPageState();
 	private final IngredientGridPaged pageDelegate;
 	private final PageNavigation navigation;
 	private final IIngredientGridConfig gridConfig;
@@ -100,8 +104,11 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 
 		this.ingredientSource.addSourceListChangedListener(() -> {
 			if (isActive()) {
-				boolean resetToFirstPage = clientConfig.isAddingBookmarksToFrontEnabled();
-				updateLayout(resetToFirstPage);
+				if (clientConfig.isAddingBookmarksToFrontEnabled()) {
+					updateLayoutToFirstPage();
+				} else {
+					updateLayoutKeepingPageAnchorVisible(getPageAnchorElement());
+				}
 			}
 		});
 	}
@@ -116,14 +123,54 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 
 	public void updateLayout(boolean resetToFirstPage) {
 		if (resetToFirstPage) {
-			firstItemIndex = 0;
+			updateLayoutToFirstPage();
+		} else {
+			updateLayoutStartingAt(this.pageState.getFirstItemIndex());
 		}
+	}
+
+	public void updateLayoutToFirstPage() {
+		updateLayoutStartingAt(0);
+	}
+
+	public void updateLayoutKeepingPageAnchorVisible(@Nullable IElement<?> pageAnchorElement) {
 		List<IElement<?>> ingredientList = ingredientSource.getElements();
-		if (firstItemIndex >= ingredientList.size()) {
-			firstItemIndex = 0;
-		}
+		int firstItemIndex = this.pageState.updateKeepingPageAnchorVisible(pageAnchorElement, ingredientList, ingredientGrid.size());
 		this.ingredientGrid.set(firstItemIndex, ingredientList);
 		this.navigation.updatePageNumber();
+	}
+
+	@Nullable
+	public IElement<?> getPageAnchorElement() {
+		IElement<?> pageAnchorElement = this.pageState.getPageAnchorElement(ingredientSource.getElements());
+		if (pageAnchorElement != null) {
+			return pageAnchorElement;
+		}
+		return this.ingredientGrid.getSlots()
+			.map(IngredientListSlot::getOptionalElement)
+			.flatMap(Optional::stream)
+			.findFirst()
+			.orElse(null);
+	}
+
+	public <T> IClickableIngredientInternal<T> createPageAnchorIngredient(IClickableIngredientInternal<T> delegate) {
+		return new PageAnchorClickableIngredient<>(delegate);
+	}
+
+	private void updateLayoutStartingAt(int firstItemIndex) {
+		List<IElement<?>> ingredientList = ingredientSource.getElements();
+		int renderFirstItemIndex = this.pageState.updateForPageNavigation(firstItemIndex, ingredientList.size(), ingredientGrid.size());
+		this.ingredientGrid.set(renderFirstItemIndex, ingredientList);
+		this.navigation.updatePageNumber();
+		setAnchorToFirstVisible();
+	}
+
+	private void setAnchorToFirstVisible() {
+		this.ingredientGrid.getSlots()
+			.map(IngredientListSlot::getOptionalElement)
+			.flatMap(Optional::stream)
+			.findFirst()
+			.ifPresent(this.pageState::setPageAnchorElement);
 	}
 
 	private static ImmutableRect2i avoidExclusionAreas(
@@ -294,7 +341,8 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 
 	@Override
 	public Stream<IClickableIngredientInternal<?>> getIngredientUnderMouse(double mouseX, double mouseY) {
-		return this.ingredientGrid.getIngredientUnderMouse(mouseX, mouseY);
+		return this.ingredientGrid.getIngredientUnderMouse(mouseX, mouseY)
+			.map(this::createPageAnchorIngredient);
 	}
 
 	@Override
@@ -339,15 +387,14 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 			}
 			final int itemsCount = ingredientSource.getElements().size();
 			if (itemsCount > 0) {
-				firstItemIndex += ingredientGrid.size();
-				if (firstItemIndex >= itemsCount) {
-					firstItemIndex = 0;
+				int nextFirstItemIndex = pageState.getFirstItemIndex() + ingredientGrid.size();
+				if (nextFirstItemIndex >= itemsCount) {
+					nextFirstItemIndex = 0;
 				}
-				updateLayout(false);
+				updateLayoutStartingAt(nextFirstItemIndex);
 				return true;
 			} else {
-				firstItemIndex = 0;
-				updateLayout(false);
+				updateLayoutStartingAt(0);
 				return false;
 			}
 		}
@@ -360,25 +407,24 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 
 			final int itemsPerPage = ingredientGrid.size();
 			if (itemsPerPage == 0) {
-				firstItemIndex = 0;
-				updateLayout(false);
+				updateLayoutStartingAt(0);
 				return false;
 			}
 			final int itemsCount = ingredientSource.getElements().size();
 
-			int pageNum = firstItemIndex / itemsPerPage;
+			int pageNum = pageState.getFirstItemIndex() / itemsPerPage;
 			if (pageNum == 0) {
 				pageNum = itemsCount / itemsPerPage;
 			} else {
 				pageNum--;
 			}
 
-			firstItemIndex = itemsPerPage * pageNum;
-			if (firstItemIndex > 0 && firstItemIndex == itemsCount) {
+			int previousFirstItemIndex = itemsPerPage * pageNum;
+			if (previousFirstItemIndex > 0 && previousFirstItemIndex == itemsCount) {
 				pageNum--;
-				firstItemIndex = itemsPerPage * pageNum;
+				previousFirstItemIndex = itemsPerPage * pageNum;
 			}
-			updateLayout(false);
+			updateLayoutStartingAt(previousFirstItemIndex);
 			return true;
 		}
 
@@ -396,23 +442,27 @@ public class IngredientGridWithNavigation implements IRecipeFocusSource {
 
 		@Override
 		public int getPageCount() {
-			final int itemCount = ingredientSource.getElements().size();
-			final int stacksPerPage = ingredientGrid.size();
-			if (stacksPerPage == 0) {
-				return 1;
-			}
-			int pageCount = MathUtil.divideCeil(itemCount, stacksPerPage);
-			pageCount = Math.max(1, pageCount);
-			return pageCount;
+			return IngredientGridPageState.getPageCount(ingredientSource.getElements().size(), ingredientGrid.size());
 		}
 
 		@Override
 		public int getPageNumber() {
-			final int stacksPerPage = ingredientGrid.size();
-			if (stacksPerPage == 0) {
-				return 0;
+			return IngredientGridPageState.getPageNumberForFirstItemIndex(pageState.getFirstItemIndex(), ingredientGrid.size(), ingredientSource.getElements().size());
+		}
+	}
+
+	private class PageAnchorClickableIngredient<T> extends DelegatingClickableIngredientInternal<T> {
+		PageAnchorClickableIngredient(IClickableIngredientInternal<T> delegate) {
+			super(delegate);
+		}
+
+		@Override
+		public void show(IRecipesGui recipesGui, FocusUtil focusUtil, List<RecipeIngredientRole> roles) {
+			IElement<T> element = getElement();
+			if (element.isVisible()) {
+				pageState.setPageAnchorElement(element);
 			}
-			return firstItemIndex / stacksPerPage;
+			super.show(recipesGui, focusUtil, roles);
 		}
 	}
 

--- a/Gui/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/IngredientListOverlay.java
@@ -29,6 +29,7 @@ import mezz.jei.gui.input.handlers.NullInputHandler;
 import mezz.jei.gui.input.handlers.ProxyDragHandler;
 import mezz.jei.gui.input.handlers.ProxyInputHandler;
 import mezz.jei.gui.overlay.bookmarks.history.LookupHistoryOverlay;
+import mezz.jei.gui.overlay.elements.IElement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import org.jetbrains.annotations.Nullable;
@@ -54,6 +55,7 @@ public class IngredientListOverlay implements IIngredientListOverlay, IRecipeFoc
 	private final IInternalKeyMappings keyBindings;
 	private final ScreenPropertiesCache screenPropertiesCache;
 	private final IFilterTextSource filterTextSource;
+	private String lastFilterText = "";
 
 
 	// these need to be stored as strong references here because listeners are weakly stored elsewhere
@@ -82,9 +84,10 @@ public class IngredientListOverlay implements IIngredientListOverlay, IRecipeFoc
 		this.keyBindings = keyBindings;
 		this.filterTextSource = filterTextSource;
 		this.searchField.setValue(filterTextSource.getFilterText());
+		this.lastFilterText = filterTextSource.getFilterText();
 		this.searchField.setFocused(false);
 		this.searchField.setResponder(filterTextSource::setFilterText);
-		filterTextSource.addListener(this.searchField::setValue);
+		filterTextSource.addListener(this::onFilterTextChanged);
 
 		ingredientGridSource.addSourceListChangedListener(() -> {
 			Minecraft minecraft = Minecraft.getInstance();
@@ -139,7 +142,7 @@ public class IngredientListOverlay implements IIngredientListOverlay, IRecipeFoc
 		ImmutableRect2i availableContentsArea = getAvailableContentsArea(displayArea, searchBarCentered);
 		if (clientConfig.isLookupHistoryEnabled() && lookupHistoryOverlay.isOnSide()) {
 			int historyRows = clientConfig.getMaxLookupHistoryRows();
-			availableContentsArea  = availableContentsArea.cropBottom(historyRows * LookupHistoryOverlay.SLOT_HEIGHT);
+			availableContentsArea = availableContentsArea.cropBottom(historyRows * LookupHistoryOverlay.SLOT_HEIGHT);
 			ImmutableRect2i historyArea = displayArea
 				.insetBy(BORDER_MARGIN)
 				.moveUp(BUTTON_SIZE + INNER_PADDING)
@@ -147,10 +150,9 @@ public class IngredientListOverlay implements IIngredientListOverlay, IRecipeFoc
 			this.lookupHistoryOverlay.updateBounds(historyArea, guiExclusionAreas, null);
 			this.lookupHistoryOverlay.updateLayout();
 		}
-		int legacySize = contents.size();
+		IElement<?> pageAnchorElement = this.contents.getPageAnchorElement();
 		this.contents.updateBounds(availableContentsArea, guiExclusionAreas, null);
-		boolean resetToFirstPage = legacySize != contents.size();
-		this.contents.updateLayout(resetToFirstPage);
+		this.contents.updateLayoutKeepingPageAnchorVisible(pageAnchorElement);
 
 		final ImmutableRect2i searchAndConfigArea = getSearchAndConfigArea(displayArea, searchBarCentered, guiProperties);
 		final ImmutableRect2i searchArea = searchAndConfigArea.cropRight(BUTTON_SIZE);
@@ -160,6 +162,14 @@ public class IngredientListOverlay implements IIngredientListOverlay, IRecipeFoc
 		this.searchField.updateBounds(searchArea);
 
 		this.configButton.updateBounds(configButtonArea);
+	}
+
+	private void onFilterTextChanged(String filterText) {
+		this.searchField.setValue(filterText);
+		if (!this.lastFilterText.isEmpty() && filterText.isEmpty()) {
+			this.contents.updateLayoutToFirstPage();
+		}
+		this.lastFilterText = filterText;
 	}
 
 	private static boolean isSearchBarCentered(IClientConfig clientConfig, IGuiProperties guiProperties) {

--- a/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
@@ -150,10 +150,9 @@ public class BookmarkOverlay implements IRecipeFocusSource, IBookmarkOverlay {
 			this.lookupHistoryOverlay.updateBounds(historyArea, guiExclusionAreas, mouseExclusionArea);
 			this.lookupHistoryOverlay.updateLayout();
 		}
-		int legacySize = contents.size();
+		IElement<?> pageAnchorElement = this.contents.getPageAnchorElement();
 		this.contents.updateBounds(availableContentsArea, guiExclusionAreas, mouseExclusionArea);
-		boolean resetToFirstPage = legacySize != contents.size();
-		this.contents.updateLayout(resetToFirstPage);
+		this.contents.updateLayoutKeepingPageAnchorVisible(pageAnchorElement);
 
 		if (contents.hasRoom()) {
 			ImmutableRect2i contentsArea = this.contents.getBackgroundArea();


### PR DESCRIPTION
Backport the 26.2 design to fix the related resize issue.
same as #4387 