### PR TITLE
Utilize `getCreatorNamespace` on Fabric

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/platform/ItemStackHelper.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/platform/ItemStackHelper.java
@@ -18,7 +18,7 @@ public class ItemStackHelper implements IPlatformItemStackHelper {
 
 	@Override
 	public Optional<String> getCreatorModId(ItemStack stack) {
-		return Optional.empty();
+		return Optional.of(stack.getCreatorNamespace());
 	}
 
 	@Override


### PR DESCRIPTION
Fabric has had a method equivalent to NeoForge's `getCreatorModId` since 1.21.8, and I backported it to 1.21.1, 1.21.4, and 1.21.5 when it was initially released.
https://github.com/FabricMC/fabric-api/pull/4746