### PR TITLE
Move ContainerScreenEvent to ScreenEvent.Render.Foreground

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/events/JeiScreenEvents.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/events/JeiScreenEvents.java
@@ -6,7 +6,6 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 
 public class JeiScreenEvents {
 	public static final Event<DrawForeground> DRAW_FOREGROUND = createDrawForegroundEvent();
@@ -26,7 +25,7 @@ public class JeiScreenEvents {
 	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface DrawForeground {
-		void drawForeground(AbstractContainerScreen<?> screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY);
+		void drawForeground(Screen screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY);
 	}
 
 	public static final Event<DrawBackground> DRAW_BACKGROUND = createDrawBackgroundEvent();
@@ -36,9 +35,9 @@ public class JeiScreenEvents {
 	}
 
 	private static DrawBackground createDrawBackgroundInvoker(DrawBackground[] callbacks) {
-		return (screen, guiGraphics, mouseX, mouseY, partialTicks) -> {
+		return (screen, guiGraphics) -> {
 			for (DrawBackground callback : callbacks) {
-				callback.drawBackground(screen, guiGraphics, mouseX, mouseY, partialTicks);
+				callback.drawBackground(screen, guiGraphics);
 			}
 		};
 	}
@@ -46,6 +45,6 @@ public class JeiScreenEvents {
 	@Environment(EnvType.CLIENT)
 	@FunctionalInterface
 	public interface DrawBackground {
-		void drawBackground(Screen screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTicks);
+		void drawBackground(Screen screen, GuiGraphicsExtractor guiGraphics);
 	}
 }

--- a/Fabric/src/main/java/mezz/jei/fabric/mixin/ScreenMixin.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/mixin/ScreenMixin.java
@@ -3,7 +3,6 @@ package mezz.jei.fabric.mixin;
 import mezz.jei.fabric.events.JeiScreenEvents;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import org.joml.Matrix3x2fStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -26,7 +25,7 @@ public class ScreenMixin {
 		Screen screen = (Screen) (Object) this;
 		runWithIdentityPose(
 			graphics,
-			() -> JeiScreenEvents.DRAW_BACKGROUND.invoker().drawBackground(screen, graphics, mouseX, mouseY, a)
+			() -> JeiScreenEvents.DRAW_BACKGROUND.invoker().drawBackground(screen, graphics)
 		);
 	}
 
@@ -42,13 +41,11 @@ public class ScreenMixin {
 	private void drawForeground(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a, CallbackInfo ci) {
 		@SuppressWarnings("DataFlowIssue")
 		Screen screen = (Screen) (Object) this;
-		if (screen instanceof AbstractContainerScreen<?> containerScreen) {
-			graphics.nextStratum();
-			runWithIdentityPose(
-				graphics,
-				() -> JeiScreenEvents.DRAW_FOREGROUND.invoker().drawForeground(containerScreen, graphics, mouseX, mouseY)
-			);
-		}
+		graphics.nextStratum();
+		runWithIdentityPose(
+			graphics,
+			() -> JeiScreenEvents.DRAW_FOREGROUND.invoker().drawForeground(screen, graphics, mouseX, mouseY)
+		);
 	}
 
 	private static void runWithIdentityPose(GuiGraphicsExtractor graphics, Runnable runnable) {

--- a/Fabric/src/main/java/mezz/jei/fabric/startup/EventRegistration.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/startup/EventRegistration.java
@@ -14,7 +14,6 @@ import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
@@ -123,15 +122,15 @@ public class EventRegistration {
 		}
 	}
 
-	private void drawForeground(AbstractContainerScreen<?> screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+	private void drawForeground(Screen screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
 		if (guiEventHandler != null) {
-			guiEventHandler.drawForContainerScreen(screen, guiGraphics, mouseX, mouseY);
+			guiEventHandler.drawForScreenForeground(screen, guiGraphics, mouseX, mouseY);
 		}
 	}
 
-	private void drawBackground(Screen screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float tickDelta) {
+	private void drawBackground(Screen screen, GuiGraphicsExtractor guiGraphics) {
 		if (guiEventHandler != null) {
-			guiEventHandler.drawForScreen(screen, guiGraphics, mouseX, mouseY);
+			guiEventHandler.drawForScreenBackground(screen, guiGraphics);
 		}
 	}
 

--- a/Gui/src/main/java/mezz/jei/gui/events/GuiEventHandler.java
+++ b/Gui/src/main/java/mezz/jei/gui/events/GuiEventHandler.java
@@ -67,25 +67,21 @@ public class GuiEventHandler {
 	}
 
 	/**
-	 * Draws after the screen contents and before deferred tooltips are extracted.
+	 * Draws the JEI overlay backgrounds, before the screen contents are drawn.
 	 */
-	public void drawForContainerScreen(AbstractContainerScreen<?> screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
-		IGuiProperties guiProperties = screenHelper.getGuiProperties(screen).orElse(null);
-		drawOverlayForegrounds(guiGraphics, mouseX, mouseY, true);
-		drawPostForeground(screen, guiProperties, guiGraphics, mouseX, mouseY);
-	}
-
-	public void drawForScreen(Screen screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+	public void drawForScreenBackground(Screen screen, GuiGraphicsExtractor guiGraphics) {
 		IGuiProperties guiProperties = screenHelper.getGuiProperties(screen).orElse(null);
 		updateOverlayProperties(screen, guiProperties);
-
 		drawOverlayBackgrounds(guiGraphics);
+	}
 
-		if (screen instanceof AbstractContainerScreen<?>) {
-			return;
-		}
-
-		drawOverlayForegrounds(guiGraphics, mouseX, mouseY, false);
+	/**
+	 * Draws the JEI overlay foregrounds, after the screen contents and before deferred tooltips are extracted.
+	 */
+	public void drawForScreenForeground(Screen screen, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+		IGuiProperties guiProperties = screenHelper.getGuiProperties(screen).orElse(null);
+		boolean drawScreenForeground = screen instanceof AbstractContainerScreen<?>;
+		drawOverlayForegrounds(guiGraphics, mouseX, mouseY, drawScreenForeground);
 		drawPostForeground(screen, guiProperties, guiGraphics, mouseX, mouseY);
 	}
 

--- a/NeoForge/src/main/java/mezz/jei/neoforge/startup/EventRegistration.java
+++ b/NeoForge/src/main/java/mezz/jei/neoforge/startup/EventRegistration.java
@@ -9,11 +9,9 @@ import mezz.jei.neoforge.input.ForgeUserInput;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.input.CharacterEvent;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
-import net.neoforged.neoforge.client.event.ContainerScreenEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import org.joml.Matrix3x2fStack;
 
@@ -111,23 +109,21 @@ public class EventRegistration {
 			Screen screen = event.getScreen();
 			guiEventHandler.onGuiOpen(screen);
 		});
-		subscriptions.register(EventPriority.LOWEST, ContainerScreenEvent.Render.Foreground.class, event -> {
-			AbstractContainerScreen<?> containerScreen = event.getContainerScreen();
+		subscriptions.register(EventPriority.LOWEST, ScreenEvent.Render.Foreground.class, event -> {
+			Screen screen = event.getScreen();
 			var guiGraphics = event.getGuiGraphics();
 			int mouseX = event.getMouseX();
 			int mouseY = event.getMouseY();
 			guiGraphics.nextStratum();
 			runWithIdentityPose(guiGraphics, () -> {
-				guiEventHandler.drawForContainerScreen(containerScreen, guiGraphics, mouseX, mouseY);
+				guiEventHandler.drawForScreenForeground(screen, guiGraphics, mouseX, mouseY);
 			});
 		});
 		subscriptions.register(EventPriority.HIGHEST, ScreenEvent.Render.Background.class, event -> {
 			Screen screen = event.getScreen();
 			var guiGraphics = event.getGuiGraphics();
-			int mouseX = event.getMouseX();
-			int mouseY = event.getMouseY();
 			runWithIdentityPose(guiGraphics, () -> {
-				guiEventHandler.drawForScreen(screen, guiGraphics, mouseX, mouseY);
+				guiEventHandler.drawForScreenBackground(screen, guiGraphics);
 			});
 		});
 		subscriptions.register(ScreenEvent.RenderInventoryMobEffects.class, event -> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,11 +27,11 @@ minecraftVersionRangeStart=26.2
 
 # NeoForge
 # https://projects.neoforged.net/neoforged/neoforge
-neoforgeVersion=26.2.0.24-beta
+neoforgeVersion=26.2.0.40-beta
 neoforgeLoaderVersionRange=[4,)
-# first version with net.neoforged.neoforge.common.extensions.TooltipFlagExtension#shouldDisplayAllInformation
-# https://github.com/neoforged/NeoForge/commit/788b7c3c2ce49846f641d5ec02e95da32d62dc78
-neoforgeVersionRange=[26.2.0.16-beta,)
+# first version with net.neoforged.neoforge.client.event.ScreenEvent.Render.Foreground
+# https://github.com/neoforged/NeoForge/pull/3342
+neoforgeVersionRange=[26.2.0.40-beta,)
 neogradle.subsystems.conventions.runs.create-default-run-per-type=false
 
 # Fabric


### PR DESCRIPTION
Update NeoForge to 26.2.0.40-beta and migrate from ContainerScreenEvent.Render.Foreground to ScreenEvent.Render.Foreground for both Fabric and NeoForge. 