### PR TITLE
Fix IME preedit rendering in the ingredient search field

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/mixin/CreativeModeInventoryScreenMixin.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/mixin/CreativeModeInventoryScreenMixin.java
@@ -1,0 +1,26 @@
+package mezz.jei.fabric.mixin;
+
+import mezz.jei.gui.input.GuiTextFieldFilter;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+import net.minecraft.client.input.PreeditEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CreativeModeInventoryScreen.class)
+public abstract class CreativeModeInventoryScreenMixin {
+	@Inject(
+		method = "preeditUpdated",
+		at = @At("HEAD"),
+		cancellable = true
+	)
+	private void jei$preeditUpdated(PreeditEvent event, CallbackInfoReturnable<Boolean> cir) {
+		CreativeModeInventoryScreen screen = (CreativeModeInventoryScreen) (Object) this;
+		GuiEventListener focused = screen.getFocused();
+		if (focused instanceof GuiTextFieldFilter searchField && searchField.isFocused()) {
+			cir.setReturnValue(searchField.preeditUpdated(event));
+		}
+	}
+}

--- a/Fabric/src/main/resources/jei.mixins.json
+++ b/Fabric/src/main/resources/jei.mixins.json
@@ -8,6 +8,7 @@
   ],
   "client": [
     "ClientPacketListenerRecipeUpdateMixin",
+    "CreativeModeInventoryScreenMixin",
     "EffectsInInventoryMixin",
     "GuiGraphicsExtractorMixin",
     "KeyboardHandlerMixin",

--- a/Gui/src/main/java/mezz/jei/gui/input/GuiTextFieldFilter.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/GuiTextFieldFilter.java
@@ -84,15 +84,21 @@ public class GuiTextFieldFilter extends EditBox implements ISearchField {
 
 		if (previousFocus != keyboardFocus) {
 			Minecraft minecraft = Minecraft.getInstance();
+			Screen screen = minecraft.screen;
 			if (keyboardFocus) {
-				Screen screen = minecraft.screen;
 				if (screen != null) {
 					screenUnfocusHandler = ScreenFocusHandler.create(screen);
 					if (screenUnfocusHandler != null) {
 						screenUnfocusHandler.unFocus();
 					}
+					screen.setFocused(this);
 				}
+				minecraft.onTextInputFocusChange(this, true);
 			} else {
+				minecraft.onTextInputFocusChange(this, false);
+				if (screen != null && screen.getFocused() == this) {
+					screen.setFocused(null);
+				}
 				if (screenUnfocusHandler != null) {
 					screenUnfocusHandler.focus();
 					screenUnfocusHandler = null;

--- a/NeoForge/src/main/java/mezz/jei/neoforge/mixin/CreativeModeInventoryScreenMixin.java
+++ b/NeoForge/src/main/java/mezz/jei/neoforge/mixin/CreativeModeInventoryScreenMixin.java
@@ -1,0 +1,26 @@
+package mezz.jei.neoforge.mixin;
+
+import mezz.jei.gui.input.GuiTextFieldFilter;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+import net.minecraft.client.input.PreeditEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CreativeModeInventoryScreen.class)
+public abstract class CreativeModeInventoryScreenMixin {
+	@Inject(
+		method = "preeditUpdated",
+		at = @At("HEAD"),
+		cancellable = true
+	)
+	private void jei$preeditUpdated(PreeditEvent event, CallbackInfoReturnable<Boolean> cir) {
+		CreativeModeInventoryScreen screen = (CreativeModeInventoryScreen) (Object) this;
+		GuiEventListener focused = screen.getFocused();
+		if (focused instanceof GuiTextFieldFilter searchField && searchField.isFocused()) {
+			cir.setReturnValue(searchField.preeditUpdated(event));
+		}
+	}
+}

--- a/NeoForge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/NeoForge/src/main/resources/META-INF/neoforge.mods.toml
@@ -73,3 +73,6 @@ ${modDescription}
 
 [modproperties.jei]
     catalogueImageIcon="jei-icon.png"
+
+[[mixins]]
+    config="jei.neoforge.mixins.json"

--- a/NeoForge/src/main/resources/jei.neoforge.mixins.json
+++ b/NeoForge/src/main/resources/jei.neoforge.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "mezz.jei.neoforge.mixin",
+  "compatibilityLevel": "JAVA_25",
+  "client": [
+    "CreativeModeInventoryScreenMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Fixes #4421 

## Summary

- Register the JEI ingredient search field as the current screen focus target while it is focused.
- Notify Minecraft when the JEI search field gains or loses text input focus.
- Route creative inventory preedit events to the JEI search field when it owns the screen focus.
- Preserve the vanilla creative search behavior when JEI does not have focus.
- Add the creative inventory handling for both Fabric and NeoForge.

## Cause

The JEI search field extends Minecraft's `EditBox`, but it is managed outside the screen's normal listener hierarchy. As a result, IME preedit events sent through the active screen do not normally reach it.

`CreativeModeInventoryScreen` also overrides `preeditUpdated` and sends the event directly to its own search box, bypassing the focused screen listener.