### PR TITLE
Fix text input being disabled for other fields by the search field

### DIFF
--- a/Gui/src/main/java/mezz/jei/gui/input/GuiTextFieldFilter.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/GuiTextFieldFilter.java
@@ -81,33 +81,36 @@ public class GuiTextFieldFilter extends EditBox implements ISearchField {
 
 	@Override
 	public void setFocused(boolean keyboardFocus) {
-		final boolean previousFocus = isFocused();
-		super.setFocused(keyboardFocus);
+		if (isFocused() == keyboardFocus) {
+			return;
+		}
 
-		if (previousFocus != keyboardFocus) {
-			Minecraft minecraft = Minecraft.getInstance();
-			Screen screen = minecraft.gui.screen();
-			if (keyboardFocus) {
-				if (screen != null) {
-					screenUnfocusHandler = ScreenFocusHandler.create(screen);
-					if (screenUnfocusHandler != null) {
-						screenUnfocusHandler.unFocus();
-					}
-					screen.setFocused(this);
-				}
-			} else {
-				if (screen != null && screen.getFocused() == this) {
-					screen.setFocused(null);
-				}
+		Minecraft minecraft = Minecraft.getInstance();
+		Screen screen = minecraft.gui.screen();
+		if (keyboardFocus) {
+			if (screen != null) {
+				screenUnfocusHandler = ScreenFocusHandler.create(screen);
 				if (screenUnfocusHandler != null) {
-					screenUnfocusHandler.focus();
-					screenUnfocusHandler = null;
+					screenUnfocusHandler.unFocus();
 				}
 			}
-
-			String text = getValue();
-			history.add(text);
+			super.setFocused(true);
+			if (screen != null) {
+				screen.setFocused(this);
+			}
+		} else {
+			super.setFocused(false);
+			if (screen != null && screen.getFocused() == this) {
+				screen.setFocused(null);
+			}
+			if (screenUnfocusHandler != null) {
+				screenUnfocusHandler.focus();
+				screenUnfocusHandler = null;
+			}
 		}
+
+		String text = getValue();
+		history.add(text);
 	}
 
 	@Override


### PR DESCRIPTION
The IME gets stuck off in a text field other than JEI's search field. It can still be turned off, but any attempt to turn it back on is reverted one tick later, so it looks like the toggle fires twice.

## Steps to reproduce

1. Open chat, turn the IME on, close chat.
2. Open the creative inventory and select the search tab. The IME is restored.
3. Focus JEI's search field, then close the inventory.
4. Open chat. The IME is off and cannot be turned back on.
5. Close and reopen chat. It works again.

Also reproducible in the recipe book: focus its search box and the IME cannot be switched on, while JEI's own search field works fine.

`EditBox.setFocused` notifies Minecraft's `TextInputManager` without checking `IngredientListOverlayController.clearScreen()`. When the search field is already unfocused, those calls stop text input for whichever field really has focus, and `TextInputManager.tick()` then force-disables the IME every tick.

## Fix

Two changes in `GuiTextFieldFilter.setFocused`:
- Return early when `isFocused() == keyboardFocus`, so redundant calls never reach `TextInputManager`.
- Release the previously focused element before claiming text input, instead of after. The last `start`/`stopTextInput` call wins, so `startTextInput` has to run last. It previously ran first and only survived because `screen.setFocused(this)` re-entered `setFocused` and called it again, which the early return now prevents.

The unfocus path already ended with `screenUnfocusHandler.focus()`, so it is unchanged.