### PR TITLE
Add config toggle to disable recipe sync warning messages

### DIFF
--- a/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/ClientConfig.java
@@ -44,6 +44,7 @@ public final class ClientConfig implements IClientConfig {
 	// advanced
 	private final ConfigValue<Boolean> lowMemorySlowSearchEnabled;
 	private final ConfigValue<Boolean> catchRenderErrorsEnabled;
+	private final ConfigValue<Boolean> recipeSyncWarningEnabled;
 	private final ConfigValue<Boolean> lookupFluidContentsEnabled;
 	private final ConfigValue<Boolean> lookupBlockTagsEnabled;
 	private final ConfigValue<Boolean> showTagRecipesEnabled;
@@ -132,6 +133,7 @@ public final class ClientConfig implements IClientConfig {
 
 		IConfigCategoryBuilder advanced = schema.addCategory("advanced");
 		catchRenderErrorsEnabled = advanced.addBoolean("catchRenderErrorsEnabled", !isDev);
+		recipeSyncWarningEnabled = advanced.addBoolean("recipeSyncWarningEnabled", true);
 
 		IConfigCategoryBuilder input = schema.addCategory("input");
 		dragDelayMs = input.addInteger(
@@ -263,6 +265,11 @@ public final class ClientConfig implements IClientConfig {
 	@Override
 	public ConfigValue<Boolean> catchRenderErrorsEnabled() {
 		return catchRenderErrorsEnabled;
+	}
+
+	@Override
+	public ConfigValue<Boolean> recipeSyncWarningEnabled() {
+		return recipeSyncWarningEnabled;
 	}
 
 	@Override

--- a/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
+++ b/Common/src/main/java/mezz/jei/common/config/IClientConfig.java
@@ -47,6 +47,8 @@ public interface IClientConfig {
 
 	IJeiConfigValue<Boolean> catchRenderErrorsEnabled();
 
+	IJeiConfigValue<Boolean> recipeSyncWarningEnabled();
+
 	IJeiConfigValue<Boolean> lookupFluidContentsEnabled();
 
 	IJeiConfigValue<Boolean> lookupBlockTagsEnabled();

--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -214,6 +214,8 @@
   "jei.config.client.advanced.description": "Advanced config options to change the way JEI functions.",
   "jei.config.client.advanced.catchRenderErrorsEnabled": "Catch Render Errors",
   "jei.config.client.advanced.catchRenderErrorsEnabled.description": "Catch render errors from modded ingredients and attempt to recover from them instead of crashing.",
+  "jei.config.client.advanced.recipeSyncWarningEnabled": "Recipe Sync Warning",
+  "jei.config.client.advanced.recipeSyncWarningEnabled.description": "Show a chat warning when the server doesn't provide synced recipes to JEI (e.g. vanilla servers, or servers without JEI installed).",
 
   "jei.config.client.sorting": "Sorting",
   "jei.config.client.sorting.description": "Config options related to how JEI sorts recipes and ingredients.",

--- a/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
+++ b/Library/src/main/java/mezz/jei/library/startup/JeiStarter.java
@@ -233,10 +233,13 @@ public final class JeiStarter {
 	private void verifyClientRecipes(Minecraft minecraft) {
 		IConnectionToServer serverConnection = data.serverConnection();
 		RecipeMap clientRecipes = Internal.getClientSyncedRecipes();
+		boolean showWarning = jeiClientConfigs.getClientConfig().recipeSyncWarningEnabled().getValue();
 
 		if (Internal.hasClientSyncedRecipes() && clientRecipes.values().isEmpty()) {
 			String key = "jei.message.server.recipe.sync.error";
-			writeChatMessage(minecraft, Component.translatable(key).withStyle(ChatFormatting.RED));
+			if (showWarning) {
+				writeChatMessage(minecraft, Component.translatable(key).withStyle(ChatFormatting.RED));
+			}
 			LOGGER.error(Translator.translateToLocal(key));
 		} else if (Internal.hasClientFallbackRecipes()) {
 			if (!serverConnection.isJeiOnServer() &&
@@ -244,16 +247,22 @@ public final class JeiStarter {
 			) {
 				String key = "jei.message.server.recipe.sync.jei.missing";
 				String serverBrand = ClientConnectionHelper.getServerBrand();
-				writeChatMessage(minecraft, Component.translatable(key, serverBrand).withStyle(ChatFormatting.RED));
+				if (showWarning) {
+					writeChatMessage(minecraft, Component.translatable(key, serverBrand).withStyle(ChatFormatting.RED));
+				}
 				LOGGER.warn(Translator.translateToLocalFormatted(key, serverBrand));
 			} else if (ClientConnectionHelper.hasServerBrand(VANILLA_SERVER_BRAND)) {
 				String key = "jei.message.server.recipe.sync.vanilla";
-				writeChatMessage(minecraft, Component.translatable(key).withStyle(ChatFormatting.YELLOW));
+				if (showWarning) {
+					writeChatMessage(minecraft, Component.translatable(key).withStyle(ChatFormatting.YELLOW));
+				}
 				LOGGER.warn(Translator.translateToLocal(key));
 			} else {
 				String key = "jei.message.server.recipe.sync.unavailable";
 				String serverBrand = ClientConnectionHelper.getServerBrand();
-				writeChatMessage(minecraft, Component.translatable(key, serverBrand).withStyle(ChatFormatting.RED));
+				if (showWarning) {
+					writeChatMessage(minecraft, Component.translatable(key, serverBrand).withStyle(ChatFormatting.RED));
+				}
 				LOGGER.warn(Translator.translateToLocalFormatted(key, serverBrand));
 			}
 		}

--- a/NeoForge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
+++ b/NeoForge/src/test/java/mezz/jei/test/lib/TestClientConfig.java
@@ -30,6 +30,7 @@ public class TestClientConfig implements IClientConfig {
 	private final IJeiConfigValue<Boolean> ingredientsSummaryEnabled = value("ingredientsSummaryEnabled", true);
 	private final IJeiConfigValue<Boolean> lowMemorySlowSearchEnabled;
 	private final IJeiConfigValue<Boolean> catchRenderErrorsEnabled = value("catchRenderErrorsEnabled", false);
+	private final IJeiConfigValue<Boolean> recipeSyncWarningEnabled = value("recipeSyncWarningEnabled", true);
 	private final IJeiConfigValue<Boolean> lookupFluidContentsEnabled = value("lookupFluidContentsEnabled", false);
 	private final IJeiConfigValue<Boolean> lookupBlockTagsEnabled = value("lookupBlockTagsEnabled", false);
 	private final IJeiConfigValue<Boolean> showCreativeTabNamesEnabled = value("showCreativeTabNamesEnabled", false);
@@ -137,6 +138,11 @@ public class TestClientConfig implements IClientConfig {
 	@Override
 	public IJeiConfigValue<Boolean> catchRenderErrorsEnabled() {
 		return catchRenderErrorsEnabled;
+	}
+
+	@Override
+	public IJeiConfigValue<Boolean> recipeSyncWarningEnabled() {
+		return recipeSyncWarningEnabled;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #4397

Adds a new `recipeSyncWarningEnabled` boolean under the `advanced` config category, defaulting to `true` so existing behavior is unchanged unless a player opts out.

When disabled, all four recipe-sync chat warnings in `JeiStarter.verifyClientRecipes()` are suppressed in-game (sync error, JEI missing on server, vanilla server, sync unavailable) the issue specifically describes the "vanilla server" case (Paper/Velocity servers that don't sync recipes to JEI), but all four messages share the same root cause, so one toggle covers the category rather than just the one variant.

Each message is still logged to console/log file regardless of the toggle, so the information isn't lost — only the in-game chat popup is suppressed.

**Testing:** `TestClientConfig` (the test double for `IClientConfig`) updated to implement the new interface method. Full test suite passes (`./gradlew test`). Manually verified the config value round-trips through JEI's config file.