### PR TITLE
Shrink the retained GUI item atlas after JEI screens close

### DIFF
--- a/Fabric/src/main/java/mezz/jei/fabric/mixin/GuiRendererMixin.java
+++ b/Fabric/src/main/java/mezz/jei/fabric/mixin/GuiRendererMixin.java
@@ -1,0 +1,34 @@
+package mezz.jei.fabric.mixin;
+
+import net.minecraft.client.gui.render.GuiItemAtlas;
+import net.minecraft.client.gui.render.GuiRenderer;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Set;
+
+@Mixin(GuiRenderer.class)
+public class GuiRendererMixin {
+	@Shadow
+	private @Nullable GuiItemAtlas itemAtlas;
+
+	@Inject(
+		method = "prepareItemAtlas",
+		at = @At("HEAD")
+	)
+	private void shrinkItemAtlas(Set<Object> itemsInFrame, int slotTextureSize, CallbackInfoReturnable<GuiItemAtlas> cir) {
+		if (this.itemAtlas == null) {
+			return;
+		}
+
+		int requiredTextureSize = GuiItemAtlas.computeTextureSizeFor(slotTextureSize, itemsInFrame.size());
+		if (requiredTextureSize < this.itemAtlas.textureSize()) {
+			this.itemAtlas.close();
+			this.itemAtlas = null;
+		}
+	}
+}

--- a/Fabric/src/main/resources/jei.mixins.json
+++ b/Fabric/src/main/resources/jei.mixins.json
@@ -10,6 +10,7 @@
     "ClientPacketListenerRecipeUpdateMixin",
     "EffectsInInventoryMixin",
     "GuiGraphicsExtractorMixin",
+    "GuiRendererMixin",
     "KeyboardHandlerMixin",
     "MinecraftMixin",
     "ScreenMixin"


### PR DESCRIPTION
On Fabric 26.2 with the Vulkan renderer, opening an inventory with JEI can lower FPS even after the screen is closed. Reopening it makes the slowdown progressively worse until it plateaus, especially when enchanted items are visible in the HUD.

JEI ingredient rendering can grow the cached `GuiItemAtlas` substantially. Minecraft keeps that larger atlas afterward, while animated foil entries are discarded and drawn back into it every frame.

This adds a small Fabric mixin that closes the cached atlas when the current frame needs a smaller power-of-two texture. The existing vanilla code then recreates it at the right size.

The 26.2 Fabric jar builds cleanly. 