### PR TITLE
Split Recipe Slot capability.

### DIFF
--- a/CommonApi/src/main/java/mezz/jei/api/gui/builder/IRecipeLayoutBuilder.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/builder/IRecipeLayoutBuilder.java
@@ -1,5 +1,6 @@
 package mezz.jei.api.gui.builder;
 
+import mezz.jei.api.gui.ingredient.IRecipeIngredientsSource;
 import mezz.jei.api.gui.placement.IPlaceable;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
@@ -101,6 +102,20 @@ public interface IRecipeLayoutBuilder {
 	 * @since 9.3.0
 	 */
 	IIngredientAcceptor<?> addInvisibleIngredients(RecipeIngredientRole recipeIngredientRole);
+
+	/**
+	 * Add an external source of ingredients that is drawn by the plugin itself, not by JEI.
+	 *
+	 * <p>The source is managed like one of JEI's own slots for hover detection, tooltips,
+	 * ingredient lookup, bookmarks and focus, and its ingredients are added to the recipe lookup index
+	 * (a snapshot is taken once when recipes are registered).</p>
+	 *
+	 * <p>For per-displayed-recipe sources that should not be indexed, see
+	 * {@link mezz.jei.api.gui.widgets.IRecipeExtrasBuilder#addIngredientsSource}.</p>
+	 *
+	 * @since 30.26.0
+	 */
+	void addIngredientsSource(IRecipeIngredientsSource source);
 
 	/**
 	 * Moves the recipe transfer button's position relative to the recipe layout.

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeHoverable.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeHoverable.java
@@ -1,0 +1,21 @@
+package mezz.jei.api.gui.ingredient;
+
+/**
+ * An element in a recipe layout that can report whether the mouse is over it.
+ *
+ * <p>Coordinates are relative to the recipe layout area, matching JEI's own recipe slots.
+ * Implementations are free to apply their own transformations, clipping, or non-rectangular hit testing.</p>
+ *
+ * @since 30.26.0
+ */
+public interface IRecipeHoverable {
+	/**
+	 * Return true if the given mouse position is over this element.
+	 *
+	 * @param mouseX the x coordinate of the mouse, relative to the recipe layout area.
+	 * @param mouseY the y coordinate of the mouse, relative to the recipe layout area.
+	 *
+	 * @since 30.26.0
+	 */
+	boolean isMouseOver(double mouseX, double mouseY);
+}

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeIngredientsSource.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeIngredientsSource.java
@@ -1,0 +1,53 @@
+package mezz.jei.api.gui.ingredient;
+
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import net.minecraft.tags.TagKey;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A source of ingredients in a recipe: a role, a set of ingredient variations,
+ * and an optional tag.
+ *
+ * <p>This is the unified view shared by JEI's recipe slots (via {@link IRecipeSlotView})
+ * and by external elements implemented by addon mods.
+ * Results are evaluated on every call, so the ingredients can change over time.</p>
+ *
+ * @since 30.26.0
+ */
+public interface IRecipeIngredientsSource {
+	/**
+	 * The role of the ingredients in this source (input, output, catalyst, etc.).
+	 *
+	 * @since 30.26.0
+	 */
+	RecipeIngredientRole getRole();
+
+	/**
+	 * All ingredient variations that can be shown by this source.
+	 *
+	 * @since 30.26.0
+	 */
+	Stream<ITypedIngredient<?>> getAllIngredients();
+
+	/**
+	 * The ingredient variation that is shown at this moment.
+	 * Defaults to the first ingredient from {@link #getAllIngredients()}.
+	 *
+	 * @since 30.26.0
+	 */
+	default Optional<ITypedIngredient<?>> getDisplayedIngredient() {
+		return getAllIngredients().findFirst();
+	}
+
+	/**
+	 * The tag represented by every ingredient in this source, if there is one.
+	 *
+	 * @since 30.26.0
+	 */
+	default Optional<TagKey<?>> getTagKey() {
+		return Optional.empty();
+	}
+}

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotDrawable.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotDrawable.java
@@ -24,7 +24,7 @@ import java.util.List;
  * @since 11.5.0
  */
 @ApiStatus.NonExtendable
-public interface IRecipeSlotDrawable extends IRecipeSlotView {
+public interface IRecipeSlotDrawable extends IRecipeSlotView, IRecipeHoverable {
 	/**
 	 * Draws the recipe slot relative to the pose stack.
 	 *

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotDrawablesView.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotDrawablesView.java
@@ -29,6 +29,32 @@ public interface IRecipeSlotDrawablesView {
 	List<IRecipeSlotDrawable> getSlots();
 
 	/**
+	 * Get all the ingredient sources for a recipe, as the unified {@link IRecipeIngredientsSource} view.
+	 * Equivalent to {@link #getSlots()} unless slot-specific features like positions or drawing are needed.
+	 *
+	 * @since 30.26.0
+	 */
+	@Unmodifiable
+	default List<IRecipeIngredientsSource> getIngredientSources() {
+		return List.copyOf(getSlots());
+	}
+
+	/**
+	 * Get the ingredient sources for the given {@link RecipeIngredientRole} for a recipe.
+	 *
+	 * @since 30.26.0
+	 */
+	default List<IRecipeIngredientsSource> getIngredientSources(RecipeIngredientRole role) {
+		List<IRecipeIngredientsSource> list = new ArrayList<>();
+		for (IRecipeIngredientsSource source : getIngredientSources()) {
+			if (source.getRole() == role) {
+				list.add(source);
+			}
+		}
+		return list;
+	}
+
+	/**
 	 * Get the list of slots for the given {@link RecipeIngredientRole} for a recipe.
 	 *
 	 * @since 19.19.3

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotView.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotView.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
  * @since 9.3.0
  */
 @ApiStatus.NonExtendable
-public interface IRecipeSlotView {
+public interface IRecipeSlotView extends IRecipeIngredientsSource {
 	/**
 	 * All ingredient variations that can be shown, ignoring focus and visibility.
 	 *

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotsView.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeSlotsView.java
@@ -29,6 +29,32 @@ public interface IRecipeSlotsView {
 	List<IRecipeSlotView> getSlotViews();
 
 	/**
+	 * Get all the ingredient sources for a recipe, as the unified {@link IRecipeIngredientsSource} view.
+	 * Equivalent to {@link #getSlotViews()} unless slot-specific features like positions or drawing are needed.
+	 *
+	 * @since 30.26.0
+	 */
+	@Unmodifiable
+	default List<IRecipeIngredientsSource> getIngredientSources() {
+		return List.copyOf(getSlotViews());
+	}
+
+	/**
+	 * Get the ingredient sources for the given {@link RecipeIngredientRole} for a recipe.
+	 *
+	 * @since 30.26.0
+	 */
+	default List<IRecipeIngredientsSource> getIngredientSources(RecipeIngredientRole role) {
+		List<IRecipeIngredientsSource> list = new ArrayList<>();
+		for (IRecipeIngredientsSource source : getIngredientSources()) {
+			if (source.getRole() == role) {
+				list.add(source);
+			}
+		}
+		return list;
+	}
+
+	/**
 	 * Get the list of slots for the given {@link RecipeIngredientRole} for a recipe.
 	 *
 	 * @since 9.3.0

--- a/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeTooltipAppender.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/ingredient/IRecipeTooltipAppender.java
@@ -1,0 +1,24 @@
+package mezz.jei.api.gui.ingredient;
+
+import mezz.jei.api.gui.builder.ITooltipBuilder;
+
+/**
+ * An element in a recipe layout that can append lines to its own tooltip.
+ *
+ * <p>JEI first fills the tooltip with the standard information for the currently displayed ingredient
+ * (mod name, tag name, and user configuration), then calls {@link #addTooltip(ITooltipBuilder)}
+ * so the implementation can append any extra lines.</p>
+ *
+ * @since 30.26.0
+ */
+public interface IRecipeTooltipAppender {
+	/**
+	 * Append extra lines to the given tooltip.
+	 *
+	 * @param tooltip the tooltip builder to append to.
+	 *
+	 * @since 30.26.0
+	 */
+	default void addTooltip(ITooltipBuilder tooltip) {
+	}
+}

--- a/CommonApi/src/main/java/mezz/jei/api/gui/widgets/IRecipeExtrasBuilder.java
+++ b/CommonApi/src/main/java/mezz/jei/api/gui/widgets/IRecipeExtrasBuilder.java
@@ -1,6 +1,7 @@
 package mezz.jei.api.gui.widgets;
 
 import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeIngredientsSource;
 import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotDrawablesView;
 import mezz.jei.api.gui.inputs.IJeiGuiEventListener;
@@ -66,6 +67,20 @@ public interface IRecipeExtrasBuilder {
 	 * @since 19.19.3
 	 */
 	void addSlottedWidget(ISlottedRecipeWidget widget, List<IRecipeSlotDrawable> slots);
+
+	/**
+	 * Add an {@link IRecipeIngredientsSource} for the recipe category,
+	 * for elements that are drawn by the addon itself instead of JEI.
+	 *
+	 * <p>The source is managed like one of JEI's own slots for hover detection, tooltips,
+	 * ingredient lookup, bookmarks and focus, but JEI never draws it.
+	 * Sources added here are per-displayed-recipe and are not added to the recipe search index;
+	 * to have an external source indexed, register it in {@link mezz.jei.api.recipe.category.IRecipeCategory#setRecipe}
+	 * with {@link mezz.jei.api.gui.builder.IRecipeLayoutBuilder#addIngredientsSource}.</p>
+	 *
+	 * @since 30.26.0
+	 */
+	void addIngredientsSource(IRecipeIngredientsSource source);
 
 	/**
 	 * Add a {@link IJeiInputHandler} for the recipe category.

--- a/CommonApi/src/main/java/mezz/jei/api/helpers/IJeiHelpers.java
+++ b/CommonApi/src/main/java/mezz/jei/api/helpers/IJeiHelpers.java
@@ -2,6 +2,8 @@ package mezz.jei.api.helpers;
 
 import com.mojang.serialization.Codec;
 import mezz.jei.api.IModPlugin;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
+import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.IFocusFactory;
 import mezz.jei.api.recipe.types.IRecipeType;
 import mezz.jei.api.recipe.vanilla.IVanillaRecipeFactory;
@@ -113,4 +115,12 @@ public interface IJeiHelpers {
 	 * @since 19.18.4
 	 */
 	IIngredientVisibility getIngredientVisibility();
+
+	/**
+	 * Build a rich tooltip for the given ingredient using JEI's standard logic.
+	 * Useful for addons that draw their own UI but want to show the same tooltip JEI would show.
+	 *
+	 * @since 30.26.0
+	 */
+	ITooltipBuilder createTooltip(ITypedIngredient<?> ingredient);
 }

--- a/Library/src/main/java/mezz/jei/library/gui/ingredients/IngredientsSourceAdapter.java
+++ b/Library/src/main/java/mezz/jei/library/gui/ingredients/IngredientsSourceAdapter.java
@@ -1,0 +1,187 @@
+package mezz.jei.library.gui.ingredients;
+
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeIngredientsSource;
+import mezz.jei.api.gui.ingredient.IRecipeHoverable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeTooltipAppender;
+import mezz.jei.api.ingredients.IIngredientRenderer;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import org.jetbrains.annotations.Unmodifiable;
+import mezz.jei.common.Internal;
+import mezz.jei.common.config.IClientConfig;
+import mezz.jei.common.gui.JeiTooltip;
+import mezz.jei.common.platform.Services;
+import mezz.jei.common.util.SafeIngredientUtil;
+import mezz.jei.library.ingredients.IIngredientManagerInternal;
+import mezz.jei.library.ingredients.SimpleIngredientAcceptor;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.network.chat.Component;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.context.ContextMap;
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Adapts an {@link IRecipeIngredientsSource} to a {@link IRecipeSlotDrawable} so that JEI can manage it
+ * exactly like one of its own recipe slots (hover detection, tooltips, ingredient lookup, bookmarks, and focus).
+ * JEI never draws the wrapped source, and its area is a zero-sized rectangle.
+ */
+public class IngredientsSourceAdapter implements IRecipeSlotDrawable {
+	private final IRecipeIngredientsSource source;
+	private final IIngredientManagerInternal ingredientManager;
+	private final ContextMap contextMap;
+
+	public IngredientsSourceAdapter(IRecipeIngredientsSource source, IIngredientManagerInternal ingredientManager, ContextMap contextMap) {
+		this.source = source;
+		this.ingredientManager = ingredientManager;
+		this.contextMap = contextMap;
+	}
+
+	@Override
+	public Stream<ITypedIngredient<?>> getAllIngredients() {
+		return source.getAllIngredients();
+	}
+
+	@Override
+	@Unmodifiable
+	public List<@Nullable ITypedIngredient<?>> getAllIngredientsList() {
+		return source.getAllIngredients().toList();
+	}
+
+	@Override
+	public Optional<ITypedIngredient<?>> getDisplayedIngredient() {
+		return source.getDisplayedIngredient();
+	}
+
+	@Override
+	public Stream<ITypedIngredient<?>> getDisplayedIngredients() {
+		return source.getDisplayedIngredient().stream();
+	}
+
+	@Override
+	public Optional<TagKey<?>> getTagKey() {
+		return source.getTagKey();
+	}
+
+	@Override
+	public RecipeIngredientRole getRole() {
+		return source.getRole();
+	}
+
+	@Override
+	public Optional<String> getSlotName() {
+		return Optional.empty();
+	}
+
+	@Override
+	public void drawHighlight(GuiGraphicsExtractor guiGraphics, int color) {
+	}
+
+	@Override
+	public boolean isMouseOver(double mouseX, double mouseY) {
+		if (source instanceof IRecipeHoverable hoverable) {
+			return hoverable.isMouseOver(mouseX, mouseY);
+		}
+		return false;
+	}
+
+	@Override
+	@SuppressWarnings("removal")
+	public void draw(GuiGraphicsExtractor guiGraphics) {
+	}
+
+	@Override
+	public void draw(GuiGraphicsExtractor guiGraphics, boolean hovered) {
+	}
+
+	@Override
+	@SuppressWarnings("removal")
+	public void drawHoverOverlays(GuiGraphicsExtractor guiGraphics) {
+	}
+
+	@Override
+	@SuppressWarnings("removal")
+	public List<Component> getTooltip() {
+		JeiTooltip tooltip = new JeiTooltip();
+		buildTooltip(tooltip);
+		return tooltip.getLegacyComponents();
+	}
+
+	@Override
+	@SuppressWarnings("removal")
+	public void getTooltip(ITooltipBuilder tooltipBuilder) {
+		buildTooltip(tooltipBuilder);
+	}
+
+	@Override
+	public void drawTooltip(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+		JeiTooltip tooltip = new JeiTooltip();
+		buildTooltip(tooltip);
+		tooltip.draw(guiGraphics, mouseX, mouseY);
+	}
+
+	@Override
+	public void setPosition(int x, int y) {
+	}
+
+	@Override
+	public IIngredientAcceptor<?> createDisplayOverrides() {
+		return new SimpleIngredientAcceptor(ingredientManager, contextMap, source.getRole());
+	}
+
+	@Override
+	public void clearDisplayOverrides() {
+	}
+
+	@Override
+	public Rect2i getAreaIncludingBackground() {
+		return new Rect2i(0, 0, 0, 0);
+	}
+
+	private void buildTooltip(ITooltipBuilder tooltip) {
+		source.getDisplayedIngredient()
+			.ifPresent(typedIngredient -> addRichTooltip(tooltip, ingredientManager, typedIngredient));
+		addTagTooltip(tooltip);
+		if (source instanceof IRecipeTooltipAppender appender) {
+			appender.addTooltip(tooltip);
+		}
+	}
+
+	private <T> void addRichTooltip(ITooltipBuilder tooltip, IIngredientManager ingredientManager, ITypedIngredient<T> typedIngredient) {
+		IIngredientType<T> ingredientType = typedIngredient.getType();
+		IIngredientRenderer<T> ingredientRenderer = ingredientManager.getIngredientRenderer(ingredientType);
+		SafeIngredientUtil.getRichTooltip(tooltip, ingredientManager, ingredientRenderer, typedIngredient);
+	}
+
+	private void addTagTooltip(ITooltipBuilder tooltip) {
+		Optional<TagKey<?>> tagKey = source.getTagKey();
+		if (tagKey.isEmpty()) {
+			return;
+		}
+		IClientConfig clientConfig = Internal.getJeiClientConfigs().getClientConfig();
+		List<ITypedIngredient<?>> allIngredients = source.getAllIngredients().toList();
+		if (clientConfig.hideSingleTagContentTooltipEnabled().getValue() && allIngredients.size() == 1) {
+			return;
+		}
+		TagKey<?> key = tagKey.get();
+		String registryName = key.registry().identifier().getPath()
+			.replace('_', ' ');
+		tooltip.add(
+			Component.translatable("jei.tooltip.recipe.tag", StringUtils.capitalize(registryName))
+				.withStyle(ChatFormatting.GRAY)
+		);
+		Component tagName = Services.PLATFORM.getRenderHelper().getName(key);
+		tooltip.add(tagName.copy().withStyle(ChatFormatting.GRAY));
+	}
+}

--- a/Library/src/main/java/mezz/jei/library/gui/recipes/RecipeLayout.java
+++ b/Library/src/main/java/mezz/jei/library/gui/recipes/RecipeLayout.java
@@ -5,6 +5,7 @@ import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
 import mezz.jei.api.gui.drawable.IDrawableStatic;
 import mezz.jei.api.gui.drawable.IScalableDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeIngredientsSource;
 import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotDrawablesView;
 import mezz.jei.api.gui.ingredient.IRecipeSlotView;
@@ -36,6 +37,7 @@ import mezz.jei.common.util.ImmutableRect2i;
 import mezz.jei.common.util.MathUtil;
 import mezz.jei.common.util.LimitedLogger;
 import mezz.jei.library.gui.ingredients.CycleTicker;
+import mezz.jei.library.gui.ingredients.IngredientsSourceAdapter;
 import mezz.jei.library.gui.recipes.layout.builder.RecipeLayoutBuilder;
 import mezz.jei.library.ingredients.IIngredientManagerInternal;
 import mezz.jei.library.gui.widgets.ScrollBoxRecipeWidget;
@@ -67,6 +69,8 @@ public class RecipeLayout<R> implements IRecipeLayoutDrawable<R>, IRecipeExtrasB
 
 	private final IRecipeCategory<R> recipeCategory;
 	private final Collection<IRecipeCategoryDecorator<R>> recipeCategoryDecorators;
+	private final IIngredientManagerInternal ingredientManager;
+	private final ContextMap contextMap;
 	/**
 	 * Slots handled by the recipe category directly.
 	 */
@@ -127,10 +131,14 @@ public class RecipeLayout<R> implements IRecipeLayoutDrawable<R>, IRecipeExtrasB
 		ImmutablePoint2i recipeTransferButtonPos,
 		List<IRecipeSlotDrawable> slots,
 		CycleTicker cycleTicker,
-		IFocusGroup focuses
+		IFocusGroup focuses,
+		IIngredientManagerInternal ingredientManager,
+		ContextMap contextMap
 	) {
 		this.recipeCategory = recipeCategory;
 		this.recipeCategoryDecorators = recipeCategoryDecorators;
+		this.ingredientManager = ingredientManager;
+		this.contextMap = contextMap;
 		this.drawables = new ArrayList<>();
 		this.slottedWidgets = new ArrayList<>();
 		this.allWidgets = new ArrayList<>();
@@ -412,6 +420,11 @@ public class RecipeLayout<R> implements IRecipeLayoutDrawable<R>, IRecipeExtrasB
 		this.allWidgets.add(widget);
 		this.slottedWidgets.add(widget);
 		this.slots.removeAll(slots);
+	}
+
+	@Override
+	public void addIngredientsSource(IRecipeIngredientsSource source) {
+		this.slots.add(new IngredientsSourceAdapter(source, ingredientManager, contextMap));
 	}
 
 	@Override

--- a/Library/src/main/java/mezz/jei/library/gui/recipes/layout/builder/RecipeLayoutBuilder.java
+++ b/Library/src/main/java/mezz/jei/library/gui/recipes/layout/builder/RecipeLayoutBuilder.java
@@ -8,6 +8,7 @@ import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IScalableDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeIngredientsSource;
 import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
 import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.IFocusGroup;
@@ -19,6 +20,7 @@ import mezz.jei.common.Internal;
 import mezz.jei.common.util.ImmutablePoint2i;
 import mezz.jei.common.util.Pair;
 import mezz.jei.library.gui.ingredients.CycleTicker;
+import mezz.jei.library.gui.ingredients.IngredientsSourceAdapter;
 import mezz.jei.library.ingredients.IIngredientManagerInternal;
 import mezz.jei.library.gui.recipes.IngredientsTooltipCallback;
 import mezz.jei.library.gui.recipes.OutputSlotTooltipCallback;
@@ -42,6 +44,7 @@ import java.util.function.Supplier;
 public class RecipeLayoutBuilder<T> implements IRecipeLayoutBuilder {
 	private final List<RecipeSlotBuilder> visibleSlots = new ArrayList<>();
 	private final List<List<RecipeSlotBuilder>> focusLinkedSlots = new ArrayList<>();
+	private final List<IRecipeIngredientsSource> ingredientSources = new ArrayList<>();
 
 	private final IIngredientManagerInternal ingredientManager;
 	private final ContextMap contextMap;
@@ -86,6 +89,11 @@ public class RecipeLayoutBuilder<T> implements IRecipeLayoutBuilder {
 	@Override
 	public IIngredientAcceptor<?> addInvisibleIngredients(RecipeIngredientRole role) {
 		return new RecipeSlotBuilder(ingredientManager, contextMap, nextSlotIndex++, role);
+	}
+
+	@Override
+	public void addIngredientsSource(IRecipeIngredientsSource source) {
+		this.ingredientSources.add(source);
 	}
 
 	@Override
@@ -187,6 +195,11 @@ public class RecipeLayoutBuilder<T> implements IRecipeLayoutBuilder {
 			}
 		}
 
+		List<IRecipeSlotDrawable> sortedSlots = sortSlots(slots);
+		for (IRecipeIngredientsSource source : ingredientSources) {
+			sortedSlots.add(new IngredientsSourceAdapter(source, ingredientManager, contextMap));
+		}
+
 		RecipeLayout<T> recipeLayout = new RecipeLayout<>(
 			recipeCategory,
 			decorators,
@@ -195,9 +208,11 @@ public class RecipeLayoutBuilder<T> implements IRecipeLayoutBuilder {
 			recipeBorderPadding,
 			shapelessIcon,
 			recipeTransferButtonPosition,
-			sortSlots(slots),
+			sortedSlots,
 			cycleTicker,
-			focuses
+			focuses,
+			ingredientManager,
+			contextMap
 		);
 
 		layoutSupplier.drawable = recipeLayout;

--- a/Library/src/main/java/mezz/jei/library/gui/recipes/supplier/builder/IngredientSupplierBuilder.java
+++ b/Library/src/main/java/mezz/jei/library/gui/recipes/supplier/builder/IngredientSupplierBuilder.java
@@ -3,12 +3,14 @@ package mezz.jei.library.gui.recipes.supplier.builder;
 import mezz.jei.api.gui.builder.IIngredientAcceptor;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeIngredientsSource;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.library.ingredients.IIngredientManagerInternal;
 import mezz.jei.library.ingredients.RecipeIngredientSupplier;
 import mezz.jei.library.ingredients.SlotIngredient;
 import net.minecraft.util.context.ContextMap;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +23,7 @@ public class IngredientSupplierBuilder implements IRecipeLayoutBuilder {
 	private final IIngredientManagerInternal ingredientManager;
 	private final ContextMap contextMap;
 	private final Map<RecipeIngredientRole, IngredientSlotBuilder> ingredientSlotBuilders;
+	private final List<IRecipeIngredientsSource> ingredientSources = new ArrayList<>();
 
 	public IngredientSupplierBuilder(IIngredientManagerInternal ingredientManager, ContextMap contextMap) {
 		this.ingredientManager = ingredientManager;
@@ -49,6 +52,11 @@ public class IngredientSupplierBuilder implements IRecipeLayoutBuilder {
 	}
 
 	@Override
+	public void addIngredientsSource(IRecipeIngredientsSource source) {
+		this.ingredientSources.add(source);
+	}
+
+	@Override
 	public void moveRecipeTransferButton(int posX, int posY) {
 
 	}
@@ -73,6 +81,12 @@ public class IngredientSupplierBuilder implements IRecipeLayoutBuilder {
 		ingredientSlotBuilders.forEach(
 			(role, builder) -> ingredientsByRole.put(role, builder.getAllSlotIngredients())
 		);
+		// add a snapshot of externally managed sources, so their ingredients are searchable too
+		for (IRecipeIngredientsSource source : ingredientSources) {
+			List<SlotIngredient<?>> roleIngredients = ingredientsByRole.computeIfAbsent(source.getRole(), role -> new ArrayList<>());
+			source.getAllIngredients()
+				.forEach(typedIngredient -> roleIngredients.add(new SlotIngredient<>(typedIngredient)));
+		}
 		return new RecipeIngredientSupplier(ingredientsByRole);
 	}
 }

--- a/Library/src/main/java/mezz/jei/library/runtime/JeiHelpers.java
+++ b/Library/src/main/java/mezz/jei/library/runtime/JeiHelpers.java
@@ -7,13 +7,20 @@ import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.helpers.IPlatformFluidHelper;
 import mezz.jei.api.helpers.IStackHelper;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
+import mezz.jei.api.ingredients.IIngredientRenderer;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.IFocusFactory;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.api.recipe.types.IRecipeType;
 import mezz.jei.api.recipe.vanilla.IVanillaRecipeFactory;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.api.runtime.IIngredientVisibility;
+import mezz.jei.common.gui.JeiTooltip;
 import mezz.jei.common.platform.Services;
+import mezz.jei.common.util.ErrorUtil;
+import mezz.jei.common.util.SafeIngredientUtil;
 import mezz.jei.library.gui.helpers.GuiHelper;
 import mezz.jei.library.ingredients.IngredientVisibility;
 import net.minecraft.resources.Identifier;
@@ -142,6 +149,20 @@ public class JeiHelpers implements IJeiHelpers {
 	@Override
 	public IIngredientVisibility getIngredientVisibility() {
 		return ingredientVisibility;
+	}
+
+	@Override
+	public ITooltipBuilder createTooltip(ITypedIngredient<?> ingredient) {
+		ErrorUtil.checkNotNull(ingredient, "ingredient");
+		return createTooltipInternal(ingredient);
+	}
+
+	private <T> ITooltipBuilder createTooltipInternal(ITypedIngredient<T> ingredient) {
+		ITooltipBuilder tooltip = new JeiTooltip();
+		IIngredientType<T> ingredientType = ingredient.getType();
+		IIngredientRenderer<T> ingredientRenderer = ingredientManager.getIngredientRenderer(ingredientType);
+		SafeIngredientUtil.getRichTooltip(tooltip, ingredientManager, ingredientRenderer, ingredient);
+		return tooltip;
 	}
 
 	public void onRuntimeStopped() {


### PR DESCRIPTION
Implements #4442 
Split the unique capabilities of the Recipe Slot into independent interfaces, allowing the I Recipe Widget to implement them.