### PR TITLE
Add pinnable interactive tooltip for bookmark recipe previews

### DIFF
--- a/Common/src/main/resources/assets/jei/lang/en_us.json
+++ b/Common/src/main/resources/assets/jei/lang/en_us.json
@@ -34,6 +34,7 @@
   "jei.tooltip.bookmarks.tooltips.usage": "[Press \"%s\" to show details]",
   "jei.tooltip.bookmarks.tooltips.transfer.usage": "[Press \"%s\" to craft one]",
   "jei.tooltip.bookmarks.tooltips.transfer.max.usage": "[Press \"%s\" to craft many]",
+  "jei.tooltip.bookmarks.preview.pin.usage": "[Hold \"%s\" to pin this preview, then click an ingredient to view recipes]",
   "jei.tooltip.lookupHistory.enable": "Show JEI Lookup History",
   "jei.tooltip.lookupHistory.disable": "Hide JEI Lookup History",
   "jei.tooltip.lookupHistory.usage": "Shows a list of the ingredients recently used for looking up recipes.",

--- a/Common/src/main/resources/assets/jei/lang/zh_cn.json
+++ b/Common/src/main/resources/assets/jei/lang/zh_cn.json
@@ -32,6 +32,7 @@
   "jei.tooltip.bookmarks.tooltips.usage": "[按“%s”以显示细节]",
   "jei.tooltip.bookmarks.tooltips.transfer.usage": "[按“%s”以合成一次]",
   "jei.tooltip.bookmarks.tooltips.transfer.max.usage": "[按“%s”以合成全部]",
+  "jei.tooltip.bookmarks.preview.pin.usage": "[按住“%s”固定此预览，然后点击原料查看配方]",
   "jei.tooltip.lookupHistory.enable": "显示JEI查询历史",
   "jei.tooltip.lookupHistory.disable": "隐藏JEI查询历史",
   "jei.tooltip.lookupHistory.usage": "显示最近用于查询配方的原料列表。",

--- a/Gui/src/main/java/mezz/jei/gui/input/IPinnedTooltipHolder.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/IPinnedTooltipHolder.java
@@ -1,0 +1,9 @@
+package mezz.jei.gui.input;
+
+/**
+ * Owns a tooltip that stays pinned while the pin key is held.
+ * The {@link PinnedTooltipManager} ensures that only one is shown at a time.
+ */
+public interface IPinnedTooltipHolder {
+	void hide();
+}

--- a/Gui/src/main/java/mezz/jei/gui/input/PinnedTooltipManager.java
+++ b/Gui/src/main/java/mezz/jei/gui/input/PinnedTooltipManager.java
@@ -1,0 +1,24 @@
+package mezz.jei.gui.input;
+
+import org.jspecify.annotations.Nullable;
+
+public final class PinnedTooltipManager {
+	private static @Nullable IPinnedTooltipHolder active;
+
+	public static void opened(IPinnedTooltipHolder holder) {
+		IPinnedTooltipHolder active = PinnedTooltipManager.active;
+		if (active != null && active != holder) {
+			active.hide();
+		}
+		PinnedTooltipManager.active = holder;
+	}
+
+	public static void closed(IPinnedTooltipHolder holder) {
+		if (PinnedTooltipManager.active == holder) {
+			PinnedTooltipManager.active = null;
+		}
+	}
+
+	private PinnedTooltipManager() {
+	}
+}

--- a/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkOverlay.java
@@ -67,6 +67,7 @@ public class BookmarkOverlay implements IRecipeFocusSource, IBookmarkOverlay {
 	private final BookmarkList bookmarkList;
 	private final IClientToggleState toggleState;
 	private final IClientConfig clientConfig;
+	private final BookmarkPreviewTooltipController previewTooltipController;
 	private boolean screenPropertiesDirty;
 
 	public BookmarkOverlay(
@@ -91,6 +92,7 @@ public class BookmarkOverlay implements IRecipeFocusSource, IBookmarkOverlay {
 				.orElse(null)
 		);
 		this.bookmarkDragManager = new BookmarkDragManager(this);
+		this.previewTooltipController = new BookmarkPreviewTooltipController(this);
 		bookmarkList.addSourceListChangedListener(() -> {
 			toggleState.setBookmarkEnabled(!bookmarkList.isEmpty());
 			markScreenPropertiesDirty();
@@ -248,10 +250,14 @@ public class BookmarkOverlay implements IRecipeFocusSource, IBookmarkOverlay {
 		}
 	}
 
+	public BookmarkPreviewTooltipController getPreviewTooltipController() {
+		return previewTooltipController;
+	}
+
 	public void drawTooltips(Minecraft minecraft, GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
 		updateScreenPropertiesIfDirty();
 		if (!this.bookmarkDragManager.drawDraggedItem(guiGraphics, mouseX, mouseY)) {
-			if (isListDisplayed()) {
+			if (isListDisplayed() && !previewTooltipController.isVisible()) {
 				this.contents.drawTooltips(minecraft, guiGraphics, mouseX, mouseY);
 			}
 			if (guiPropertiesCache.hasValidScreen() && toggleState.isOverlayEnabled()) {

--- a/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkPreviewTooltip.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkPreviewTooltip.java
@@ -1,0 +1,179 @@
+package mezz.jei.gui.overlay.bookmarks;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
+import mezz.jei.api.gui.IRecipeLayoutDrawable;
+import mezz.jei.api.gui.drawable.IScalableDrawable;
+import mezz.jei.api.gui.handlers.IGuiProperties;
+import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.runtime.IJeiRuntime;
+import mezz.jei.common.Internal;
+import mezz.jei.common.gui.JeiGuiColors;
+import mezz.jei.common.gui.JeiGuiColors.GuiColor;
+import mezz.jei.common.gui.JeiTooltip;
+import mezz.jei.common.input.IInternalKeyMappings;
+import mezz.jei.common.util.ImmutableRect2i;
+import mezz.jei.gui.input.IClickableIngredientInternal;
+import mezz.jei.gui.input.IMouseOverable;
+import mezz.jei.gui.input.IUserInputHandler;
+import mezz.jei.gui.input.UserInput;
+import mezz.jei.gui.input.handlers.SameElementInputHandler;
+import mezz.jei.gui.overlay.elements.RecipeBookmarkElement;
+import mezz.jei.gui.recipes.RecipeSlotClickTargetFactory;
+import mezz.jei.gui.recipes.RecipeSlotTooltipPositioner;
+import mezz.jei.gui.util.FocusUtil;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+
+import java.util.List;
+import java.util.Optional;
+
+final class BookmarkPreviewTooltip implements IUserInputHandler, IMouseOverable {
+	private static final int BACKGROUND_PADDING = 2;
+	private static final InputConstants.Key LEFT_MOUSE_BUTTON = InputConstants.Type.MOUSE.getOrCreate(InputConstants.MOUSE_BUTTON_LEFT);
+	private static final InputConstants.Key RIGHT_MOUSE_BUTTON = InputConstants.Type.MOUSE.getOrCreate(InputConstants.MOUSE_BUTTON_RIGHT);
+
+	private final BookmarkPreviewTooltipController controller;
+	private final RecipeBookmarkElement<?, ?> element;
+	private final PreviewTooltipComponent<?> component;
+	private final IRecipeLayoutDrawable<?> drawable;
+	private final RecipeSlotClickTargetFactory clickTargetFactory;
+	private final RecipeSlotTooltipPositioner positioner;
+	private final IScalableDrawable background;
+	private final int anchorX;
+	private final int anchorY;
+
+	BookmarkPreviewTooltip(
+		BookmarkPreviewTooltipController controller,
+		RecipeBookmarkElement<?, ?> element,
+		PreviewTooltipComponent<?> component,
+		int anchorX,
+		int anchorY
+	) {
+		this.controller = controller;
+		this.element = element;
+		this.component = component;
+		this.drawable = component.getRecipeLayout();
+		IJeiRuntime jeiRuntime = Internal.getJeiRuntime();
+		this.clickTargetFactory = new RecipeSlotClickTargetFactory(
+			jeiRuntime.getRecipeManager(),
+			Internal.getKeyMappings().getPauseRecipeCycling()::isDown
+		);
+		this.positioner = new RecipeSlotTooltipPositioner();
+		this.background = Internal.getTextures().getInteractiveIngredientTooltipBackground();
+		this.anchorX = anchorX;
+		this.anchorY = anchorY;
+	}
+
+	public boolean isSourceVisible() {
+		return this.element.isVisible();
+	}
+
+	@Override
+	public boolean isMouseOver(double mouseX, double mouseY) {
+		return getTooltipArea().contains(mouseX, mouseY);
+	}
+
+	private ImmutableRect2i getTooltipArea() {
+		ImmutableRect2i tooltipArea = this.positioner.getTooltipArea();
+		if (tooltipArea.isEmpty()) {
+			return ImmutableRect2i.EMPTY;
+		}
+		return tooltipArea.expandBy(BACKGROUND_PADDING);
+	}
+
+	public void draw(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+		JeiTooltip tooltip = new JeiTooltip();
+		this.element.getPinnedTooltip(tooltip);
+		this.component.setInteractive(mouseX, mouseY);
+
+		ImmutableRect2i tooltipArea = getTooltipArea();
+		guiGraphics.nextStratum();
+		guiGraphics.fill(
+			0,
+			0,
+			guiGraphics.guiWidth(),
+			guiGraphics.guiHeight(),
+			JeiGuiColors.getColor(GuiColor.INTERACTIVE_INGREDIENT_TOOLTIP_SCREEN_DIM)
+		);
+		guiGraphics.nextStratum();
+		if (!tooltipArea.isEmpty()) {
+			this.background.draw(
+				guiGraphics,
+				tooltipArea.x(),
+				tooltipArea.y(),
+				tooltipArea.width(),
+				tooltipArea.height()
+			);
+		}
+		guiGraphics.nextStratum();
+		tooltip.draw(guiGraphics, this.anchorX, this.anchorY, this.positioner);
+		this.drawable.drawOverlays(guiGraphics, mouseX, mouseY);
+
+		if (isMouseOver(mouseX, mouseY)) {
+			if (this.drawable.getSlotUnderMouse(mouseX, mouseY).isPresent()) {
+				guiGraphics.requestCursor(CursorTypes.POINTING_HAND);
+			} else {
+				guiGraphics.requestCursor(CursorTypes.ARROW);
+			}
+		}
+	}
+
+	@Override
+	public Optional<IUserInputHandler> handleUserInput(
+		Screen screen,
+		IGuiProperties guiProperties,
+		UserInput input,
+		IInternalKeyMappings keyBindings
+	) {
+		if (!this.controller.isActive(this)) {
+			return Optional.empty();
+		}
+
+		boolean leftClick = input.getKey().equals(LEFT_MOUSE_BUTTON);
+		boolean rightClick = input.getKey().equals(RIGHT_MOUSE_BUTTON);
+		if (!leftClick && !rightClick) {
+			return Optional.empty();
+		}
+
+		double mouseX = input.getMouseX();
+		double mouseY = input.getMouseY();
+		if (!isMouseOver(mouseX, mouseY)) {
+			return Optional.empty();
+		}
+
+		RecipeSlotUnderMouse slotUnderMouse = this.drawable.getSlotUnderMouse(mouseX, mouseY)
+			.orElse(null);
+		if (slotUnderMouse == null) {
+			// keep clicks on the tooltip itself from reaching the screen behind it
+			return Optional.of(this);
+		}
+
+		IClickableIngredientInternal<?> ingredient = this.clickTargetFactory.create(
+				slotUnderMouse,
+				RecipeSlotClickTargetFactory.createMouseOverable(this.drawable, slotUnderMouse)
+			)
+			.orElse(null);
+		if (ingredient == null) {
+			return Optional.of(this);
+		}
+		if (!input.isSimulate()) {
+			List<RecipeIngredientRole> roles;
+			if (leftClick) {
+				roles = List.of(RecipeIngredientRole.OUTPUT);
+			} else {
+				roles = List.of(RecipeIngredientRole.INPUT, RecipeIngredientRole.CRAFTING_STATION);
+			}
+			IJeiRuntime jeiRuntime = Internal.getJeiRuntime();
+			FocusUtil focusUtil = new FocusUtil(
+				jeiRuntime.getJeiHelpers().getFocusFactory(),
+				Internal.getJeiClientConfigs().getClientConfig(),
+				jeiRuntime.getIngredientManager()
+			);
+			ingredient.show(jeiRuntime.getRecipesGui(), focusUtil, roles);
+			this.controller.hide();
+		}
+		return Optional.of(new SameElementInputHandler(this, ingredient::isMouseOver));
+	}
+}

--- a/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkPreviewTooltipController.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/BookmarkPreviewTooltipController.java
@@ -1,0 +1,117 @@
+package mezz.jei.gui.overlay.bookmarks;
+
+import mezz.jei.api.gui.handlers.IGuiProperties;
+import mezz.jei.common.Internal;
+import mezz.jei.common.input.IInternalKeyMappings;
+import mezz.jei.gui.input.IClickableIngredientInternal;
+import mezz.jei.gui.input.IGuiInputLayer;
+import mezz.jei.gui.input.IPinnedTooltipHolder;
+import mezz.jei.gui.input.IUserInputHandler;
+import mezz.jei.gui.input.PinnedTooltipManager;
+import mezz.jei.gui.input.UserInput;
+import mezz.jei.gui.overlay.elements.RecipeBookmarkElement;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+public class BookmarkPreviewTooltipController implements IGuiInputLayer, IPinnedTooltipHolder {
+	private final BookmarkOverlay bookmarkOverlay;
+	private @Nullable BookmarkPreviewTooltip activeTooltip;
+	private @Nullable Screen lastScreen;
+
+	public BookmarkPreviewTooltipController(BookmarkOverlay bookmarkOverlay) {
+		this.bookmarkOverlay = bookmarkOverlay;
+	}
+
+	public boolean isVisible() {
+		return this.activeTooltip != null;
+	}
+
+	boolean isActive(BookmarkPreviewTooltip tooltip) {
+		return this.activeTooltip == tooltip;
+	}
+
+	@Override
+	public void hide() {
+		if (this.activeTooltip != null) {
+			this.activeTooltip = null;
+			PinnedTooltipManager.closed(this);
+		}
+	}
+
+	@Override
+	public boolean isMouseOver(double mouseX, double mouseY) {
+		BookmarkPreviewTooltip activeTooltip = this.activeTooltip;
+		return activeTooltip != null && activeTooltip.isMouseOver(mouseX, mouseY);
+	}
+
+	@Override
+	public void draw(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+		update(mouseX, mouseY);
+		BookmarkPreviewTooltip activeTooltip = this.activeTooltip;
+		if (activeTooltip != null) {
+			activeTooltip.draw(guiGraphics, mouseX, mouseY);
+		}
+	}
+
+	private void update(double mouseX, double mouseY) {
+		if (!Internal.getKeyMappings().getPauseRecipeCycling().isDown() ||
+			!bookmarkOverlay.isListDisplayed()
+		) {
+			hide();
+			return;
+		}
+		Minecraft minecraft = Minecraft.getInstance();
+		Screen screen = minecraft.gui.screen();
+		if (screen != this.lastScreen) {
+			this.lastScreen = screen;
+			hide();
+			return;
+		}
+		BookmarkPreviewTooltip activeTooltip = this.activeTooltip;
+		if (activeTooltip == null) {
+			open(mouseX, mouseY);
+		} else if (!activeTooltip.isSourceVisible()) {
+			hide();
+		}
+	}
+
+	private void open(double mouseX, double mouseY) {
+		bookmarkOverlay.getIngredientUnderMouse(mouseX, mouseY)
+			.map(IClickableIngredientInternal::getElement)
+			.<RecipeBookmarkElement<?, ?>>mapMulti((element, consumer) -> {
+				if (element instanceof RecipeBookmarkElement<?, ?> recipeBookmarkElement) {
+					consumer.accept(recipeBookmarkElement);
+				}
+			})
+			.findFirst()
+			.ifPresent(element -> element.getInteractivePreview().ifPresent(component -> {
+				hide();
+				this.activeTooltip = new BookmarkPreviewTooltip(
+					this,
+					element,
+					component,
+					(int) mouseX,
+					(int) mouseY
+				);
+				PinnedTooltipManager.opened(this);
+			}));
+	}
+
+	@Override
+	public Optional<IUserInputHandler> handleUserInput(
+		Screen screen,
+		IGuiProperties guiProperties,
+		UserInput input,
+		IInternalKeyMappings keyBindings
+	) {
+		BookmarkPreviewTooltip activeTooltip = this.activeTooltip;
+		if (activeTooltip == null) {
+			return Optional.empty();
+		}
+		return activeTooltip.handleUserInput(screen, guiProperties, input, keyBindings);
+	}
+}

--- a/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/PreviewTooltipComponent.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/bookmarks/PreviewTooltipComponent.java
@@ -23,9 +23,26 @@ public class PreviewTooltipComponent<R> implements ClientTooltipComponent, Toolt
 	private final IRecipeLayoutDrawable<R> drawable;
 	private @Nullable IRecipeTransferError transferError;
 	private long lastUpdateTime = 0;
+	private boolean interactive;
+	private double mouseX = -1;
+	private double mouseY = -1;
 
 	public PreviewTooltipComponent(IRecipeLayoutDrawable<R> drawable) {
 		this.drawable = drawable;
+	}
+
+	public IRecipeLayoutDrawable<R> getRecipeLayout() {
+		return drawable;
+	}
+
+	public void setInteractive(double mouseX, double mouseY) {
+		this.interactive = true;
+		this.mouseX = mouseX;
+		this.mouseY = mouseY;
+	}
+
+	public void setStatic() {
+		this.interactive = false;
 	}
 
 	@Override
@@ -40,18 +57,31 @@ public class PreviewTooltipComponent<R> implements ClientTooltipComponent, Toolt
 
 	@Override
 	public void extractImage(Font font, int x, int y, int w, int h, GuiGraphicsExtractor guiGraphics) {
+		if (interactive) {
+			int mouseX = (int) this.mouseX;
+			int mouseY = (int) this.mouseY;
+			drawable.setPosition(x + 2, y + 5);
+			drawable.drawRecipe(guiGraphics, mouseX, mouseY);
+			drawTransferError(guiGraphics, mouseX, mouseY);
+			return;
+		}
 		var pose = guiGraphics.pose();
 		pose.pushMatrix();
 		{
 			pose.translate(x + 2, y + 5);
+			drawable.setPosition(0, 0);
 			drawable.drawRecipe(guiGraphics, 0, 0);
-			updateTransferError();
-			if (transferError != null) {
-				Rect2i recipeRect = drawable.getRect();
-				transferError.showError(guiGraphics, x, y, drawable.getRecipeSlotsView(), recipeRect.getX(), recipeRect.getY());
-			}
+			drawTransferError(guiGraphics, x, y);
 		}
 		pose.popMatrix();
+	}
+
+	private void drawTransferError(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY) {
+		updateTransferError();
+		if (transferError != null) {
+			Rect2i recipeRect = drawable.getRect();
+			transferError.showError(guiGraphics, mouseX, mouseY, drawable.getRecipeSlotsView(), recipeRect.getX(), recipeRect.getY());
+		}
 	}
 
 	public void tick() {

--- a/Gui/src/main/java/mezz/jei/gui/overlay/elements/RecipeBookmarkElement.java
+++ b/Gui/src/main/java/mezz/jei/gui/overlay/elements/RecipeBookmarkElement.java
@@ -8,6 +8,7 @@ import mezz.jei.api.helpers.IJeiHelpers;
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientRenderer;
+import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IFocusFactory;
@@ -120,13 +121,42 @@ public class RecipeBookmarkElement<R, I> implements IElement<I> {
 
 	@Override
 	public void getTooltip(JeiTooltip tooltip, IngredientGridTooltipHelper tooltipHelper, IIngredientRenderer<I> ingredientRenderer, IIngredientHelper<I> ingredientHelper) {
+		getTooltip(tooltip, ingredientRenderer, ingredientHelper, false);
+	}
+
+	public void getPinnedTooltip(JeiTooltip tooltip) {
+		IJeiRuntime jeiRuntime = Internal.getJeiRuntime();
+		IIngredientManager ingredientManager = jeiRuntime.getIngredientManager();
+		ITypedIngredient<I> displayIngredient = recipeBookmark.getDisplayIngredient();
+		IIngredientType<I> ingredientType = displayIngredient.getType();
+		IIngredientRenderer<I> ingredientRenderer = ingredientManager.getIngredientRenderer(ingredientType);
+		IIngredientHelper<I> ingredientHelper = ingredientManager.getIngredientHelper(ingredientType);
+		getTooltip(tooltip, ingredientRenderer, ingredientHelper, true);
+	}
+
+	public Optional<PreviewTooltipComponent<R>> getInteractivePreview() {
+		if (!getBookmarkTooltipFeatures().contains(BookmarkTooltipFeature.PREVIEW)) {
+			return Optional.empty();
+		}
+		PreviewTooltipComponent<R> component = this.previewTooltipComponent;
+		if (component == null) {
+			component = createPreviewTooltipComponent();
+			if (component == null) {
+				return Optional.empty();
+			}
+			this.previewTooltipComponent = component;
+		}
+		return Optional.of(component);
+	}
+
+	private void getTooltip(JeiTooltip tooltip, IIngredientRenderer<I> ingredientRenderer, IIngredientHelper<I> ingredientHelper, boolean pinned) {
 		ITypedIngredient<I> displayIngredient = recipeBookmark.getDisplayIngredient();
 		R recipe = recipeBookmark.getRecipe();
 
 		IRecipeCategory<R> recipeCategory = recipeBookmark.getRecipeCategory();
 		tooltip.add(Component.translatable("jei.tooltip.bookmarks.recipe", recipeCategory.getTitle()));
 
-		addBookmarkTooltipFeaturesIfEnabled(tooltip);
+		boolean previewAdded = addBookmarkTooltipFeaturesIfEnabled(tooltip, pinned);
 
 		if (recipeBookmark.isDisplayIsOutput()) {
 			IJeiRuntime jeiRuntime = Internal.getJeiRuntime();
@@ -149,44 +179,53 @@ public class RecipeBookmarkElement<R, I> implements IElement<I> {
 
 			SafeIngredientUtil.getRichTooltip(tooltip, ingredientManager, ingredientRenderer, displayIngredient);
 		}
+
+		if (previewAdded && !pinned) {
+			IJeiKeyMappingInternal pauseRecipeCycling = Internal.getKeyMappings().getPauseRecipeCycling();
+			tooltip.addKeyUsageComponent("jei.tooltip.bookmarks.preview.pin.usage", pauseRecipeCycling);
+		}
 	}
 
-	private void addBookmarkTooltipFeaturesIfEnabled(JeiTooltip tooltip) {
+	private boolean addBookmarkTooltipFeaturesIfEnabled(JeiTooltip tooltip, boolean pinned) {
 		JeiTooltip transferComponents = createTransferComponents();
 		List<BookmarkTooltipFeature> bookmarkTooltipFeatures = getBookmarkTooltipFeatures();
 
 		if (bookmarkTooltipFeatures.isEmpty() && transferComponents.isEmpty()) {
-			return;
+			return false;
 		}
 
-		if (clientConfig.holdShiftToShowBookmarkTooltipFeaturesEnabled().getValue()) {
+		if (!pinned && clientConfig.holdShiftToShowBookmarkTooltipFeaturesEnabled().getValue()) {
 			IJeiKeyMappingInternal showBookmarkTooltipFeatures = Internal.getKeyMappings().getShowBookmarkTooltipFeatures();
-			if (showBookmarkTooltipFeatures.isDown()) {
-				addBookmarkTooltipFeatures(tooltip, bookmarkTooltipFeatures);
-				tooltip.addAll(transferComponents);
-			} else {
+			if (!showBookmarkTooltipFeatures.isDown()) {
 				tooltip.addKeyUsageComponent(
 					"jei.tooltip.bookmarks.tooltips.usage",
 					showBookmarkTooltipFeatures
 				);
+				return false;
 			}
-		} else {
-			addBookmarkTooltipFeatures(tooltip, bookmarkTooltipFeatures);
-			tooltip.addAll(transferComponents);
 		}
+
+		boolean previewAdded = addBookmarkTooltipFeatures(tooltip, bookmarkTooltipFeatures);
+		tooltip.addAll(transferComponents);
+		return previewAdded;
 	}
 
 	private List<BookmarkTooltipFeature> getBookmarkTooltipFeatures() {
 		return clientConfig.bookmarkTooltipFeatures().getValue();
 	}
 
-	private void addBookmarkTooltipFeatures(JeiTooltip tooltip, List<BookmarkTooltipFeature> features) {
+	private boolean addBookmarkTooltipFeatures(JeiTooltip tooltip, List<BookmarkTooltipFeature> features) {
+		boolean previewAdded = false;
 		for (BookmarkTooltipFeature feature : features) {
 			boolean added = addBookmarkTooltipFeature(tooltip, feature);
+			if (feature == BookmarkTooltipFeature.PREVIEW && added) {
+				previewAdded = true;
+			}
 			if (!added) {
 				break;
 			}
 		}
+		return previewAdded;
 	}
 
 	private boolean addBookmarkTooltipFeature(JeiTooltip tooltip, BookmarkTooltipFeature feature) {
@@ -199,16 +238,23 @@ public class RecipeBookmarkElement<R, I> implements IElement<I> {
 	private boolean addPreviewTooltipComponent(JeiTooltip tooltip) {
 		PreviewTooltipComponent<R> component = previewTooltipComponent;
 		if (component == null) {
-			IRecipeLayoutDrawable<R> recipeLayout = getRecipeLayoutDrawable().orElse(null);
-			if (recipeLayout == null) {
+			component = createPreviewTooltipComponent();
+			if (component == null) {
 				return false;
 			}
-			component = new PreviewTooltipComponent<>(recipeLayout);
 			previewTooltipComponent = component;
 		}
-
+		component.setStatic();
 		tooltip.add(component);
 		return true;
+	}
+
+	private @Nullable PreviewTooltipComponent<R> createPreviewTooltipComponent() {
+		IRecipeLayoutDrawable<R> recipeLayout = getRecipeLayoutDrawable().orElse(null);
+		if (recipeLayout == null) {
+			return null;
+		}
+		return new PreviewTooltipComponent<>(recipeLayout);
 	}
 
 	private boolean addIngredientsTooltipComponent(JeiTooltip tooltip) {

--- a/Gui/src/main/java/mezz/jei/gui/recipes/InteractiveIngredientTooltipController.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/InteractiveIngredientTooltipController.java
@@ -9,7 +9,9 @@ import mezz.jei.common.input.IInternalKeyMappings;
 import mezz.jei.gui.input.IGuiInputLayer;
 import mezz.jei.gui.input.IClickableIngredientInternal;
 import mezz.jei.gui.input.IMouseOverable;
+import mezz.jei.gui.input.IPinnedTooltipHolder;
 import mezz.jei.gui.input.IUserInputHandler;
+import mezz.jei.gui.input.PinnedTooltipManager;
 import mezz.jei.gui.input.UserInput;
 import mezz.jei.gui.util.FocusUtil;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -19,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-final class InteractiveIngredientTooltipController implements IGuiInputLayer {
+final class InteractiveIngredientTooltipController implements IGuiInputLayer, IPinnedTooltipHolder {
 	private final RecipesGui recipesGui;
 	private final FocusUtil focusUtil;
 	private final IRecipeManager recipeManager;
@@ -55,6 +57,7 @@ final class InteractiveIngredientTooltipController implements IGuiInputLayer {
 		if (activeTooltip != null) {
 			activeTooltip.unfocus();
 			this.activeTooltip = null;
+			PinnedTooltipManager.closed(this);
 		}
 	}
 
@@ -87,6 +90,7 @@ final class InteractiveIngredientTooltipController implements IGuiInputLayer {
 		}
 		hide();
 		this.activeTooltip = tooltip.get();
+		PinnedTooltipManager.opened(this);
 		return true;
 	}
 

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeSlotClickTargetFactory.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeSlotClickTargetFactory.java
@@ -16,11 +16,11 @@ import net.minecraft.tags.TagKey;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-final class RecipeSlotClickTargetFactory {
+public final class RecipeSlotClickTargetFactory {
 	private final IRecipeManager recipeManager;
 	private final BooleanSupplier isRecipeCyclingPaused;
 
-	RecipeSlotClickTargetFactory(IRecipeManager recipeManager, BooleanSupplier isRecipeCyclingPaused) {
+	public RecipeSlotClickTargetFactory(IRecipeManager recipeManager, BooleanSupplier isRecipeCyclingPaused) {
 		this.recipeManager = recipeManager;
 		this.isRecipeCyclingPaused = isRecipeCyclingPaused;
 	}
@@ -37,7 +37,7 @@ final class RecipeSlotClickTargetFactory {
 			));
 	}
 
-	Optional<IClickableIngredientInternal<?>> create(
+	public Optional<IClickableIngredientInternal<?>> create(
 		RecipeSlotUnderMouse slotUnderMouse,
 		IMouseOverable mouseOverable
 	) {
@@ -55,7 +55,7 @@ final class RecipeSlotClickTargetFactory {
 		return new ClickableIngredientInternal<>(element, mouseOverable, false, true);
 	}
 
-	static IMouseOverable createMouseOverable(
+	public static IMouseOverable createMouseOverable(
 		IRecipeLayoutDrawable<?> recipeLayout,
 		RecipeSlotUnderMouse expected
 	) {

--- a/Gui/src/main/java/mezz/jei/gui/recipes/RecipeSlotTooltipPositioner.java
+++ b/Gui/src/main/java/mezz/jei/gui/recipes/RecipeSlotTooltipPositioner.java
@@ -7,7 +7,7 @@ import org.joml.Vector2i;
 import org.joml.Vector2ic;
 import org.jspecify.annotations.Nullable;
 
-final class RecipeSlotTooltipPositioner implements ClientTooltipPositioner {
+public final class RecipeSlotTooltipPositioner implements ClientTooltipPositioner {
 	private static final int TOOLTIP_MARGIN = 4;
 
 	private ImmutableRect2i tooltipArea = ImmutableRect2i.EMPTY;

--- a/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
+++ b/Gui/src/main/java/mezz/jei/gui/startup/JeiGuiStarter.java
@@ -219,12 +219,14 @@ public class JeiGuiStarter {
 		);
 		registration.setRecipesGui(recipesGui);
 		var recipesGuiForegroundInputLayer = recipesGui.getForegroundInputLayer();
+		var bookmarkPreviewTooltipController = bookmarkOverlay.getPreviewTooltipController();
 
 		GuiEventHandler guiEventHandler = new GuiEventHandler(
 			screenHelper,
 			bookmarkOverlay,
 			ingredientListOverlay,
-			recipesGuiForegroundInputLayer
+			recipesGuiForegroundInputLayer,
+			bookmarkPreviewTooltipController
 		);
 
 		CombinedRecipeFocusSource recipeFocusSource = new CombinedRecipeFocusSource(
@@ -241,6 +243,7 @@ public class JeiGuiStarter {
 		UserInputRouter userInputRouter = new UserInputRouter(
 			"JEIGlobal",
 			recipesGuiForegroundInputLayer,
+			bookmarkPreviewTooltipController,
 			new EditInputHandler(recipeFocusSource, toggleState, editModeConfig),
 			ingredientListOverlay.createDeleteItemInputHandler(),
 			bookmarkOverlay.createDeleteItemInputHandler(),


### PR DESCRIPTION
 Add  pinnable tooltip similar to the recipe slot for recipe bookmark previews.
<img width="1708" height="960" alt="图片" src="https://github.com/user-attachments/assets/28010548-18ab-4ce7-8fd5-f0db0114c358" />
